### PR TITLE
added a parser for HHsearch outputs.

### DIFF
--- a/microprot/scripts/pdb_search.py
+++ b/microprot/scripts/pdb_search.py
@@ -1,6 +1,3 @@
-import sys
-
-
 _HEADER = ['No',
            'Hit',
            'Prob',

--- a/microprot/scripts/pdb_search.py
+++ b/microprot/scripts/pdb_search.py
@@ -30,14 +30,11 @@ def is_overlapping(intA, intB):
     ValueError
         If left component of intA or intB is greater than its right component.
     '''
-    if (intA[0] > intA[1]):
-        raise ValueError("Left component of intA cannot be larger than its "
-                         "right component, i.e. the interval must be forward "
-                         "oriented.")
-    if (intB[0] > intB[1]):
-        raise ValueError("Left component of intB cannot be larger than its "
-                         "right component, i.e. the interval must be forward "
-                         "oriented.")
+    for x in zip(["intA", "intB"], [intA, intB]):
+        if (x[1][0] > x[1][1]):
+            raise ValueError("Left component of %s cannot be larger than its "
+                             "right component, i.e. the interval must be "
+                             "forward oriented." % x[0])
 
     return not (((intA[0] > intB[0]) & (intA[0] > intB[1])) |
                 ((intA[1] < intB[0]) & (intA[1] < intB[1])))

--- a/microprot/scripts/pdb_search.py
+++ b/microprot/scripts/pdb_search.py
@@ -1,0 +1,396 @@
+import sys
+
+
+_HEADER = ['No',
+           'Hit',
+           'Prob',
+           'E-value',
+           'P-value',
+           'Score',
+           'SS',
+           'Cols',
+           'Query HMM',
+           'Template HMM',
+           '#match states']
+
+
+def is_overlapping(intA, intB):
+    ''' Test if two intervals overlap.
+
+    Parameters
+    ----------
+    intA : (int, int)
+        A pair of coordinates, e.g. (20, 100). Left component must be <= right.
+    intB : (int, int)
+        A pair of coordinates, e.g. (50, 150). Left component must be <= right.
+
+    Returns
+    -------
+    Bool. True if intA overlaps with intB. False otherwise.
+
+    Raises
+    ------
+    ValueError
+        If left component of intA or intB is greater than its right component.
+    '''
+    if (intA[0] > intA[1]):
+        raise ValueError("Left component of intA cannot be larger than its "
+                         "right component, i.e. the interval must be forward "
+                         "oriented.")
+    if (intB[0] > intB[1]):
+        raise ValueError("Left component of intB cannot be larger than its "
+                         "right component, i.e. the interval must be forward "
+                         "oriented.")
+
+    return not (((intA[0] > intB[0]) & (intA[0] > intB[1])) |
+                ((intA[1] < intB[0]) & (intA[1] < intB[1])))
+
+
+def _parse_hit_summary_line(line):
+    """ Parses a single hit summary line of HHsearch.
+
+    Fields are described in [1]. Unfortunately, there is no single dedicated
+    separator char plus the second field might contain whitespaces. Thus, I
+    split the line on \s and consume the first element for the 'hit index'. The
+    'description' are all elements that are not consumed by the last 9 fields.
+
+    Parameters
+    ----------
+    line: str
+        The line that should be parsed and contain the expected information.
+
+    Returns
+    -------
+    A dict holding the information of the HHsearch line for a hit.
+
+    Raises
+    ------
+    ValueError
+        If some fields cannot be casted to int or float, which might be an
+        indication that the provided line is no HHsearch hit summary line.
+
+    [1] Johannes Soeding, "Quick guide to HHsearch"
+        ftp://ftp.tuebingen.mpg.de/pub/protevo/HHsearch/HHsearch1.5.01/HHsearc
+        h-guide.pdf
+    """
+
+    fields = line.rstrip().split()
+    hit = {}
+
+    try:
+        # Index of hit
+        hit[_HEADER[0]] = int(fields[0])
+
+        # First 30 characters of domain description (from nameline of query
+        # sequence)
+        hit[_HEADER[1]] = " ".join(fields[1:-9])
+
+        # Probability of target to be a true positive For the probability of
+        # being a true positive, the secondary structure score in column 7 is
+        # taken into account, together with the raw score in column 6
+        # (’Score’). True positives are defined to be either globally
+        # homologous or they are at least locally similar in structure. More
+        # precisely, the latter criterion demands that the MAXSUB score between
+        # query and hit is at least 0.1. In almost all cases the structural
+        # similarity will we be due to a global OR LOCAL homology between query
+        # and target.
+        hit[_HEADER[-9]] = float(fields[-9])
+
+        # Expect-value E-value and P-value are calculated without taking the
+        # secondary structure into account! The E-value gives the average
+        # number of false positives (’wrong hits’) with a score better than the
+        # one for the target when scanning the datbase. It is a measure of
+        # reliability: E-values near to 0 signify a very reliable hit, an
+        # E-value of 10 means about 10 wrong hits are expected to be found in
+        # the database with a score at least this good.
+        hit[_HEADER[-8]] = float(fields[-8])
+
+        # P-value The P-value is just the E-value divided by the number of
+        # sequences in the database. It is the probability that in a PAIRWISE
+        # comparison a wrong hit will score at least this good.
+        hit[_HEADER[-7]] = float(fields[-7])
+
+        # Raw score, does not include the secondary structure score
+        hit[_HEADER[-6]] = float(fields[-6])
+
+        # Secondary structure score This score tells how well the PSIPRED-
+        # predicted (3-state) or actual DSSP-determined (8-state) secondary
+        # structure sequences agree with each other. PSIPRED confidence values
+        # are used in the scoring, low confidences getting less statistical
+        # weight.
+        hit[_HEADER[-5]] = float(fields[-5])
+
+        # The number of aligned Match columns in the HMM-HMM alignment.
+        hit[_HEADER[-4]] = int(fields[-4])
+
+        # Range of aligned match states from query HMM
+        hit[_HEADER[-3]] = fields[-3]
+
+        # Range of aligned match states from target HMM
+        hit[_HEADER[-2]] = fields[-2]
+
+        # Number of match states in target HMM
+        hit[_HEADER[-1]] = int(fields[-1][1:-1])
+
+        return hit
+    except ValueError:
+        raise ValueError("Unexpected field. Check if line is a HHsearch hit"
+                         " summary line.")
+
+
+def _parse_hit_block(block):
+    """ Parse one alignment block of HHsearch output.
+
+    Unfortunately, there is no strict format description. It is unclear which
+    lines might appear. Identifier might have white spaces. I assume that there
+    will always be a line starting with 'Q Consensus', having some integer to
+    describe the start position of the query, followed by a part of the aligned
+    query sequence. Delimiter are unclear, I guess it is \s+.
+    Due to all those uncertainties the code might look confusing at first
+    sight.
+
+    Parameters
+    ----------
+    block : str
+        The lines of the HHsearch output regarding to one alignment of query
+        sequence and target HMM. It might be wrapped into several parts.
+
+    Returns
+    -------
+    A dict holding all information about the aligment.
+    """
+
+    hit = {}
+    lines = block.split('\n')
+
+    # Index of hit
+    hit['No'] = int(lines[0].split()[1])
+
+    # description of domain
+    hit['Hit'] = lines[1][1:]
+
+    # line with stats
+    for field in lines[2].rstrip().split('  '):
+        key, value = field.split('=')
+        hit[key] = value
+    hit['Similarity'] = float(hit['Similarity'])
+    hit['Score'] = float(hit['Score'])
+    hit['Probab'] = float(hit['Probab'])
+    hit['Identities'] = float(hit['Identities'][:-1])/100
+    hit['Aligned_cols'] = int(hit['Aligned_cols'])
+    hit['E-value'] = float(hit['E-value'])
+    hit['Sum_probs'] = float(hit['Sum_probs'])
+    hit['Template_Neff'] = float(hit['Template_Neff'])
+
+    idx = 4
+    block = {}
+    while(idx+1 < len(lines)):
+        # determin start and end column of alignment content
+        content = lines[idx+1].split()[3]
+        startCol = lines[idx+1].find(content)
+        endCol = startCol + len(content)
+        while((idx+1 < len(lines)) & (lines[idx] != '')):
+            start = None
+            if lines[idx].startswith(' '):
+                name = 'column score'
+            else:
+                parts = lines[idx][:startCol].split()
+                try:
+                    start = int(parts[-1])  # check if last part is a number
+                    name = lines[idx][:lines[idx][:startCol].find(parts[-1])]
+                except ValueError:
+                    name = lines[idx][:startCol]
+                name = name.rstrip()
+            if name not in block:
+                block[name] = {'sequence': lines[idx][startCol:endCol]}
+                if start is not None:
+                    block[name]['start'] = start
+            else:
+                block[name]['sequence'] += lines[idx][startCol:endCol]
+            if lines[idx][endCol:] != '':
+                fields = lines[idx][endCol:].split()
+                block[name]['end'] = int(fields[0])
+                block[name]['totallen'] = int(fields[1][1:-1])
+            idx += 1
+        idx += 2
+
+    hit['alignment'] = block
+
+    return hit
+
+
+def parse_pdb_match(filename):
+    """ Parse an HHsearch output file.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the HHsearch output file that should be parsed.
+
+    Returns
+    -------
+    A list of HHsearch hits. Each hit is a dict, holding all its information.
+
+    Raises
+    ------
+    IOError
+        If the file cannot be read.
+    """
+    hits = []
+    try:
+        fh = open(filename, 'r')
+        line = ""
+
+        # read until header of summary table is found
+        while(len(set(line.rstrip().split()) & set(_HEADER)) < 8):
+            line = fh.readline()
+        line = fh.readline()  # summary table header line
+        # read all summary lines
+        while(line != '\n'):
+            hits.append(_parse_hit_summary_line(line))
+            line = fh.readline()
+
+        # read the alignments
+        reachedEOF = False
+        alignments = []
+        block = ''
+        while(not reachedEOF):
+            line = fh.readline()
+            reachedEOF = line == ''
+            if line.startswith('No ') & (len(line.split()) == 2):
+                if block != '':
+                    alignments.append(_parse_hit_block(block))
+                block = line
+            else:
+                block += line
+        if block != '':
+            alignments.append(_parse_hit_block(block))
+
+        # merge hit summary and according alignment
+        for idx in range(len(hits)):
+            for key in alignments[idx]:
+                hits[idx][key] = alignments[idx][key]
+            # duplicate information, but more precicse on other place
+            del hits[idx][_HEADER[2]]  # Prob
+            del hits[idx][_HEADER[8]]  # Query HMM
+            del hits[idx][_HEADER[9]]  # Template HMM
+            del hits[idx][_HEADER[10]]  # match states
+
+        fh.close()
+        return hits
+    except IOError:
+        raise IOError('Cannot read file "%s"' % filename)
+
+
+def select_hits(hits, e_value_threshold=0.001):
+    """ Picking HHsearch hits from the list of all hits.
+
+    We take those hits that a) have an e-Value <= e_value_threshold and b)
+    does not overlap with any previously picked hit.
+
+    Parameters
+    ----------
+    hits: [dict]
+        The sorted list of hits from an HHsearch.
+    e_value_threshold: float
+        The threshold for a maximal e-Value for a hit to pick. Default: 0.001
+
+    Returns
+    -------
+    [dict] a potentially smaller list of HHsearch hits.
+    """
+    good_hits = []
+
+    for hit in hits:
+        if hit['E-value'] < e_value_threshold:
+            # check if there is an overlap to previous results
+            noOverlap = True
+            for good in good_hits:
+                if is_overlapping((hit['alignment']['Q Consensus']['start'],
+                                   hit['alignment']['Q Consensus']['end']),
+                                  (good['alignment']['Q Consensus']['start'],
+                                   good['alignment']['Q Consensus']['end'])):
+                    noOverlap = False
+                    break
+            if noOverlap:
+                good_hits.append(hit)
+
+    return good_hits
+
+
+def report_hits(hits):
+    """ Return condensed information about HHsearch hits.
+
+    Parameters
+    ----------
+    hits : [dict]
+        A list of HHsearch hits.
+
+    Returns
+    -------
+    For each hit: a) the pdb_id, b) the protein sub-sequence of the query
+    covered by this hit, c) the start position of the hit relative to the query
+    and d) the end position of the hit relative to the query (first AA in query
+    is position 1, not 0).
+    """
+    report = []
+    for hit in hits:
+        # find the right key for the query sequence information
+        q_keys = [k for k in hit['alignment'].keys()
+                  if k.startswith('Q') & (k != 'Q Consensus')]
+
+        # compose a new dict as report for this hit.
+        report.append({'pdb_id': hit['Hit'].split()[0],
+                       'covered_sequence': hit['alignment'][q_keys[0]]
+                       ['sequence'].replace('-', ''),
+                       'start': hit['alignment'][q_keys[0]]['start'],
+                       'end': hit['alignment'][q_keys[0]]['end']})
+    return report
+
+
+def report_uncovered_subsequences(hits, query, min_subseq_len=40):
+    """ Returns sub-sequences of query that is not covered by hits.
+
+    Parameters
+    ----------
+    hits : [dict]
+        A list of HHsearch hits.
+    query : str
+        The protein sequence that was used to generate the HHsearch hits, i.e.
+        the content of the input file for HHsearch.
+    min_subseq_len : int
+        A threhold for the minimal sub-sequence length that should be reported.
+        Default = 40
+
+    Returns
+    -------
+    A list of dicts, where each entry corresponds to a sub-sequence of the
+    query that is not covered by the HHsearch hits and whose length is at least
+    min_subseq_len. The dict holds the keys a) 'sequence' for the plain AA
+    sequence, b) 'start' for the start position of the reported sub-sequence,
+    relative to the query sequence and c) 'end' the relative end position.
+    (positions start with 1, not with 0)
+    """
+    covered = []
+    for hit in hits:
+        # find the right key for the query sequence information
+        q_keys = [k for k in hit['alignment'].keys()
+                  if k.startswith('Q') & (k != 'Q Consensus')]
+        covered.append((hit['alignment'][q_keys[0]]['start'],
+                        hit['alignment'][q_keys[0]]['end']))
+
+    uncovered = []
+    curEnd = 0
+    for sub in sorted(covered):
+        unc = {'sequence': query[curEnd:sub[0]-1],
+               'start': curEnd+1,
+               'end': sub[0]-1}
+        uncovered.append(unc)
+        curEnd = sub[1]
+    unc = {'sequence': query[curEnd:],
+           'start': curEnd+1,
+           'end': len(query)}
+    uncovered.append(unc)
+
+    return [u for u in uncovered if (u['sequence'] != '') &
+                                    (len(u['sequence']) >= min_subseq_len)]

--- a/microprot/tests/data/test_pdb_search/NC_000913.3_2.out
+++ b/microprot/tests/data/test_pdb_search/NC_000913.3_2.out
@@ -1,0 +1,5755 @@
+Query         gi|556503834|ref|NC_000913.3|_2 # 337 # 2799 # 1 # ID=1_2;partial=00;start_type=ATG;rbs_motif=GGAG/GAGG;rbs_spacer=5-10bp;gc_cont=0.531
+Match_columns 820
+No_of_seqs    1 out of 1
+Neff          1
+Searched_HMMs 36595
+Date          Wed Dec  7 15:58:15 2016
+Command       /projects/microprot/tools/hhsuite-3.0.0/build/bin/hhsearch -i NC_000913.3_2.fasta -e 0.001 -d /projects/microprot/dbs/pdb70/pdb70 -o NC_000913.3_2.out -oa3m NC_000913.3_2.out_a3m -opsi NC_000913.3_2.out_psi 
+
+ No Hit                             Prob E-value P-value  Score    SS Cols Query HMM  Template HMM
+  1 2j0w_A Lysine-sensitive aspart 100.0 3.5E-59 9.5E-64  450.7   0.0  442    1-461     4-449 (449)
+  2 3c1m_A Probable aspartokinase; 100.0 4.3E-59 1.2E-63  446.8   0.0  459    1-462     2-470 (473)
+  3 2cdq_A Aspartokinase; aspartat 100.0 4.1E-58 1.1E-62  453.8   0.0  458    1-473    28-496 (510)
+  4 3tvi_A Aspartokinase; structur 100.0 3.7E-54   1E-58  418.4   0.0  427    1-462     4-440 (446)
+  5 1ebf_A Homoserine dehydrogenas 100.0 2.5E-49   7E-54  367.1   0.0  344  464-815     3-356 (358)
+  6 3ab4_A Aspartokinase; aspartat 100.0 3.9E-47 1.1E-51  359.3   0.0  407    1-474     3-420 (421)
+  7 3do5_A HOM, homoserine dehydro 100.0 4.7E-43 1.3E-47  319.7   0.0  315  466-814     3-323 (327)
+  8 4xb1_A 319AA long hypothetical 100.0 1.2E-42 3.3E-47  323.5   0.0  308  462-815    15-329 (335)
+  9 3l76_A Aspartokinase; alloster 100.0 4.9E-41 1.3E-45  329.1   0.0  397    1-460     3-417 (600)
+ 10 3c8m_A Homoserine dehydrogenas 100.0 2.1E-36 5.8E-41  274.7   0.0  316  463-814     4-327 (331)
+ 11 3ing_A Homoserine dehydrogenas  99.9 1.1E-31 2.9E-36  244.1   0.0  306  464-814     3-321 (325)
+ 12 3mtj_A Homoserine dehydrogenas  99.9 6.5E-31 1.8E-35  254.4   0.0  312  459-814     4-324 (444)
+ 13 4ydr_A Homoserine dehydrogenas  99.9 8.1E-29 2.2E-33  220.5   0.0  293  467-814     2-300 (304)
+ 14 2ejw_A HDH, homoserine dehydro  99.9 2.5E-28   7E-33  225.3   0.0  299  465-814     3-306 (332)
+ 15 4pg7_A HDH, homoserine dehydro  99.9 3.6E-28 9.9E-33  242.9   0.0  315  459-814    17-338 (468)
+ 16 4go7_X Aspartokinase; transfer  99.6 4.3E-19 1.2E-23  154.5   0.0  175  297-479    17-196 (200)
+ 17 4ndo_B Molybdenum storage prot  99.3 8.6E-16 2.4E-20  138.8   0.0  208    1-289    38-252 (270)
+ 18 3ll9_A Isopentenyl phosphate k  99.3 1.2E-15 3.3E-20  135.6   0.0  110  179-289   133-249 (269)
+ 19 4a7w_A Uridylate kinase; trans  99.3   2E-15 5.4E-20  131.8   0.0   89  204-295   141-229 (240)
+ 20 1gs5_A Acetylglutamate kinase;  99.2 2.8E-15 7.6E-20  131.7   0.0  222    1-288     4-240 (258)
+ 21 3ek6_A Uridylate kinase; UMPK   99.2 4.3E-15 1.2E-19  130.7   0.0   83  205-290   143-225 (243)
+ 22 1ybd_A Uridylate kinase; alpha  99.2 7.2E-15   2E-19  128.2   0.0  143  127-291    82-224 (239)
+ 23 1z9d_A Uridylate kinase, UK, U  99.2 7.7E-15 2.1E-19  130.2   0.0  144  125-290    80-224 (252)
+ 24 2dtj_A Aspartokinase; protein-  99.2 1.2E-14 3.3E-19  122.6   0.0  163  304-474     4-171 (178)
+ 25 2jjx_A Uridylate kinase, UMP k  99.1 2.5E-14 6.9E-19  127.5   0.0   89  206-297   148-246 (255)
+ 26 2va1_A Uridylate kinase; UMPK,  99.1 2.6E-14   7E-19  128.7   0.0  142  126-289    97-239 (256)
+ 27 3mah_A Aspartokinase; aspartat  99.1 2.7E-14 7.3E-19  116.8   0.0  153  299-464     2-154 (157)
+ 28 3s1t_A Aspartokinase; ACT doma  99.1 3.8E-14   1E-18  120.6   0.0  163  304-474     5-172 (181)
+ 29 2dt9_A Aspartokinase; protein-  99.0 2.5E-13 6.9E-18  112.8   0.0  154  302-464     3-161 (167)
+ 30 3nwy_A Uridylate kinase; allos  99.0 2.6E-13   7E-18  125.1   0.0   84  203-289   181-264 (281)
+ 31 2rd5_A Acetylglutamate kinase-  98.9 5.9E-13 1.6E-17  122.2   0.0  201    1-260    38-246 (298)
+ 32 2j4j_A Uridylate kinase; trans  98.9 7.4E-13   2E-17  115.1   0.0   96  182-288   105-207 (226)
+ 33 4q1t_A Glutamate 5-kinase; str  98.9 7.9E-13 2.2E-17  125.3   0.0  104  182-289   136-248 (376)
+ 34 2ij9_A Uridylate kinase; struc  98.9 9.8E-13 2.7E-17  115.7   0.0   81  205-285   114-200 (219)
+ 35 2re1_A Aspartokinase, alpha an  98.8 1.7E-12 4.7E-17  106.7   0.0  152  302-461    12-166 (167)
+ 36 1gtm_A Glutamate dehydrogenase  98.8 2.9E-12 7.9E-17  126.1   0.0  201  451-679   193-407 (419)
+ 37 4ndo_A Molybdenum storage prot  98.7 8.5E-12 2.3E-16  114.1   0.0   85  202-289   165-254 (276)
+ 38 2a1f_A Uridylate kinase; PYRH,  98.7 8.6E-12 2.4E-16  110.8   0.0   84  204-290   141-224 (247)
+ 39 2ako_A Glutamate 5-kinase; str  98.7 1.6E-11 4.4E-16  107.9   0.0  103  182-288   121-232 (251)
+ 40 3wyc_A MESO-diaminopimelate D-  98.6   2E-11 5.4E-16  115.6   0.0  189  465-684     3-221 (334)
+ 41 2ap9_A NAG kinase, acetylgluta  98.6 4.2E-11 1.2E-15  111.0   0.0  106  179-289   166-272 (299)
+ 42 2brx_A Uridylate kinase; UMP k  98.5 5.8E-11 1.6E-15  105.0   0.0   80  205-284   137-222 (244)
+ 43 2buf_A Acetylglutamate kinase;  98.4 3.3E-10 8.9E-15  104.8   0.0   98  181-288   175-277 (300)
+ 44 3d2m_A Putative acetylglutamat  98.4 3.5E-10 9.7E-15  106.0   0.0   93  183-285   186-281 (456)
+ 45 3bio_A Oxidoreductase, GFO/IDH  98.3 4.2E-10 1.1E-14  100.8   0.0  183  457-673     1-183 (304)
+ 46 2bty_A Acetylglutamate kinase;  98.3 4.7E-10 1.3E-14  102.1   0.0   71  179-260   157-227 (282)
+ 47 2v5h_A Acetylglutamate kinase;  98.3 6.8E-10 1.9E-14  104.7   0.0  101  182-289   187-292 (321)
+ 48 3l76_A Aspartokinase; alloster  98.1 2.4E-09 6.5E-14  105.7   0.0  153  306-466   435-595 (600)
+ 49 3k4o_A Isopentenyl phosphate k  98.1 2.7E-09 7.3E-14   95.2   0.0  139  135-289   104-247 (266)
+ 50 1f06_A MESO-diaminopimelate D-  98.1 4.1E-09 1.1E-13   96.9   0.0  239  465-750     3-256 (320)
+ 51 3ll5_A Gamma-glutamyl kinase r  98.0 8.5E-09 2.3E-13   91.5   0.0  105  181-288   124-232 (249)
+ 52 4jz8_A Carbamate kinase; modif  98.0 8.6E-09 2.3E-13   96.9   0.0   96  184-284   190-298 (317)
+ 53 3l76_A Aspartokinase; alloster  97.9 1.6E-08 4.5E-13   99.8   0.0  165  306-474   346-536 (600)
+ 54 3wwn_A Putative acetylglutamat  97.9 1.7E-08 4.6E-13   91.3   0.0  100  182-288   150-254 (269)
+ 55 2j5v_A Glutamate 5-kinase; pro  97.7 8.1E-08 2.2E-12   90.7   0.0   88  202-289   144-240 (367)
+ 56 2we5_A Carbamate kinase 1; arg  97.6   1E-07 2.9E-12   90.2   0.0   77  180-261   180-261 (310)
+ 57 2e9y_A Carbamate kinase; trans  97.5 2.6E-07 7.1E-12   87.5   0.0  100  184-289   197-302 (316)
+ 58 3l86_A Acetylglutamate kinase;  97.4 3.3E-07 9.1E-12   84.5   0.0  150  133-296   118-277 (279)
+ 59 3d40_A FOMA protein; fosfomyci  97.4   5E-07 1.4E-11   82.7   0.0  102  181-288   146-258 (286)
+ 60 4axs_A Carbamate kinase; oxido  97.4 5.1E-07 1.4E-11   86.1   0.0  106  181-288   202-318 (332)
+ 61 1e19_A Carbamate kinase; trans  97.3 9.4E-07 2.6E-11   83.9   0.0   72  182-258   186-264 (314)
+ 62 3upl_A Oxidoreductase; rossman  97.2   1E-06 2.8E-11   84.5   0.0  219  452-694     7-244 (446)
+ 63 3tvi_A Aspartokinase; structur  97.1 2.4E-06 6.5E-11   83.9   0.0   76  305-380   364-439 (446)
+ 64 3au8_A 1-deoxy-D-xylulose 5-ph  97.0 4.1E-06 1.1E-10   85.1   0.0  194  462-690    74-309 (488)
+ 65 3c1m_A Probable aspartokinase;  96.9 4.8E-06 1.3E-10   80.5   0.0   76  306-381   395-470 (473)
+ 66 2f06_A Conserved hypothetical   96.5 3.1E-05 8.5E-10   59.5   0.0  132  310-461     1-134 (144)
+ 67 3mah_A Aspartokinase; aspartat  96.4 4.4E-05 1.2E-09   62.3   0.0   76  306-383    79-154 (157)
+ 68 1r0k_A 1-deoxy-D-xylulose 5-ph  96.4 4.6E-05 1.3E-09   73.7   0.0  187  465-689     4-214 (388)
+ 69 2j0w_A Lysine-sensitive aspart  96.2 7.4E-05   2E-09   72.8   0.0   71  307-379   378-448 (449)
+ 70 2cdq_A Aspartokinase; aspartat  96.2 9.1E-05 2.5E-09   74.1   0.0   73  309-382   414-486 (510)
+ 71 3ab4_A Aspartokinase; aspartat  96.1  0.0001 2.8E-09   70.3   0.0   77  305-383   334-410 (421)
+ 72 3zzh_A Acetylglutamate kinase;  96.1 0.00012 3.2E-09   67.9   0.0   70  179-257   177-247 (307)
+ 73 2re1_A Aspartokinase, alpha an  96.0 0.00014 3.9E-09   59.7   0.0   76  303-380    91-166 (167)
+ 74 2dtj_A Aspartokinase; protein-  96.0 0.00017 4.7E-09   60.9   0.0   78  304-383    84-161 (178)
+ 75 3s1t_A Aspartokinase; ACT doma  95.9 0.00022 5.9E-09   60.8   0.0   78  305-384    86-163 (181)
+ 76 4go7_X Aspartokinase; transfer  95.6 0.00045 1.2E-08   60.3   0.0   76  305-382   105-180 (200)
+ 77 3u3x_A Oxidoreductase; structu  95.6 0.00045 1.2E-08   63.0   0.0  151  453-626    14-165 (361)
+ 78 3db2_A Putative NADPH-dependen  95.4 0.00062 1.7E-08   60.4   0.0  140  462-626     2-142 (354)
+ 79 2dt9_A Aspartokinase; protein-  95.2 0.00097 2.6E-08   55.4   0.0   70  309-380    89-158 (167)
+ 80 3cea_A MYO-inositol 2-dehydrog  94.7  0.0021 5.9E-08   56.4   0.0  146  460-626     3-148 (346)
+ 81 1j5p_A Aspartate dehydrogenase  94.7  0.0023 6.2E-08   60.2   0.0   70  550-620    63-132 (253)
+ 82 3l76_A Aspartokinase; alloster  94.4  0.0032 8.8E-08   62.4   0.0   74  306-381   518-591 (600)
+ 83 3e9m_A Oxidoreductase, GFO/IDH  94.3  0.0037   1E-07   55.7   0.0  140  464-626     4-143 (330)
+ 84 4had_A Probable oxidoreductase  94.2  0.0041 1.1E-07   55.5   0.0  141  463-626    21-162 (350)
+ 85 2y1e_A 1-deoxy-D-xylulose 5-ph  93.8  0.0064 1.8E-07   59.3   0.0  152  453-627     9-174 (398)
+ 86 4ew6_A D-galactose-1-dehydroge  93.8  0.0066 1.8E-07   54.9   0.0  142  456-627    16-158 (330)
+ 87 4gqa_A NAD binding oxidoreduct  93.7  0.0071 1.9E-07   56.2   0.0  158  455-627    16-173 (412)
+ 88 3c1m_A Probable aspartokinase;  93.6   0.008 2.2E-07   58.3   0.0   75  386-460   308-382 (473)
+ 89 3s6g_A N-acetylglutamate kinas  93.4  0.0091 2.5E-07   58.5   0.0   68  179-256   187-255 (460)
+ 90 3ezy_A Dehydrogenase; structur  93.2   0.011 2.9E-07   52.4   0.0   75  549-626    66-140 (344)
+ 91 3ec7_A Putative dehydrogenase;  93.2   0.011   3E-07   53.5   0.0  148  459-626    17-164 (357)
+ 92 2nvw_A Galactose/lactose metab  92.7   0.015 4.2E-07   57.7   0.0  158  454-627    28-192 (479)
+ 93 3evn_A Oxidoreductase, GFO/IDH  92.6   0.017 4.5E-07   51.2   0.0  140  464-626     4-143 (329)
+ 94 4hkt_A Inositol 2-dehydrogenas  92.1   0.022 6.1E-07   49.4   0.0  137  465-627     3-140 (331)
+ 95 3mz0_A Inositol 2-dehydrogenas  92.0   0.024 6.5E-07   50.1   0.0  140  466-626     3-143 (344)
+ 96 3m2t_A Probable dehydrogenase;  91.6    0.03 8.2E-07   50.3   0.0  140  464-626     4-144 (359)
+ 97 3ohs_X Trans-1,2-dihydrobenzen  91.6    0.03 8.3E-07   49.4   0.0  140  466-626     3-142 (334)
+ 98 4nhe_A Oxidoreductase, GFO/IDH  91.4   0.032 8.9E-07   49.1   0.0  141  465-629     4-144 (328)
+ 99 3euw_A MYO-inositol dehydrogen  91.1   0.038   1E-06   48.9   0.0  140  464-627     3-142 (344)
+100 2dc1_A L-aspartate dehydrogena  90.6   0.047 1.3E-06   46.4   0.0  117  467-617     2-119 (236)
+101 3moi_A Probable dehydrogenase;  90.2   0.056 1.5E-06   49.6   0.0   76  549-627    66-141 (387)
+102 1h6d_A Precursor form of gluco  89.9   0.062 1.7E-06   51.1   0.0  144  463-626    81-226 (433)
+103 4fb5_A Probable oxidoreductase  89.4   0.074   2E-06   48.6   0.0  161  450-626     9-170 (393)
+104 3ip3_A Oxidoreductase, putativ  89.3   0.077 2.1E-06   47.5   0.0   75  549-626    69-145 (337)
+105 4gmf_A Yersiniabactin biosynth  88.9   0.089 2.4E-06   48.1   0.0  138  464-631     6-146 (372)
+106 4ab7_A Protein Arg5,6, mitocho  88.2    0.11   3E-06   52.1   0.0   70  179-257   177-247 (464)
+107 3uuw_A Putative oxidoreductase  88.1    0.11 3.1E-06   45.1   0.0  136  462-624     3-140 (308)
+108 3c1a_A Putative oxidoreductase  87.8    0.12 3.3E-06   45.4   0.0  142  464-632     9-151 (315)
+109 3fhl_A Putative oxidoreductase  87.7    0.13 3.4E-06   46.7   0.0  137  464-626     4-141 (362)
+110 3s6k_A Acetylglutamate kinase;  87.0    0.15 4.1E-06   50.1   0.0   64  179-252   190-253 (467)
+111 1zh8_A Oxidoreductase; TM0312,  86.7    0.16 4.3E-06   45.3   0.0  146  459-626    12-158 (340)
+112 3kux_A Putative oxidoreductase  86.7    0.16 4.4E-06   45.4   0.0  137  464-626     6-143 (352)
+113 2ixa_A Alpha-N-acetylgalactosa  86.6    0.16 4.5E-06   48.7   0.0  145  464-626    19-167 (444)
+114 4mkx_A Inositol dehydrogenase;  86.5    0.17 4.6E-06   45.6   0.0  138  463-626    15-157 (355)
+115 3rc1_A Sugar 3-ketoreductase;   85.9    0.19 5.3E-06   45.1   0.0  147  456-626    18-165 (350)
+116 5ees_A HTPA reductase, 4-hydro  85.4    0.21 5.9E-06   45.1   0.0  113  466-619     2-116 (247)
+117 5a04_A Aldose-aldose oxidoredu  85.0    0.23 6.3E-06   44.1   0.0   75  549-626    75-149 (339)
+118 3q2i_A Dehydrogenase; rossmann  84.9    0.24 6.5E-06   44.6   0.0  143  462-627    10-152 (354)
+119 3v5n_A Oxidoreductase; structu  84.0    0.28 7.6E-06   46.1   0.0   75  549-626   112-186 (417)
+120 2dt9_A Aspartokinase; protein-  83.9    0.28 7.8E-06   40.6   0.0   58  388-447     8-70  (167)
+121 3a06_A 1-deoxy-D-xylulose 5-ph  83.8    0.29 7.9E-06   46.9   0.0  128  465-605     3-140 (376)
+122 3e18_A Oxidoreductase; dehydro  83.5     0.3 8.3E-06   44.2   0.0  136  464-626     4-141 (359)
+123 3e82_A Putative oxidoreductase  83.4    0.31 8.5E-06   44.0   0.0  138  463-626     5-143 (364)
+124 1lc0_A Biliverdin reductase A;  83.2    0.32 8.8E-06   42.8   0.0  138  464-629     6-143 (294)
+125 4lrt_B Acetaldehyde dehydrogen  82.9    0.33 9.2E-06   44.8   0.0   95  462-577    20-117 (323)
+126 1dih_A Dihydrodipicolinate red  81.6    0.41 1.1E-05   42.1   0.0  132  464-618     4-138 (273)
+127 2j0w_A Lysine-sensitive aspart  81.5    0.42 1.1E-05   46.8   0.0   59  388-448   300-358 (449)
+128 3wgq_A MESO-diaminopimelate de  81.4    0.43 1.2E-05   42.8   0.0  131  465-625     4-136 (326)
+129 4miy_A Inositol 2-dehydrogenas  80.9    0.46 1.3E-05   41.9   0.0  140  466-626     3-143 (339)
+130 1xea_A Oxidoreductase, GFO/IDH  80.7    0.47 1.3E-05   41.7   0.0   75  549-626    65-139 (323)
+131 1tlt_A Putative oxidoreductase  80.3     0.5 1.4E-05   41.3   0.0   76  549-627    67-142 (319)
+132 3gdo_A Uncharacterized oxidore  78.5    0.63 1.7E-05   41.7   0.0   75  549-626    67-141 (358)
+133 3f4l_A Putative oxidoreductase  77.6     0.7 1.9E-05   41.2   0.0   74  550-626    68-141 (345)
+134 4koa_A 1,5-anhydro-D-fructose   77.3    0.72   2E-05   40.6   0.0   75  549-626    65-139 (333)
+135 3wb9_A Diaminopimelate dehydro  77.1    0.74   2E-05   41.9   0.0  122  464-613     8-131 (305)
+136 3i23_A Oxidoreductase, GFO/IDH  76.9    0.76 2.1E-05   40.8   0.0   75  549-626    67-141 (349)
+137 2cdq_A Aspartokinase; aspartat  76.3    0.81 2.2E-05   46.0   0.0   60  387-448   332-391 (510)
+138 1ydw_A AX110P-like protein; st  76.3    0.81 2.2E-05   40.7   0.0   73  549-624    73-145 (362)
+139 2czc_A Glyceraldehyde-3-phosph  72.4     1.2 3.3E-05   40.9   0.0   97  466-576     3-108 (334)
+140 3tvi_A Aspartokinase; structur  69.9     1.5 4.1E-05   43.2   0.0   61  386-448   288-348 (446)
+141 3dty_A Oxidoreductase, GFO/IDH  67.6     1.8   5E-05   40.0   0.0   75  549-626    87-161 (398)
+142 3p96_A Phosphoserine phosphata  67.0     1.9 5.2E-05   40.1   0.0  116  311-432     8-135 (415)
+143 3ijp_A DHPR, dihydrodipicolina  66.4       2 5.5E-05   39.0   0.0  124  463-613    19-149 (288)
+144 2axq_A Saccharopine dehydrogen  66.0     2.1 5.6E-05   41.8   0.0  132  460-614    18-150 (467)
+145 4ina_A Saccharopine dehydrogen  64.7     2.3 6.2E-05   39.4   0.0   67  549-616    78-149 (405)
+146 1zvp_A Hypothetical protein VC  63.6     2.5 6.7E-05   36.2   0.0   65  309-376    65-129 (133)
+147 3l07_A Bifunctional protein fo  63.6     2.5 6.7E-05   39.0   0.0   21  466-486   162-183 (285)
+148 3s1t_A Aspartokinase; ACT doma  63.0     2.6   7E-05   35.8   0.0   56  390-447    10-70  (181)
+149 4f3y_A DHPR, dihydrodipicolina  62.8     2.6 7.1E-05   36.2   0.0   59  549-612    75-133 (272)
+150 1p9l_A Dihydrodipicolinate red  62.5     2.7 7.3E-05   38.2   0.0   68  548-618    46-114 (245)
+151 2f06_A Conserved hypothetical   62.4     2.7 7.3E-05   32.0   0.0   67  317-383    71-137 (144)
+152 1iuk_A Hypothetical protein TT  62.3     2.7 7.4E-05   34.0   0.0  106  464-604    12-121 (140)
+153 1zhv_A Hypothetical protein AT  60.7       3 8.3E-05   36.1   0.0   68  309-379    56-123 (134)
+154 3oqb_A Oxidoreductase; structu  60.5     3.1 8.4E-05   38.3   0.0   74  550-626    86-159 (383)
+155 3o9z_A Lipopolysaccaride biosy  58.8     3.4 9.4E-05   36.7   0.0   76  549-627    74-149 (312)
+156 3mah_A Aspartokinase; aspartat  56.5       4 0.00011   33.1   0.0   55  390-446    12-66  (157)
+157 1edz_A 5,10-methylenetetrahydr  55.3     4.3 0.00012   37.7   0.0   22  466-487   178-200 (320)
+158 3abi_A Putative uncharacterize  55.0     4.4 0.00012   37.3   0.0   35  465-507    16-50  (365)
+159 1nvm_B Acetaldehyde dehydrogen  53.5     4.8 0.00013   38.0   0.0   34  549-583    73-108 (312)
+160 1gr0_A Inositol-3-phosphate sy  53.2     4.9 0.00013   39.9   0.0   74  549-626   140-218 (367)
+161 3k92_A NAD-GDH, NAD-specific g  53.1       5 0.00014   40.5   0.0   51  464-523   220-270 (424)
+162 4h3v_A Oxidoreductase domain p  51.1     5.6 0.00015   36.4   0.0   74  550-626    78-154 (390)
+163 2ph5_A Homospermidine synthase  51.0     5.7 0.00015   40.2   0.0  100  466-578    14-114 (480)
+164 3oa2_A WBPB; oxidoreductase, s  50.5     5.8 0.00016   35.5   0.0   75  549-626    75-149 (318)
+165 2tmg_A Protein (glutamate dehy  50.1       6 0.00016   39.8   0.0   53  463-523   207-259 (415)
+166 2dtj_A Aspartokinase; protein-  50.0       6 0.00016   33.2   0.0   56  390-447     9-69  (178)
+167 4xgi_A Glutamate dehydrogenase  50.0       6 0.00016   40.3   0.0   50  465-523   231-280 (436)
+168 3ab4_A Aspartokinase; aspartat  49.9       6 0.00016   37.8   0.0   66  388-455   256-326 (421)
+169 3obb_A Probable 3-hydroxyisobu  48.8     6.5 0.00018   34.0   0.0   22  465-486     3-24  (300)
+170 3ngx_A Bifunctional protein fo  48.5     6.6 0.00018   36.0   0.0   22  465-486   150-172 (276)
+171 3btv_A Galactose/lactose metab  48.0     6.7 0.00018   37.9   0.0   76  549-627    91-172 (438)
+172 4go7_X Aspartokinase; transfer  46.5     7.4  0.0002   33.8   0.0   59  387-447    26-89  (200)
+173 3zgy_A R-imine reductase; oxid  43.9     8.7 0.00024   33.4   0.0   24  463-486    17-40  (309)
+174 4ywj_A HTPA reductase, 4-hydro  43.1     9.1 0.00025   36.5   0.0   63  548-615    78-140 (276)
+175 2fp4_A Succinyl-COA ligase [GD  43.0     9.1 0.00025   35.6   0.0   28  549-576    73-101 (305)
+176 1ff9_A Saccharopine reductase;  42.9     9.1 0.00025   36.8   0.0  126  466-614     4-130 (450)
+177 5cef_A Aspartate-semialdehyde   42.6     9.3 0.00025   36.3   0.0   29  549-577    85-113 (375)
+178 1a4i_A Methylenetetrahydrofola  41.7     9.9 0.00027   35.4   0.0   22  465-486   165-187 (301)
+179 3v1y_O PP38, glyceraldehyde-3-  40.1      11  0.0003   34.8   0.0   30  547-576    93-123 (337)
+180 2re1_A Aspartokinase, alpha an  39.8      11  0.0003   30.7   0.0   57  389-447    18-77  (167)
+181 1b7g_O Protein (glyceraldehyde  39.6      11  0.0003   35.0   0.0   99  466-577     2-107 (340)
+182 3aog_A Glutamate dehydrogenase  38.2      12 0.00033   38.3   0.0   50  465-523   235-284 (440)
+183 3doj_A AT3G25530, dehydrogenas  38.1      12 0.00033   32.7   0.0   25  462-486    18-42  (310)
+184 1bgv_A Glutamate dehydrogenase  37.2      13 0.00035   37.9   0.0   57  465-530   230-286 (449)
+185 3qha_A Putative oxidoreductase  36.0      14 0.00038   32.2   0.0   27  460-486    10-36  (296)
+186 2x5j_O E4PDH, D-erythrose-4-ph  33.5      16 0.00044   33.8   0.0   29  549-577    94-123 (339)
+187 3aoe_E Glutamate dehydrogenase  33.3      16 0.00045   36.7   0.0   51  464-523   217-267 (419)
+188 2hjs_A USG-1 protein homolog;   33.2      16 0.00045   33.6   0.0   31  548-578    69-99  (340)
+189 3cmc_O GAPDH, glyceraldehyde-3  33.1      17 0.00045   33.0   0.0   73  548-621    89-165 (334)
+190 4dpl_A Malonyl-COA/succinyl-CO  32.7      17 0.00047   33.8   0.0   30  548-577    80-109 (359)
+191 4ei7_A Plasmid replication pro  32.2      18 0.00048   34.4   0.0   52  459-510     9-60  (389)
+192 3hsk_A Aspartate-semialdehyde   31.9      18 0.00049   34.8   0.0  104  462-578    16-124 (381)
+193 2g1u_A Hypothetical protein TM  31.7      18 0.00049   28.8   0.0   22  466-487    20-41  (155)
+194 3pdu_A 3-hydroxyisobutyrate de  31.2      19 0.00051   30.9   0.0   20  467-486     3-22  (287)
+195 2izz_A Pyrroline-5-carboxylate  30.3      20 0.00054   32.6   0.0   36  449-486     8-43  (322)
+196 2dt5_A AT-rich DNA-binding pro  29.8      20 0.00056   30.7   0.0   37  462-506    77-113 (211)
+197 1vl6_A Malate oxidoreductase;   28.4      23 0.00062   34.7   0.0   22  466-487   193-214 (388)
+198 4b4u_A Bifunctional protein fo  27.9      23 0.00063   33.4   0.0   21  466-486   180-201 (303)
+199 2cdc_A Glucose dehydrogenase g  27.6      24 0.00065   31.4   0.0   29  549-577   248-277 (366)
+200 2pc6_A Probable acetolactate s  27.4      24 0.00065   29.4   0.0  125  318-453     7-138 (165)
+201 4o59_O Glyceraldehyde-3-phosph  27.3      24 0.00066   33.3   0.0   99  466-575     1-117 (332)
+202 3mw9_A GDH 1, glutamate dehydr  27.0      25 0.00067   36.7   0.0   50  465-523   244-293 (501)
+203 4egb_A DTDP-glucose 4,6-dehydr  25.9      27 0.00073   31.5   0.0   39  449-487     8-47  (346)
+204 3wv7_A HMD CO-occurring protei  25.2      28 0.00076   30.7   0.0   20  467-486    15-34  (218)
+205 2yop_A Protein FAM3B; apoptosi  24.7      29 0.00079   31.7   0.0   60  101-161    11-83  (198)
+206 4d79_A TRNA threonylcarbamoyla  24.7      29 0.00079   32.2   0.0   23  466-488    31-53  (276)
+207 1zud_1 Adenylyltransferase THI  24.7      29 0.00079   29.1   0.0   22  465-486    28-49  (251)
+208 1jw9_B Molybdopterin biosynthe  23.7      31 0.00085   29.0   0.0   22  466-487    32-53  (249)
+209 2f1f_A Acetolactate synthase i  23.2      32 0.00088   28.8   0.0   99  329-433    14-119 (164)
+210 3ic5_A Putative saccharopine d  23.2      32 0.00088   23.6   0.0   21  466-486     6-26  (118)
+211 4r3n_A Aspartate-semialdehyde   23.1      33 0.00089   32.7   0.0   28  549-576    66-93  (366)
+212 1y81_A Conserved hypothetical   22.9      33  0.0009   27.1   0.0   32  455-486     4-39  (138)
+213 1npy_A Hypothetical shikimate   22.4      34 0.00094   30.5   0.0   24  464-487   118-141 (271)
+214 1ofu_A FTSZ, cell division pro  22.3      35 0.00094   31.0   0.0   28  461-488     7-34  (320)
+215 4a26_A Putative C-1-tetrahydro  22.2      35 0.00095   31.7   0.0   21  466-486   166-187 (300)
+216 5hm8_A Adenosylhomocysteinase;  22.1      35 0.00096   34.8   0.0   20  467-486   273-292 (498)
+217 2iz1_A 6-phosphogluconate dehy  22.0      35 0.00097   32.8   0.0   23  464-486     4-26  (474)
+218 2rir_A Dipicolinate synthase,   21.7      36 0.00099   28.9   0.0   21  467-487   159-179 (300)
+219 3gvp_A Adenosylhomocysteinase   21.2      38   0.001   33.0   0.0   20  467-486   222-241 (435)
+220 3h8v_A Ubiquitin-like modifier  21.1      38   0.001   30.5   0.0   21  467-487    38-58  (292)
+221 2d59_A Hypothetical protein PH  20.5      40  0.0011   27.4   0.0   22  465-486    22-47  (144)
+222 2r75_1 Cell division protein F  20.3      40  0.0011   31.3   0.0   27  461-487     3-29  (338)
+223 3off_A LDLR chaperone BOCA; ME  20.3      41  0.0011   28.5   0.0   42  484-525    31-72  (90)
+224 4zrm_A UDP-glucose 4-epimerase  20.2      41  0.0011   28.1   0.0   21  467-487     5-26  (312)
+225 3ofg_A BOCA/MESD chaperone for  20.1      41  0.0011   28.6   0.0   43  483-525    35-77  (95)
+
+No 1
+>2j0w_A Lysine-sensitive aspartokinase 3; feedback inhibition, allosteric regulation, ACT domain, transferase, amino acid biosynthesis; HET: ADP; 2.5A {Escherichia coli} SCOP: c.73.1.3 d.58.18.10 d.58.18.10 PDB: 2j0x_A*
+Probab=100.00  E-value=3.5e-59  Score=450.67  Aligned_cols=442  Identities=31%  Similarity=0.495  Sum_probs=369.8  Template_Neff=8.600
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQGQVATVLSAPAKITNHLVAMIEKTISGQDALPNISDAERIFAELLTGLAA   80 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarqgqvatvlsapakitnhlvamiektisgqdalpnisdaerifaelltglaa   80 (820)
+                      |.|.||||||+++++++.++++++.++.  .++..|+||+.++|++|....+....+.. ...+........++...+..
+T Consensus         4 ~~V~KfGGssl~~~~~~~~~~~ii~~~~--~~~vvVvSA~~~iTd~L~~~~~~~~~~~~-~~~~~~i~~~~~~~~~~l~~   80 (449)
+T 2j0w_A            4 IVVSKFGGTSVADFDAMNRSADIVLSDA--NVRLVVLSASAGITNLLVALAEGLEPGER-FEKLDAIRNIQFAILERLRY   80 (449)
+T ss_dssp             CEEEEECSGGGSSHHHHHHHHHHHTSCT--TEEEEEECCCTTHHHHHHHHTTCCCHHHH-HHHHHHHHHHHHHHHTTSSS
+T ss_pred             cEEEEECCcccCCHHHHHHHHHHHhhcc--CceEEEEeCCCCCcHHHHHHHHHhhcccc-HHHHHHHHHHHHHHHhhhcc
+Confidence            5799999999999999999999997754  46789999999999999999987666532 11222222222222222211
+
+
+Q gi|556503834|r   81 AQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVGHY  160 (820)
+Q Consensus        81 aqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvekllavghy  160 (820)
+                           + ..++..+++.+.++...++++.+  .+++..-..++..||++|..+|+..|..+|.++..+||.+-+..-.+|
+T Consensus        81 -----~-~~~~~~i~~~~~~l~~~~~~~~~--~~~~~~~d~i~s~GE~ls~~l~~~~L~~~gv~a~~~~~~~~i~~~~~~  152 (449)
+T 2j0w_A           81 -----P-NVIREEIERLLENITVLAEAAAL--ATSPALTDELVSHGELMSTLLFVEILRERDVQAQWFDVRKVMRTNDRF  152 (449)
+T ss_dssp             -----T-HHHHHHHHHHHHHHHHHHHHHTT--CCCHHHHHHHHHHHHHHHHHHHHHHHHTTSCCEEECCGGGTCBBCSCT
+T ss_pred             -----h-hhHHHHHHHHHHHHHHHHhhhhc--cCCHHHHHHHhhhhHHHHHHHHHHHHHhccCCceEeCHHHhhcccCcc
+Confidence                 1 24455566777778778877766  778888899999999999999999999999999999998765666677
+
+
+Q gi|556503834|r  161 LESTVDIAESTRRIAA---SRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDP  237 (820)
+Q Consensus       161 lestvdiaestrriaa---sripadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdp  237 (820)
+                      ....+++..+.+.+..   ... ...++++.||.+.++.|+...+||+||||+|+.||+++.++-|.+||||||+||+||
+T Consensus       153 ~~~~~~~~~~~~~~~~~~~~~l-~~~i~Vv~Gf~g~~~~g~~~~lgrggsD~~A~~lA~~l~a~~l~~~tdv~Gi~~~dp  231 (449)
+T 2j0w_A          153 GRAEPDIAALAELAALQLLPRL-NEGLVITQGFIGSENKGRTTTLGRGGSDYTAALLAEALHASRVDIWTDVPGIYTTDP  231 (449)
+T ss_dssp             TSCCBCHHHHHHHHHHHTHHHH-HHSEEEEESSEEECTTSCEEECCTTHHHHHHHHHHHHTTCSEEEEEESSSSEESSCT
+T ss_pred             CcccccHHHHHHHHHHHHHhhc-CCCeEEEeeEEEeCCCCCEEEeecCCchHHHHHHHHHhCCCeEEEeeCCCceEeCCC
+Confidence            7777776654332211   122 235889999999999999999999999999999999999999999999999999999
+
+
+Q gi|556503834|r  238 RQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDEDELPVKGISNLNNMAM  317 (820)
+Q Consensus       238 rqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntgnpqapgtligasrdedelpvkgisnlnnmam  317 (820)
+                      +.+|++++++.+||+|+.+++++|+|++||+++.|..+..+|+.|.|+.+|..+||.|.... +..-++++|+..+|+++
+T Consensus       232 ~~~~~a~~i~~is~~ea~~l~~~G~~v~~~~a~~~~~~~~i~v~I~~~~~~~~~gt~i~~~~-~~~~~v~~It~~~~ial  310 (449)
+T 2j0w_A          232 RVVSAAKRIDEIAFAEAAEMATFGAKVLHPATLLPAVRSDIPVFVGSSKDPRAGGTLVCNKT-ENPPLFRALALRRNQTL  310 (449)
+T ss_dssp             TTCTTCCEESEEEHHHHHHHHHTTCTTSCTTTHHHHHHHTCCEEEEESSCTTSCCEEEESCC-SSCCSEEEEEEEEEEEE
+T ss_pred             CCCccceECCccCHHHHHHHHhCCCccCCHHHHHHHHHCCCcEEEecCCCCCCCCeEEeccc-cccccccceEecCCeEE
+Confidence            99999999999999999999999999999999999999999999999999999999998765 34467999999999999
+
+
+Q gi|556503834|r  318 FSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERA-MQEEFYLELKEGLLEPLAVTERL  396 (820)
+Q Consensus       318 fsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraera-mqeefylelkeglleplavterl  396 (820)
+                      .++.+++|.+-.|..+++|..+.++.|++.+|+|  ++.+++|+++.++-.++... ...++..+++.  .....+.+.+
+T Consensus       311 i~v~~~~~~~~~~~~~~i~~~la~~~I~i~~I~~--s~~~is~~i~~~~~~~~~~~~~~~~~~~~l~~--~~~i~v~~~~  386 (449)
+T 2j0w_A          311 LTLHSLNMLHSRGFLAEVFGILARHNISVDLITT--SEVSVALTLDTTGSTSTGDTLLTQSLLMELSA--LCRVEVEEGL  386 (449)
+T ss_dssp             EEECCCSCSCHHHHHHHHTTTTTTTTCCCSEEEE--ETTEEEEEECCCCCSSTTCCSSCHHHHHHHHH--HSCEEEEEEE
+T ss_pred             EEEEEccccchhhHHHHHHHHHHHCCCcEEEEEc--CCCceEEEEechhhhhHHHHHHHHHHHHHhhc--CceEEEeCCe
+Confidence            9999999999999999999999999999999999  47889999998876554321 12334555554  4567788999
+
+
+Q gi|556503834|r  397 AIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFN  461 (820)
+Q Consensus       397 aiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlfn  461 (820)
+                      ++||+||.||+.-.|+.+++|.+|+  +++|-.|.||+|+.+|+++|+.+|...-++.-|+-+|.
+T Consensus       387 a~IsvVG~~~~~~~~i~~~~~~~L~--~~~I~~i~~~~S~~~is~vV~~~d~~~av~~LH~~f~~  449 (449)
+T 2j0w_A          387 ALVALIGNDLSKACGVGKEVFGVLE--PFNIRMICYGASSHNLCFLVPGEDAEQVVQKLHSNLFE  449 (449)
+T ss_dssp             EEEEEEESSCTTSSSHHHHHHSSCT--TSCCCEEEESSCTTEEEEEEEGGGHHHHHHHHHHHHHC
+T ss_pred             EEEEEeccccccchhHHHHHHHHhc--cCCeEEEEecCCCCeEEEEEehHHHHHHHHHHHHHHhC
+Confidence            9999999999999999999999995  67778899999999999999999999999999998773
+
+
+No 2
+>3c1m_A Probable aspartokinase; allosteric inhibition, threonine-sensitive, ACT DOMA amino-acid biosynthesis, threonine biosynthesis; HET: ANP; 2.30A {Methanocaldococcus jannaschii} PDB: 3c1n_A 3c20_A 2hmf_A*
+Probab=100.00  E-value=4.3e-59  Score=446.75  Aligned_cols=459  Identities=37%  Similarity=0.570  Sum_probs=389.1  Template_Neff=9.100
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQ-GQVATVLSAPAKITNHLVAMIEKTISGQDA---LPNISDAERIFAELLT   76 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarq-gqvatvlsapakitnhlvamiektisgqda---lpnisdaerifaellt   76 (820)
+                      +.|.||||||+++++++.++++++.....+ .++.-|.||+.++|+.|..........++.   .+.+.+.+..+.+++.
+T Consensus         2 ~~V~KfGGssl~~~~~~~~v~~~i~~~~~~~~~~vvVvsA~~~~t~~L~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   81 (473)
+T 3c1m_A            2 TTVMKFGGTSVGSGERIRHVAKIVTKRKKEDDDVVVVVSAMSEVTNALVEISQQALDVRDIAKVGDFIKFIREKHYKAIE   81 (473)
+T ss_dssp             CEEEEECTTTTSSHHHHHHHHHHHHHHHTTCSCEEEEECCSTTHHHHHHHHHHHHHHTCCHHHHHHHHHHHHHHHHHHHH
+T ss_pred             cEEEEECccccCCHHHHHHHHHHHHHHhhcCCcEEEEEECCCCccHHHHHHHHHHHhccchhhHHHHHHHHHHHHHHHHH
+Confidence            479999999999999999999999887653 479999999999999999887765543321   1222233333333333
+
+
+Q gi|556503834|r   77 GLAAAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLA  156 (820)
+Q Consensus        77 glaaaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpveklla  156 (820)
+                      .+-..+  --...++.+++.+|.++...++|+..++.+++.....++..||++|..+++..|..+|.++..++|.+..+.
+T Consensus        82 ~~~~~~--~~~~~~~~~i~~~~~~l~~~~~~~~~~~~~~~~~~d~i~~~ge~~s~~l~~~~L~~~g~~~~~~~~~~~~~~  159 (473)
+T 3c1m_A           82 EAIKSE--EIKEEVKKIIDSRIEELEKVLIGVAYLGELTPKSRDYILSFGERLSSPILSGAIRDLGEKSIALEGGEAGII  159 (473)
+T ss_dssp             HHCCCH--HHHHHHHHHHHHHHHHHHHHHHHHHHHTCCCHHHHHHHHHHHHHHHHHHHHHHHHHTTCCEEEECHHHHTEE
+T ss_pred             Hhccch--hhHHHHHHHHHHHHHHHHHHHHHHHhccCCCHHHHHHHhHhhHHHHHHHHHHHHHhhccCceecchHHhcee
+Confidence            332111  123457788899999999999999999999999899999999999999999999999999998999886443
+
+
+Q gi|556503834|r  157 V-GHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTC  235 (820)
+Q Consensus       157 v-ghylestvdiaestrriaasripadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytc  235 (820)
+                      . ..|....++..++..+|.. .+..+.++++.||.+.++.|++..+||+||||+|+.+|++++|+.|.+||||||+|++
+T Consensus       160 ~~~~~~~~~~~~~~~~~~l~~-~l~~~~ipVv~g~~~~~~~g~~~~lgrg~sD~~A~~lA~~l~a~~l~~~tdv~Gv~~~  238 (473)
+T 3c1m_A          160 TDNNFGSARVKRLEVKERLLP-LLKEGIIPVVTGFIGTTEEGYITTLGRGGSDYSAALIGYGLDADIIEIWTDVSGVYTT  238 (473)
+T ss_dssp             ECSCTTSCCEEEECHHHHHHH-HHHTTCEEEEESSEEEETTSCEEECCTTTHHHHHHHHHHHTTCSEEEEEESSSSCBSS
+T ss_pred             cCCccccccccHHHHHHHHHH-HHhCCceEEEeCCcccCCCCcEeecCCCCccHHHHHHHhhcCCCEEEECcCCCCCEEC
+Confidence            3 3333323333332333322 2345678899999999989999999999999999999999999999999999999999
+
+
+Q gi|556503834|r  236 DPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDEDELPVKGISNLNNM  315 (820)
+Q Consensus       236 dprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntgnpqapgtligasrdedelpvkgisnlnnm  315 (820)
+                      ||+.+|++++++.+||+|+.+++++|++++||+++.+..+..+|+.|.|+.+|..+||+|.....+....+++++..+|+
+T Consensus       239 dp~~~~~a~~i~~is~~e~~~l~~~g~~v~~~~a~~~a~~~~i~v~I~~~~~~~~~gT~i~~~~~~~~~~v~~It~~~~v  318 (473)
+T 3c1m_A          239 DPRLVPTARRIPKLSYIEAMELAYFGAKVLHPRTIEPAMEKGIPILVKNTFEPESEGTLITNDMEMSDSIVKAISTIKNV  318 (473)
+T ss_dssp             CTTTCTTCCBCSEEEHHHHHHHHHTTCTTSCGGGHHHHHHHTCCEEEEETTSTTSCCEEEESCCCCCTTSCCEEEEEEEE
+T ss_pred             CCccCccccccCCCCHHHHHHHHhcCCccchHHHHHHHHHcCCeEEEecCCCCCCCCceeecccccccccceEEEecCCE
+Confidence            99999999999999999999999999999999999999999999999999999999999998776556679999999999
+
+
+Q gi|556503834|r  316 AMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYL-----ELKEGLLEPL  390 (820)
+Q Consensus       316 amfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefyl-----elkegllepl  390 (820)
+                      ++.++.|++|.+.-|..+++|..+.+..|.+.+++|++++.+++|++++.+..++-+.+..+|..     +++.......
+T Consensus       319 alIsi~g~~~~~~~~~~~~i~~~L~~~~I~v~~i~~~~s~~sis~~v~~~~~~~~l~~l~~~l~~~~~~~~~~~~~~~~i  398 (473)
+T 3c1m_A          319 ALINIFGAGMVGVSGTAARIFKALGEEEVNVILISQGSSETNISLVVSEEDVDKALKALKREFGDFGKKSFLNNNLIRDV  398 (473)
+T ss_dssp             EEEEEEECSSSCHHHHHHHHHHHHHHTTCCEEEEEECCTTCCEEEEEEGGGHHHHHHHHHHHHCC----CTTSCCCEEEE
+T ss_pred             EEEEEEecCCCCcccHHHHHHHHHHHCCCcEEEEEcccccceEEEecCHHHHHHHHHHHHHHHHhhcchhhhhhcCCceE
+Confidence            99999999999999999999999999999999999999999999999999977777777776653     2334445667
+
+
+Q gi|556503834|r  391 AVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFNT  462 (820)
+Q Consensus       391 avterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlfnt  462 (820)
+                      .+.+.+++|+++|.+|+.-.++.+++|++|++++||+..|.||+++.+++++|+.+|...-++.-|+.+|..
+T Consensus       399 ~~~~~~alIsvvG~~~~~~~~i~~~i~~~L~~~~i~v~~i~~~~s~~~is~vv~~~~~~~a~~~Lh~~~~~~  470 (473)
+T 3c1m_A          399 SVDKDVCVISVVGAGMRGAKGIAGKIFTAVSESGANIKMIAQGSSEVNISFVIDEKDLLNCVRKLHEKFIEK  470 (473)
+T ss_dssp             EEEEEEEEEEEECTTTTTCTTHHHHHHHHHHHHTCCCCEEEESSCSSEEEEEEEGGGHHHHHHHHHHHHTTC
+T ss_pred             EEECCEEEEEEEeeccCCCCCHHHHHHHHHHhCCCCEEEEEecCCCCeEEEEEeHHHHHHHHHHHHHHHhcc
+Confidence            788899999999999999999999999999999999999999999999999999999999999999988764
+
+
+No 3
+>2cdq_A Aspartokinase; aspartate kinase, amino acid metabolism, ACT domain, alloste S-adenosylmethionine, lysine, allosteric effector, plant; HET: TAR SAM LYS; 2.85A {Arabidopsis thaliana} SCOP: c.73.1.3 d.58.18.10 d.58.18.10
+Probab=100.00  E-value=4.1e-58  Score=453.81  Aligned_cols=458  Identities=29%  Similarity=0.442  Sum_probs=384.4  Template_Neff=8.200
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQGQVATVLSAPAKITNHLVAMIEKTISGQD----ALPNISDAERIFAELLT   76 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarqgqvatvlsapakitnhlvamiektisgqd----alpnisdaerifaellt   76 (820)
+                      |.|.||||||+++.+++.++++++.... +++..-|.||+.++|++|..+..+...+.+    ....+.+.+..+.+++.
+T Consensus        28 ~~V~KfGGssl~~~~~~~~v~~~I~~~~-~~~~vvVvsA~~~itd~L~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  106 (510)
+T 2cdq_A           28 TCVMKFGGSSVASAERMKEVADLILTFP-EESPVIVLSAMGKTTNNLLLAGEKAVSCGVSNASEIEELSIIKELHIRTVK  106 (510)
+T ss_dssp             CEEEEECTGGGSSHHHHHHHHHHHHHCT-TCCEEEEECCSTTHHHHHHHHHHHHTTTCTTTGGGCHHHHHHHHHHHHHHH
+T ss_pred             eEEEEECCcCcCCHHHHHHHHHHHHhhc-cCCeEEEeCCCCCchHHHHHHHHHhhcccchhhhHHHHHHHHHHHHHHHHH
+Confidence            4699999999999999999999998754 368888999999999999987766443322    12234444555555554
+
+
+Q gi|556503834|r   77 GLAAAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEK-LL  155 (820)
+Q Consensus        77 glaaaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvek-ll  155 (820)
+                      .+....         .+++.++.++...++++.+.+.++......+...||++|..+|+..|..+|.++..+||.+- ++
+T Consensus       107 ~l~~~~---------~~i~~~~~~l~~~l~~~~~~~~~~~~~~d~i~~~ge~ls~~l~~~~L~~~Gi~a~~l~~~~~~~~  177 (510)
+T 2cdq_A          107 ELNIDP---------SVILTYLEELEQLLKGIAMMKELTLRTRDYLVSFGECLSTRIFAAYLNTIGVKARQYDAFEIGFI  177 (510)
+T ss_dssp             HHTCCS---------HHHHHHHHHHHHHHHHHHHHTCCCHHHHHHHHHHHHHHHHHHHHHHHHHTTCCEEEECGGGTTCE
+T ss_pred             HhccCH---------HHHHHHHHHHHHHHHHHHhcccCCHHHHHHHHHHhHHHHHHHHHHHHHhhcCCcEEEchHHheee
+Confidence            443211         45778899999999999999999999999999999999999999999999999999999885 44
+
+
+Q gi|556503834|r  156 AVGHYLESTVDIAESTRRIAASR----IPADHMVLMAGFTAGNE-KGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVD  230 (820)
+Q Consensus       156 avghylestvdiaestrriaasr----ipadhmvlmagftagne-kgelvvlgrngsdysaavlaaclradcceiwtdvd  230 (820)
+                      ....|....++ ..+.+++....    .....++++.||.+-+. .|+...+||+||||+|+.+|++++|+.|.+|||||
+T Consensus       178 ~~~~~~~~~i~-~~~~~~v~~~~~~~~l~~g~IpVv~Gfig~~~~~G~~~~l~rggsD~~A~~lA~~l~A~~l~~~tDV~  256 (510)
+T 2cdq_A          178 TTDDFTNGDIL-EATYPAVAKRLYDDWMHDPAVPIVTGFLGKGWKTGAVTTLGRGGSDLTATTIGKALGLKEIQVWKDVD  256 (510)
+T ss_dssp             ECSCSTTCCBC-TTHHHHHHHHHHHHHHHSCCEEEEESSEEEETTTCCEEECCTTHHHHHHHHHHHHHTCSEEEEEESSS
+T ss_pred             eccccCccccc-ccCHHHHHHHHHHhhccCCceEEecCccccccCCCceeecCCCCchHHHHHHHHhcCCCEEEEecCCC
+Confidence            44444443343 33333333222    25678899999998887 79999999999999999999999999999999999
+
+
+Q gi|556503834|r  231 GVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDEDELPVKGIS  310 (820)
+Q Consensus       231 gvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntgnpqapgtligasrdedelpvkgis  310 (820)
+                      |+|++||+.+|++++++.+||+|+.+++++|++++||+++.+..+..+|+.|.|+.+|..+||+|...+.++..++++|+
+T Consensus       257 Gv~~~dP~~~~~a~~i~~is~~ea~~l~~~g~~~~~~~a~~~a~~~~i~v~I~n~~~~~~~GT~I~~~~~~~~~~i~~It  336 (510)
+T 2cdq_A          257 GVLTCDPTIYKRATPVPYLTFDEAAELAYFGAQVLHPQSMRPAREGEIPVRVKNSYNPKAPGTIITKTRDMTKSILTSIV  336 (510)
+T ss_dssp             SSBSSCTTTCTTCCBCCEEEHHHHHHHHHHHSSCCCHHHHHHHHHHTCCEEEEETTSTTSCCEEEESCCCCTTCCEEEEE
+T ss_pred             ceEECCCCcCCcceEecccCHHHHHHHhhcCCCccHHHHHHHHHhCCCeEEEEecCCCCCCCceEecccccccccceecc
+Confidence            99999999999999999999999999999999999999999999999999999999999999999998876567899999
+
+
+Q gi|556503834|r  311 NLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELKE-GLLEP  389 (820)
+Q Consensus       311 nlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelke-gllep  389 (820)
+                      -.+|+++.++++++|.+..|..+++|..+.++.|+|.+|+|  ++++|+||++.++.... ...++++-..+++ ....+
+T Consensus       337 ~~~~ialI~v~~~~~~~~~~~~~~if~~La~~gI~v~~Is~--s~~~is~~v~~~~~~~~-~~~~~~~~~~~~~l~~~~~  413 (510)
+T 2cdq_A          337 LKRNVTMLDIASTRMLGQVGFLAKVFSIFEELGISVDVVAT--SEVSISLTLDPSKLWSR-ELIQQELDHVVEELEKIAV  413 (510)
+T ss_dssp             EEEEEEEEEEECGGGTTCTTHHHHHHHHHHHTTCCEEEEEE--ETTEEEEEECCGGGSSS-CCCHHHHHHHHHHHTTTSE
+T ss_pred             ccCCeeEEEEEecCcCCchhHHHHHHHHHHhcCceEEEEEc--CCceEEEEEehhhhHHH-HHHHHHHHHHHHHhhccce
+Confidence            99999999999999999999999999999999999999987  48899999999876532 2333443221111 11234
+
+
+Q gi|556503834|r  390 LAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFNTDQVIEVF  469 (820)
+Q Consensus       390 lavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlfntdqvievf  469 (820)
+                      ..+.+.+++||+||.++ .-.|+.+++|.+|+.++|||..|+||+|+.+||++|+.+|...-++.-|+.+|..+..++.+
+T Consensus       414 v~~~~~~a~IsvVG~~~-~~~~v~~~~f~~L~~~~I~i~~Is~g~Se~sis~vV~~~d~~~al~~Lh~~f~~~~~~~~~~  492 (510)
+T 2cdq_A          414 VNLLKGRAIISLIGNVQ-HSSLILERAFHVLYTKGVNVQMISQGASKVNISFIVNEAEAEGCVQALHKSFFESGDLSELL  492 (510)
+T ss_dssp             EEEEEEEEEEEEEECGG-GHHHHHHHHHHHHHHHTCCCSEEEECTTCSEEEEEEEHHHHHHHHHHHHHHHHSSCCCCCCC
+T ss_pred             EEEecCccEEEEEecCC-CCCchHHHHHHHHHhCCCcEEEEEecCCCCEEEEEEEhHHHHHHHHHHHHHHhcCCCeeeEE
+Confidence            66788999999999864 55799999999999999999999999999999999999999999999999999999999988
+
+
+Q gi|556503834|r  470 VIGV  473 (820)
+Q Consensus       470 vigv  473 (820)
+                      |-+=
+T Consensus       493 ~~~~  496 (510)
+T 2cdq_A          493 IQPR  496 (510)
+T ss_dssp             CCCC
+T ss_pred             Eecc
+Confidence            8654
+
+
+No 4
+>3tvi_A Aspartokinase; structural genomics, ACT domains, regulatory domains, kinase transferase, PSI-2, protein structure initiative; HET: LYS; 3.00A {Clostridium acetobutylicum}
+Probab=100.00  E-value=3.7e-54  Score=418.45  Aligned_cols=427  Identities=26%  Similarity=0.405  Sum_probs=330.0  Template_Neff=8.300
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQGQVATVLSAPAKITNHLVA-------MIEKTISGQDALPNISDAERIFAE   73 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarqgqvatvlsapakitnhlva-------miektisgqdalpnisdaerifae   73 (820)
+                      |.|.||||||+++++++.++++++.++.  .+..-|+||+.++|++|+.       ..+....++....-+.+.+..+.+
+T Consensus         4 ~~V~KfGGssl~~~~~~~~~~~ii~~~~--~~~vvVvSA~~~~t~~l~~~td~L~~~~~~~~~~~~~~~~~~~~~~~~~~   81 (446)
+T 3tvi_A            4 IVVTKFGGSSLADSNQFKKVKGIIDSDA--NRKYIIPSAPGKRTNKDYKITDLLYLCNAHVKNGIPFDDVFKLISQRYTE   81 (446)
+T ss_dssp             CEEEEECGGGGSSHHHHHHHHHHHTTCT--TEEEEEECSCCCSSSSSCCHHHHHHHHHHHHHTTCCCHHHHHHHHHHHHH
+T ss_pred             eEEEEECCcccCCHHHHHHHHHHHHhhc--CceEEEEcCCCCCCchhhhHHHHHHHHHhhhhccchHHHHHHHHHHHHHH
+Confidence            5799999999999999999999998764  4577899999997776543       322211122111112222222223
+
+
+Q gi|556503834|r   74 LLTGLAAAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEK  153 (820)
+Q Consensus        74 lltglaaaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvek  153 (820)
+                      +...+-..      ..    .+..+.+++..+.        +...-..+.+.||++|..+|+..|+++|.+.     .+-
+T Consensus        82 ~~~~l~~~------~~----~~~~~~~l~~~~~--------~~~~~d~i~~~Ge~~sa~l~~~~l~~~~~~~-----~~~  138 (446)
+T 3tvi_A           82 IVSELNID------MD----IAYYLEKVKKNIE--------NGASSDYAASRGEYLNGVILAKYLNAEFIDA-----AEV  138 (446)
+T ss_dssp             HHHHHTCC------SC----HHHHHHHHHHHHH--------TTCCHHHHHHHHHHHHHHHHHHHHTCEECCG-----GGT
+T ss_pred             HHHHhccc------ch----hHHHHHHHHHhcc--------ChhHHHHHHHHHHHHHHHHHHHHHhhccccH-----HHh
+Confidence            32222111      11    2334455554442        2223356789999999999999999887543     221
+
+
+Q gi|556503834|r  154 LLAVGHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVY  233 (820)
+Q Consensus       154 llavghylestvdiaestrriaasripadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvy  233 (820)
+                      ++.-+   ...++..++.++|.. .+..+.++++.||.+.++.|+...+||+|||++|+.+|.++.||-|.+||||||+|
+T Consensus       139 ~~~~~---~~~~~~~~~~~~i~~-~l~~~~i~vi~G~~g~~~~g~~~~l~rggsD~~A~~lA~~l~A~~l~~~tdv~Gi~  214 (446)
+T 3tvi_A          139 IFFDK---SGCFDEKKSYEKIKE-KVLSCNKAVIPGFYGSSFNGDVKTFSRGGSDVTGSIISAGVNADLYENWTDVSGFL  214 (446)
+T ss_dssp             CBBCC-----CBCHHHHHHHHHH-HTTTCSSEECCCSEEECTTSCEEECSSSTTHHHHHHHHHHTTCSEEEEEESSSSCB
+T ss_pred             eEecC---CcccchhhhHHHHHH-HHhcCCceEeccccccCCCCcccccCcCCccHHHHHHHHHhCCCEEEeccCCCceE
+Confidence            11111   134555555555432 23446688899999999999999999999999999999999999999999999999
+
+
+Q gi|556503834|r  234 TCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDE--DELPVKGISN  311 (820)
+Q Consensus       234 tcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntgnpqapgtligasrde--delpvkgisn  311 (820)
+                      ++||+.+|++++++.+||.|+.+++++|++++||+.+.+..+..+|+.|.|+.+|..+||+|.....+  ...++++|+.
+T Consensus       215 ~~dp~~~~~a~~i~~ls~~ea~~l~~~g~~~~~~~a~~~a~~~gi~v~I~~~~~~~~~GT~i~~~~~~~~~~~~v~~It~  294 (446)
+T 3tvi_A          215 MADPRIVENPKTISKISYKELRELSYMGATVLHEEAIFPVKDSGIPINIKNTNKPSDPGTLILSDTHKEINLGTITGIAG  294 (446)
+T ss_dssp             SSCTTTSSSCCBCSEEEHHHHHHTTTC----CCSTTTHHHHHSSCCEEEEETTBTTSCCEEEECTTTSCCCTTCCCEEEE
+T ss_pred             eCCCCcCCCceEecccCHHHHHHHHhCCCCcccHHHHHHHHHcCCcEEEEecCCCCCCCeEEecCcccccccccceeeee
+Confidence            99999999999999999999999999999999999999999999999999999999999999877653  4567999999
+
+
+Q gi|556503834|r  312 LNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELKEG-LLEPL  390 (820)
+Q Consensus       312 lnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelkeg-llepl  390 (820)
+                      ..|.++.++.+++|.+..|+++++|..+.++.|+|.+|++  ++++|+|+++.++...+...    ...++++. .....
+T Consensus       295 ~~ni~li~i~~~~~~~~~g~~~~if~~La~~gI~V~~Is~--s~~~is~~i~~~~~~~~~~~----i~~~l~~~~~~~~v  368 (446)
+T 3tvi_A          295 KKNFTVIAIEKALLNSEVGFCRKILSILEMYGVSFEHMPS--GVDSVSLVIEDCKLDGKCDK----IIEEIKKQCNPDSI  368 (446)
+T ss_dssp             EEEEEEEEEECTTGGGSTTHHHHHHHHHHTTTCCEEEBCE--ETTEEEEEEEHHHHTTTHHH----HHHHHHHHSCCSEE
+T ss_pred             cCCceeEEEeccCCCCcccHHHHHHHHHHHcCceEEeecc--CcccEEEEEehhhhhHHHHH----HHHHHHhhCCCceE
+Confidence            9999999999999999999999999999999999999965  58899999997654222111    22222221 23456
+
+
+Q gi|556503834|r  391 AVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFNT  462 (820)
+Q Consensus       391 avterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlfnt  462 (820)
+                      .+.+.+++||+||.||+.-.|+.+++|.+|+.++|||..|.||+|+.+||++|+.+|...-++.-|+.+|..
+T Consensus       369 ~~~~~~a~IsvVG~gm~~~~gva~~v~~~L~~~~I~i~~Is~~~Se~~is~vV~~~d~~~av~~Lh~~f~~~  440 (446)
+T 3tvi_A          369 EIHPNMALVATVGTGMAKTKGIANKIFTALSKENVNIRMIDQGSSEINVIVGVETVDFEKAVKSIYNAFNEG  440 (446)
+T ss_dssp             EEEEEEEEEEEECGGGSSCTTHHHHHHHHHHHTTCCEEEEEECSCTTEEEEEEEGGGHHHHHHHHHHHHCCC
+T ss_pred             EEeCCeEEEEEEcCCcccCccHHHHHHHHHHhCCCCEEEEEecCCCCEEEEEEEhHHHHHHHHHHHHHHHhc
+Confidence            778899999999999999999999999999999999999999999999999999999999999999998854
+
+
+No 5
+>1ebf_A Homoserine dehydrogenase; dinucleotide, NAD, dimer, oxidoreductase; HET: NAD; 2.30A {Saccharomyces cerevisiae} SCOP: c.2.1.3 d.81.1.2 PDB: 1ebu_A* 1tve_A* 1q7g_A*
+Probab=100.00  E-value=2.5e-49  Score=367.10  Aligned_cols=344  Identities=35%  Similarity=0.590  Sum_probs=291.2  Template_Neff=9.100
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNL---ENWQEELAQAK-EPFNLGRLIR  539 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnl---enwqeelaqak-epfnlgrlir  539 (820)
+                      ..+.|.+||.|.+|..++++++++..     ++++++++|+.+..-..+..|...   +.|.+.+.... ...++..++.
+T Consensus         3 ~~i~I~iiG~G~vG~~~~~~l~~~~~-----~~~~~v~~v~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~l~   77 (358)
+T 1ebf_A            3 KVVNVAVIGAGVVGSAFLDQLLAMKS-----TITYNLVLLAEAERSLISKDFSPLNVGSDWKAALAASTTKTLPLDDLIA   77 (358)
+T ss_dssp             SEEEEEEECCSHHHHHHHHHHHHCCC-----SSEEEEEEEECSSBEEECSSCSCCSCTTCHHHHHHTCCCBCCCHHHHHH
+T ss_pred             ceEEEEEEecCHHHHHHHHHHHhchh-----hccccEEEEEEEEchhhcccccccchhhhHHHHhhhcccccCCHHHHHH
+Confidence            35778999999999999999987654     245566776544332222222222   44555443221 1123334443
+
+
+Q gi|556503834|r  540 LVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENL  619 (820)
+Q Consensus       540 lvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienl  619 (820)
+                      .+++.+ --.++++||.+....+.+..+|+.|.||++.|||....+.+.++++..+ ++...+++|..+++.++|++..+
+T Consensus        78 ~~~~~~-~~DvVv~~t~~~~~~~~~~~al~~Gk~Vv~aNekpla~~~~e~~~l~~~-~~~~~~~~~~~~~~~~~P~i~~l  155 (358)
+T 1ebf_A           78 HLKTSP-KPVILVDNTSSAYIAGFYTKFVENGISIATPNKKAFSSDLATWKALFSN-KPTNGFVYHEATVGAGLPIISFL  155 (358)
+T ss_dssp             HHTTCS-SCEEEEECSCCHHHHTTHHHHHHTTCEEECCCCGGGSSCHHHHHHHTCC-CTTCCCEECGGGTTTTSSCHHHH
+T ss_pred             HhhccC-CCeEEEECCCcHHHHHHHHHHHHcCCeEEeccccccCCCHHHHHHHHHH-HHcCCeEEEecccccCCcHHHHH
+Confidence            333222 2378999999999999999999999999999999999999999999877 77777888999999999999999
+
+
+Q gi|556503834|r  620 QNLLNAGDELMKFSGILSGSLSYIFGKLDE----GMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARETGRELE  695 (820)
+Q Consensus       620 qnllnagdelmkfsgilsgslsyifgklde----gmsfseattlaremgytepdprddlsgmdvarkllilaretgrele  695 (820)
+                      ++++..|+++.++.|+++|+.+||+.++++    |++|+++...|+++||+||||++|++|+|+++||.||||+.|...+
+T Consensus       156 ~~~l~~g~~I~~i~~i~~gt~nyil~~~~~~~~~g~~~~~al~~A~~~G~~e~dp~~Dl~G~D~a~Kl~ila~~~g~~~~  235 (358)
+T 1ebf_A          156 REIIQTGDEVEKIEGIFSGTLSYIFNEFSTSQANDVKFSDVVKVAKKLGYTEPDPRDDLNGLDVARKVTIVGRISGVEVE  235 (358)
+T ss_dssp             HHHHHHTCCEEEEEEECCHHHHHHHHHHSCSSCCCCCHHHHHHHHHHHTCSCSSTHHHHTCHHHHHHHHHHHHHTTCCCC
+T ss_pred             HHHHhcCCceeeeeEEecCccceeccchhccCcCCCCHHHHHHHHHHcCCCCCCccccccCHhHHHHHHHHHHHhCCCcc
+Confidence            999999999999999999999999999984    8999999999999999999999999999999999999999999996
+
+
+Q gi|556503834|r  696 -LADIEIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDED-GVCRVKIAEVDGNDPLFKVKN  773 (820)
+Q Consensus       696 -ladieiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnided-gvcrvkiaevdgndplfkvkn  773 (820)
+                       +.||++++.+|.++..-..+..|+..++.+|..|.+++++|+.+|+++||++.++.+ +.++|+..+++.++||+.++.
+T Consensus       236 ~~~~i~~~~~~~~~~~~~~~~~~~~~~~~~~d~~~~~~~~~a~~~g~~lr~v~~~~~~~~~~~V~~~~v~~~~~l~~~~~  315 (358)
+T 1ebf_A          236 SPTSFPVQSLIPKPLESVKSADEFLEKLSDYDKDLTQLKKEAATENKVLRFIGKVDVATKSVSVGIEKYDYSHPFASLKG  315 (358)
+T ss_dssp             CTTSSCBCCCSCGGGSTTSCTHHHHHHHGGGHHHHHHHHHHHTTTTEEEEEEEEEETTTTEEEEEEEEEESSSGGGGCCT
+T ss_pred             ChhHeeecccCccchhhcccHHHHHHHhHhhHHHHHHHHHHHHhcCCEEEEEEEEecCCceEEEEEEEECCCCcceeCCC
+Confidence             599999999999887555556899999999999999999999999999999999874 578999999999999999999
+
+
+Q gi|556503834|r  774 GENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTLS  815 (820)
+Q Consensus       774 genalafyshyyqplplvlrgygagndvtaagvfadllrtls  815 (820)
+                      .+|++.|+++.| .-|+++.|-|||.++||++||+|+++...
+T Consensus       316 ~~n~v~i~t~~~-~~~~~~~G~gag~~~TA~~v~~Dll~~~~  356 (358)
+T 1ebf_A          316 SDNVISIKTKRY-TNPVVIQGAGAGAAVTAAGVLGDVIKIAQ  356 (358)
+T ss_dssp             TCEEEEEEESSC-SSCEEEEECCCCHHHHHHHHHHHHHHHHH
+T ss_pred             CceEEEEcccCC-cCCeEEEeCCCChHHhHHHHHHHHHHHHh
+Confidence            999999999976 57999999999999999999999998654
+
+
+No 6
+>3ab4_A Aspartokinase; aspartate kinase, concerted inhibition, alternative initiati amino-acid biosynthesis, ATP-binding; HET: LYS; 2.47A {Corynebacterium glutamicum} PDB: 3aaw_A* 3ab2_A
+Probab=100.00  E-value=3.9e-47  Score=359.31  Aligned_cols=407  Identities=30%  Similarity=0.489  Sum_probs=303.3  Template_Neff=9.100
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQ-GQVATVLSAPAKITNHLVAMIEKTISGQDALPNISDAERIFAELLTGLA   79 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarq-gqvatvlsapakitnhlvamiektisgqdalpnisdaerifaelltgla   79 (820)
+                      +.|+||||+++.+.+++.++++.+....+. .++.-|.|++..+++.+.......             .+          
+T Consensus         3 ~~ViK~GGs~l~~~~~~~~i~~~i~~~~~~g~~~iiV~gg~g~~~~~l~~~~~~~-------------~~----------   59 (421)
+T 3ab4_A            3 LVVQKYGGSSLESAERIRNVAERIVATKKAGNDVVVVCSAMGDTTDELLELAAAV-------------NP----------   59 (421)
+T ss_dssp             EEEEEECSGGGSSHHHHHHHHHHHHHHHHTTCEEEEEECCSTTHHHHHHHHHHHH-------------CS----------
+T ss_pred             CEEEEECCcccCCHHHHHHHHHHHHHHHhcCCCEEEEECCCCCChHHHHHHHHHh-------------cC----------
+Confidence            458999999999999999999998866543 478888888888998876553321             00          
+
+
+Q gi|556503834|r   80 AAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVG-  158 (820)
+Q Consensus        80 aaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvekllavg-  158 (820)
+                                   +.+                   ++.. ..+...||+++..+|+..|..+|.+...+++.+..+... 
+T Consensus        60 -------------~~~-------------------~~~~-~~~~s~ge~ls~~l~~~~l~~~gi~a~~~~~~~~~~~~~~  106 (421)
+T 3ab4_A           60 -------------VPP-------------------AREM-DMLLTAGERISNALVAMAIESLGAEAQSFTGSQAGVLTTE  106 (421)
+T ss_dssp             -------------SCC-------------------HHHH-HHHHHHHHHHHHHHHHHHHHHTTCCEEECCCC--------
+T ss_pred             -------------CCC-------------------HHHH-HHHHHhhHHHHHHHHHHHHHhcCcceEEeeCCcceEEeCC
+Confidence                         000                   1111 223345899999999999999999998888876543322 
+
+
+Q gi|556503834|r  159 HYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEK-GELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDP  237 (820)
+Q Consensus       159 hylestvdiaestrriaasripadhmvlmagftagnek-gelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdp  237 (820)
+                      .+....++ ..+...|. ..+....++++.||.+.++. |+...+||.++|++|+.||++++|+-+.+|||+||+|++||
+T Consensus       107 ~~~~~~~~-~~~~~~l~-~~l~~g~IpVv~g~~~~~~~~g~~~~l~~~~sD~~A~~lA~~l~a~~li~~tdv~Gv~~~dp  184 (421)
+T 3ab4_A          107 RHGNARIV-DVTPGRVR-EALDEGKICIVAGFQGVNKETRDVTTLGRGGSDTTAVALAAALNADVCEIYSDVDGVYTADP  184 (421)
+T ss_dssp             ----------CCHHHHH-HHHHTTCEEEC------------------CCHHHHHHHHHHHHTCSEEEEEESCCSCBSSCT
+T ss_pred             CCCCceeh-hhhHHHHH-HHHhcCceEEecceeecCCCCCceeeccCCCchHHHHHHHHHCCCCEEEEeECCCCCEECCC
+Confidence            22222221 11222221 22445678899999988875 99999999999999999999999999999999999999999
+
+
+Q gi|556503834|r  238 RQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDE---DELPVKGISNLNN  314 (820)
+Q Consensus       238 rqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntgnpqapgtligasrde---delpvkgisnlnn  314 (820)
+                      +.+|++++++.+||+|+.+++++|++++||+.+.+..+..+|+.|.|+-+| .+||+|...+++   .+-++++|+...+
+T Consensus       185 ~~~~~a~~i~~is~~ea~~l~~~g~~~~~~~a~~~~~~~~i~v~I~~~~~~-~~gt~i~~~~~~~~~~~~~v~~i~~~~~  263 (421)
+T 3ab4_A          185 RIVPNAQKLEKLSFEEMLELAAVGSKILVLRSVEYARAFNVPLRVRSSYSN-DPGTLIAGSMEDIPVEEAVLTGVATDKS  263 (421)
+T ss_dssp             TTSTTCCBCSEECHHHHHHHHHTTCCSSCHHHHHHHHHTTCCEEEEESSSC-CCCEEECSCGGGSCTTTCCCCEEEEECS
+T ss_pred             CcCCCceEcCccCHHHHHHHHHcCCceeChhhhhHHHhcCCCEEEEecCCC-CCCcEEeccccccccccceeeEEEecCc
+Confidence            999999999999999999999999999999999999999999999999987 589999876543   2456999999999
+
+
+Q gi|556503834|r  315 MAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSS-----SEYSISFCVPQSDCVRAERAMQEEFYLELKEGLLEP  389 (820)
+Q Consensus       315 mamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqss-----seysisfcvpqsdcvraeramqeefylelkegllep  389 (820)
+                      ++|+++++  |.+-.|..+++|..+.+..|+|.+|+||.     ++.+++|+++.++--++...+++.+    +++-+..
+T Consensus       264 i~~i~i~~--~~~~~g~l~~i~~~l~~~~I~v~~i~~s~~~~~~~~~~~~~~~~~~~~~~~~~~L~~~~----~~~~~~~  337 (421)
+T 3ab4_A          264 EAKVTVLG--ISDKPGEAAKVFRALADAEINIDMVLQNVFSVEDGTTDITFTCPRSDGRRAMEILKKLQ----VQGNWTN  337 (421)
+T ss_dssp             EEEEEEEE--EESSTTHHHHHHHHHHHTTCCCEEEEECCCC--CCEEEEEEEEETTTHHHHHHHHHHHH----TTTTCSE
+T ss_pred             eEEEEEec--CCCCccHHHHHHHHHHHcCCcEEEEEeccccccCCcceEEEEeeHHHHHHHHHHHHHHH----hhcCCce
+Confidence            99999986  77777999999999999999999999985     5689999999888656655544433    2333455
+
+
+Q gi|556503834|r  390 LAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFNTDQVIEVF  469 (820)
+Q Consensus       390 lavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlfntdqvievf  469 (820)
+                      ..+.+.+++||++|++|+.-.|+.+++|.+|++++|||..+.  +|+.+|+++|+.+|...-++.-|+.+|.....+-+|
+T Consensus       338 i~~~~~~a~IsvvG~~~~~~~g~~~~~~~~L~~~~I~i~~i~--~s~~~is~vv~~~d~~~a~~~Lh~~f~~~~~~~~~~  415 (421)
+T 3ab4_A          338 VLYDDQVGKVSLVGAGMKSHPGVTAEFMEALRDVNVNIELIS--TSEIRISVLIREDDLDAAARALHEQFQLGGEDEAVV  415 (421)
+T ss_dssp             EEEECCEEEEEEECGGGTSCTTHHHHHHHHHHHTTCCCCEEE--EETTEEEEEEEGGGHHHHHHHHHHHTTCCCC-----
+T ss_pred             EEEcCCceEEEEecCccccCcchHHHHHHHHHhCCCcEEEEe--cCCCEEEEEEEHHHHHHHHHHHHHHHhcCCCeEEEE
+Confidence            678899999999999999999999999999999999999987  678899999999999999999999999999999999
+
+
+Q gi|556503834|r  470 VIGVG  474 (820)
+Q Consensus       470 vigvg  474 (820)
+                      ++|-|
+T Consensus       416 ~~g~g  420 (421)
+T 3ab4_A          416 YAGTG  420 (421)
+T ss_dssp             -----
+T ss_pred             EecCC
+Confidence            99976
+
+
+No 7
+>3do5_A HOM, homoserine dehydrogenase; NP_069768.1, putative homoserine dehydrogenase, structural G joint center for structural genomics, JCSG; 2.20A {Archaeoglobus fulgidus}
+Probab=100.00  E-value=4.7e-43  Score=319.73  Aligned_cols=315  Identities=25%  Similarity=0.428  Sum_probs=260.2  Template_Neff=9.300
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLN-LENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhgln-lenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      +.|.+||.|.||..++++++++..++++++.++++++|.++..-..  .+++ .+.|.... +.........+..++++.
+T Consensus         3 i~I~iiG~G~vG~~~~~~l~~~~~~~~~~~~~~~vv~v~d~~~~~~--~~~~~~~~~~~~~-~~~~~~~~~~~~~~l~~~   79 (327)
+T 3do5_A            3 IKIAIVGFGTVGQGVAELLIRKREEIEKAIGEFKVTAVADSKSSIS--GDFSLVEALRMKR-ETGMLRDDAKAIEVVRSA   79 (327)
+T ss_dssp             EEEEEECCSHHHHHHHHHHHHTHHHHHHHHCCEEEEEEECSSCEEE--SSCCHHHHHHHHH-HHSSCSBCCCHHHHHHHS
+T ss_pred             eEEEEEecCHHHHHHHHHHHhhHHHHHHhCCCEEEEEEEeCChhhc--ccccHHHHHhhhc-ccccccCcHhHHHHHhcC
+Confidence            5688999999999999999999888887778899999988764322  1111 11121100 000000111222333322
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSS----QAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQ  620 (820)
+Q Consensus       545 hllnpvivdctss----qavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlq  620 (820)
+                        --.++++||.+    ....+.+..+|+.|.||++.||.+..   ..|.+|..+++++.++|.|..+++.++|++..++
+T Consensus        80 --~~D~vvi~t~~~~~~~~~~~~~~~aL~~G~~Vv~enp~~~~---~~~~~L~~~a~~~g~~~~~~~~~~~~~P~i~~l~  154 (327)
+T 3do5_A           80 --DYDVLIEASVTRVDGGEGVNYIREALKRGKHVVTSNKGPLV---AEFHGLMSLAERNGVRLMYEATVGGAMPVVKLAK  154 (327)
+T ss_dssp             --CCSEEEECCCCC----CHHHHHHHHHTTTCEEEECCSHHHH---HHHHHHHHHHHHTTCCEECGGGSSTTSCCHHHHH
+T ss_pred             --CCCEEEEEcCCCCCCHHHHHHHHHHHHcCCeEEecCHHHHH---HHHHHHHHHHHHcCCeEEEeeecccCCcHHHHHH
+Confidence              23467788876    67788899999999999999998752   4678888889999999999999999999999999
+
+
+Q gi|556503834|r  621 NLLNAGDELMKFSGILSGSLSYIFGKLDE-GMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARETGRELELADI  699 (820)
+Q Consensus       621 nllnagdelmkfsgilsgslsyifgklde-gmsfseattlaremgytepdprddlsgmdvarkllilaretgreleladi  699 (820)
+                      +++.. +++-++.|+++|..+||+.++.+ |.+|+|+...|+++||+||||++|++|+|+++||.|||++.|..+++.|+
+T Consensus       155 ~~i~~-~~i~~i~gi~~~t~~yil~~~~~~~~~~~~~~~~a~~~G~~e~dp~~Dl~G~d~a~kl~ila~~~g~~~~~~~v  233 (327)
+T 3do5_A          155 RYLAL-CEIESVKGIFNGTCNYILSRMEEERLPYEHILKEAQELGYAEADPSYDVEGIDAALKLVIIANTIGVKASYEDV  233 (327)
+T ss_dssp             TTTTT-SCEEEEEEECCHHHHHHHHHHHHHCCCHHHHHHHHHHTTSSCSSCHHHHTSHHHHHHHHHHHHHTTCCCCGGGS
+T ss_pred             HHHhc-CCccceeeEECCCcchhHHHHccCCCCHHHHHHHHHHcCCCCCCcchhccchHHHHHHHHHHHHHCCCCChhhc
+Confidence            99976 69999999999999999999986 79999999999999999999999999999999999999999999999999
+
+
+Q gi|556503834|r  700 EIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDGVCRVKIAEVDGNDPLFKVKNGENALA  779 (820)
+Q Consensus       700 eiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedgvcrvkiaevdgndplfkvkngenala  779 (820)
+                      +++++.|..                     .+.+..|+.+|+++|||+.++. +.++|+..+++.++|+. ++..+|++.
+T Consensus       234 ~~~~i~~~~---------------------~~~~~~a~~~g~~~r~v~~~~~-~~~~v~~~~v~~~~~l~-~~~~~n~~~  290 (327)
+T 3do5_A          234 EVTGITQIT---------------------PEAFQVAAEKGYTIRLIAEVSR-EKLKVSPRLVPFHHPLA-IKGTMNAAM  290 (327)
+T ss_dssp             EECCSTTCC---------------------HHHHHHHHTTTEEEEEEEEESS-SCEEEEEEEEETTSGGG-CCSSCEEEE
+T ss_pred             eEEeeccCC---------------------HHHHHHHHHCCCeEEEEEEecc-CcEEEEEEEecCCChhh-cCCCCcEEE
+Confidence            998888751                     2336678899999999999986 47999999999999999 999999999
+
+
+Q gi|556503834|r  780 FYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       780 fyshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      ||+.+|.  |+++.|.|||..+||+|||+|+++..
+T Consensus       291 ~~t~~~~--~~~~~g~gag~~~Ta~~v~~D~~~~~  323 (327)
+T 3do5_A          291 FKTDTAG--SIFVAGRGAGKEETASAILSDLYEIY  323 (327)
+T ss_dssp             EEESSSC--EEEEEECCCCHHHHHHHHHHHHHHHH
+T ss_pred             EEecccC--cEEEEeCCCChHHHHHHHHHHHHHHH
+Confidence            9999999  78999999999999999999998753
+
+
+No 8
+>4xb1_A 319AA long hypothetical homoserine dehydrogenase; rossmann fold, oxidoreductase; HET: NDP; 2.30A {Pyrococcus horikoshii OT3} PDB: 4xb2_A*
+Probab=100.00  E-value=1.2e-42  Score=323.55  Aligned_cols=308  Identities=26%  Similarity=0.429  Sum_probs=252.2  Template_Neff=8.700
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKE-------PFNL  534 (820)
+Q Consensus       462 tdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqake-------pfnl  534 (820)
+                      .+..+.|.+||.|.||..++++|.++..   ..+++++|++|.++..-..+-  ++.+.|.+.+.+...       +.-.
+T Consensus        15 ~~~~i~V~iiG~G~vG~~~~~~L~~~~~---~~~~~~~v~~V~d~~~~~~~~--~~~~~~~~~~~~~~~~~~~~~~~~~~   89 (335)
+T 4xb1_A           15 RHMKVNISIFGFGTVGRALAEIIAEKSR---IFGVELNVISITDRSGTIWGD--FDLLEAKEVKESTGKLSNIGDYEVYN   89 (335)
+T ss_dssp             --CEEEEEEECCSHHHHHHHHHHHHHSE---ETTEEEEEEEEEETTEEEESS--CCHHHHHHHHHHHSCGGGSTTCCCBC
+T ss_pred             cCceEEEEEEeeCHHHHHHHHHHHhhHH---hcCCCEEEEEEEECCHHHccc--cCHHHHHHHHHhcccccccccccccC
+Confidence            3778999999999999999999987754   456789999998876543221  556666665543221       0000
+
+
+Q gi|556503834|r  535 GRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       535 grlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                      ..+-.++.  +.-..++++||+++...+.+..+++.|.|||+.||+...   .+|.+|+..+++...+|+|+..++.|+|
+T Consensus        90 ~~~~~ll~--~~~~DiVv~~t~~~~~~~~~~~al~~Gk~Vv~aNk~pla---~~~~eL~~la~~~g~~~~~ea~v~~g~P  164 (335)
+T 4xb1_A           90 FSPQELVE--EVKPNILVDVSSWDEAHEMYKVALGEGISVVTSNKPPIA---NYYDELMNLAKENNAGIFFESTVMAGTP  164 (335)
+T ss_dssp             CCHHHHHH--HHCCSEEEECSCCTTTHHHHHHHHHTTCEEEECCHHHHH---HHHHHHHHHHHHTTCCEECGGGSSTTSC
+T ss_pred             CCHHHHHh--CCCCCEEEECCCCHHHHHHHHHHHHCCCeEEecCcHHHH---HHHHHHHHHHHHcCCEEEEeccccccch
+Confidence            11112222  123578999999999999999999999999999999987   7899999999999999999999999999
+
+
+Q gi|556503834|r  615 VIENLQNLLNAGDELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARETGREL  694 (820)
+Q Consensus       615 vienlqnllnagdelmkfsgilsgslsyifgkldegmsfseattlaremgytepdprddlsgmdvarkllilaretgrel  694 (820)
+                      ++..+++++. |+++..+.|+++|..+||+.++.+|++|+|+...|+++||+|+||++|++|+|+|||++||||+...+.
+T Consensus       165 ~i~~l~~~l~-g~~I~~i~gi~~gt~n~il~~~~~g~~~~eal~~A~~~G~~e~dp~~dl~G~D~a~Kl~ila~~~~~~~  243 (335)
+T 4xb1_A          165 IIGVLRENLL-GENIKRIDAVVNASTTFILTKMSEGKTLDDAIEEAKSLGILEEDPSKDIDGIDAYYKAKILHWVSYGEP  243 (335)
+T ss_dssp             HHHHHHHSCT-TCCEEEEEEECCHHHHHHHHHHHHTCCHHHHHHHHHHTTSSCSSCHHHHTTHHHHHHHHHHHHHHHSSC
+T ss_pred             HHHHHHHHhc-cCcceEEEEEEecCCcchhhhhhCCCCHHHHHHHHHHcCCCcCCchhhhcCccHHHHHHHHhhcccccC
+Confidence            9999999995 999999999999999999999999999999999999999999999999999999999999999984321
+
+
+Q gi|556503834|r  695 ELADIEIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDGVCRVKIAEVDGNDPLFKVKNG  774 (820)
+Q Consensus       695 eladieiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedgvcrvkiaevdgndplfkvkng  774 (820)
+                                 |.+...+|           ++.     +    +.|+++||++.++. +.++|+..+++.++|+. +++.
+T Consensus       244 -----------~~~~~~~g-----------i~~-----~----~~~~~~~~v~~~~~-~~~~V~~~~v~~~~~l~-~~~~  290 (335)
+T 4xb1_A          244 -----------PEEEERLG-----------IRE-----V----RDARNVRLVAQVSK-GKISVKPRKLSSDNPLL-VEGV  290 (335)
+T ss_dssp             -----------CSEEEECC-----------STT-----C----SCCTTEEEEEEEET-TEEEEEEEECCTTCTTC-CCTT
+T ss_pred             -----------CchhhhcC-----------chh-----h----ccCCeEEEEEEEec-CcEEEEEEEECCCCcee-eCCC
+Confidence                       11111111           111     1    34789999999985 58999999999999998 9999
+
+
+Q gi|556503834|r  775 ENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTLS  815 (820)
+Q Consensus       775 enalafyshyyqplplvlrgygagndvtaagvfadllrtls  815 (820)
+                      +|++.|++.+|.  |+++.|.|||.+.||++||+|+++...
+T Consensus       291 ~n~v~~~t~~~~--~~~~~g~gag~~~Ta~~v~~Dl~~~~~  329 (335)
+T 4xb1_A          291 QNAAVIRTNNLG--EVILKGPGGGGRVTASGVFTDIIKATL  329 (335)
+T ss_dssp             EEEEEEEETTTE--EEEEEEECCCHHHHHHHHHHHHHHHHT
+T ss_pred             ccEEEEEccccC--cEEEEeCCCChHHHHHHHHHHHHHHHh
+Confidence            999999999999  679999999999999999999998654
+
+
+No 9
+>3l76_A Aspartokinase; allostery, ACT domains, kinase transferase; HET: LYS; 2.54A {Synechocystis}
+Probab=100.00  E-value=4.9e-41  Score=329.06  Aligned_cols=397  Identities=30%  Similarity=0.449  Sum_probs=314.0  Template_Neff=9.300
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQ-GQVATVLSAPAKITNHLVAMIEKTISGQDALPNISDAERIFAELLTGLA   79 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarq-gqvatvlsapakitnhlvamiektisgqdalpnisdaerifaelltgla   79 (820)
+                      +.|+||||+++.+.+++.++++++...... -++.-|.|++.+.++.+...... +         .+             
+T Consensus         3 ~~ViK~GGs~l~~~~~~~~~~~~i~~~~~~g~~~viV~sg~g~~~~~l~~~~~~-~---------~~-------------   59 (600)
+T 3l76_A            3 LIVQKFGGTSVGTVERIQAVAQRIKRTVQGGNSLVVVVSAMGKSTDVLVDLAQQ-I---------SP-------------   59 (600)
+T ss_dssp             EEEEEECSGGGSSHHHHHHHHHHHHHHHHTTCEEEEEECCSSTHHHHHHHHHHH-H---------CS-------------
+T ss_pred             eEEEEECccccCCHHHHHHHHHHHHHHHhCCCCEEEEEeCCchhHHHHHHHHHH-h---------cc-------------
+Confidence            468999999999999999999999865543 47888899999999876532111 0         00             
+
+
+Q gi|556503834|r   80 AAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVG-  158 (820)
+Q Consensus        80 aaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvekllavg-  158 (820)
+                                                      ..+.+ .-..+...||+++..+|...|..+|.++..++|.+..+... 
+T Consensus        60 --------------------------------~~~~~-~~~~~~~~Ge~~~~~l~~~~L~~~gi~~~~~~~~~~~~~~~~  106 (600)
+T 3l76_A           60 --------------------------------NPCRR-EMDMLLSTGEQVSIALLSLALQEIDQPAISLTGAQVGIVTEA  106 (600)
+T ss_dssp             --------------------------------SCCHH-HHHHHHHHHHHHHHHHHHHHHHHTTCCEEEEEGGGTEEEEC-
+T ss_pred             --------------------------------CCCHH-HHHHHHHHhHHHHHHHHHHHHHHcCCceEEechhHcCEEecC
+Confidence                                            00011 11245667999999999999999999998888877643332 
+
+
+Q gi|556503834|r  159 HYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGN--EKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCD  236 (820)
+Q Consensus       159 hylestvdiaestrriaasripadhmvlmagftagn--ekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcd  236 (820)
+                      ++....+. ...++.|. ..+....++++.||...+  +.|++..+||+++||+|+.||++++|+-+.+||||||+|++|
+T Consensus       107 ~~~~~~~~-~~~~~~i~-~~l~~~~ipVv~g~~~~~~~~~~~i~~lgrg~sD~~A~~lA~~l~A~~li~~tdv~Gv~~~d  184 (600)
+T 3l76_A          107 EHSRARIL-EIRPDRLE-HHLREGKVVVVAGFQGISSVEHLEITTLGRGGSDTSAVALAAALKADFCEIYTDVPGILTTD  184 (600)
+T ss_dssp             ------CC-EEEECCHH-HHHTTTCEEEEECEEEC----CEEEECCCTTHHHHHHHHHHHHHTCSEEEEEESSSSCBSSC
+T ss_pred             CCCCceec-ccCHHHHH-HHHhcCcEEEEeCccccCCcccCceeecCCCCchHHHHHHHHhCCCCEEEEccCCCCcEECC
+Confidence            33222221 11222222 223446788999996554  568899999999999999999999999999999999999999
+
+
+Q gi|556503834|r  237 PRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDE--------DELPVKG  308 (820)
+Q Consensus       237 prqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntgnpqapgtligasrde--------delpvkg  308 (820)
+                      |+.+|++++++.+||.||.+++++|++++||+.+.+..+..+|..|.|..+| .+||.|......        -..++++
+T Consensus       185 p~~~~~a~~i~~is~~ea~~l~~~g~~~~~~~a~~~a~~~gi~~~i~~~~~~-~~gt~i~~~~~~~~~~~~~~~~~~~~~  263 (600)
+T 3l76_A          185 PRLVPEAQLMAEITCDEMLELASLGAKVLHPRAVEIARNYGIPLVVRSSWSD-EPGTKVVAPPVQNRSLVGLEIAKAVDG  263 (600)
+T ss_dssp             TTTCTTCCBCSEEEHHHHHHTGGGGTTTCCHHHHHHHHHHTCCEEEEETTCC-SCCEEEECCCCCSCCCCCCBSSCSCCE
+T ss_pred             CCcCCcceEcceecHHHHHHHHhCCCCccCHHHHHHHHHcCCcEEEEECCCC-CCCceeeccccccccchhhccccccce
+Confidence            9999999999999999999999999999999999999999999999999984 589998765431        1346788
+
+
+Q gi|556503834|r  309 ISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSE---YSISFCVPQSDCVRAE---RAMQEEFYLEL  382 (820)
+Q Consensus       309 isnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssse---ysisfcvpqsdcvrae---ramqeefylel  382 (820)
+                      |+.-.+..++...+  |.+..|+.+++|..+.++.|+|.+|+||.++   ++++|++++.+--+++   .++++++..++
+T Consensus       264 i~~~~~~~~v~~~~--~~~~~~~~~~i~~~l~~~~i~v~~i~~s~~~~~~~~i~~~i~~~~~~~~~~~~~~l~~~~~~~~  341 (600)
+T 3l76_A          264 VEYDADQAKVALLR--VPDRPGVASKLFRDIAQQQVDIDLIIQSIHDGNSNDIAFTVVKDLLNTAEAVTSAIAPALRSYP  341 (600)
+T ss_dssp             EEEECCCEEEEEEE--EECSTTHHHHHHHHHHHTTCCCCCEEBCCCBTTEEEEEEEECGGGHHHHHHHHHHHGGGGSSST
+T ss_pred             EEeecCccEEEEEe--cCCCccHHHHHHHHHHHcCCcEEEEEeccccCCcccEEEEEeHHHHHHHHHHHHHHHHHHHhhh
+Confidence            99889999998885  7777789999999999999999999998776   8999999977654444   44566666555
+
+
+Q gi|556503834|r  383 KEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLF  460 (820)
+Q Consensus       383 keglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlf  460 (820)
+                      +...+......+.+++|+++|.+|..-.++.+++|.+|.+.+|++..+.+  ++.+++++++.+|...-++..|+.++
+T Consensus       342 ~~~~~~~i~~~~~~alIsi~g~~~~~~~~~~~~i~~~L~~~~i~i~~i~~--s~~sis~~v~~~~~~~a~~~l~~~~~  417 (600)
+T 3l76_A          342 EADQEAEIIVEKGIAKIAIAGAGMIGRPGIAAKMFKTLADVGVNIEMIST--SEVKVSCVIDQRDADRAIAALSNAFG  417 (600)
+T ss_dssp             TCSSSSEEEEECSEEEEEEECGGGTTCTTHHHHHHHHHHHTTCCCCEEEE--CSSEEEEEEEGGGHHHHHHHHHHHTT
+T ss_pred             hhcCcceeEEeCCeeEEEEECCccccCcchHHHHHHHHHhCCCCEEEEec--CCCeEEEEEehhHHHHHHHHHHHHHh
+Confidence            55556777888999999999999988889999999999999999988874  78899999999888777888887554
+
+
+No 10
+>3c8m_A Homoserine dehydrogenase; structural genomics, APC89447, PS protein structure initiative, midwest center for structural genomics; HET: MSE; 1.90A {Thermoplasma volcanium GSS1} PDB: 3jsa_A*
+Probab=100.00  E-value=2.1e-36  Score=274.68  Aligned_cols=316  Identities=22%  Similarity=0.329  Sum_probs=258.5  Template_Neff=9.500
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEP---FNLGRLIR  539 (820)
+Q Consensus       463 dqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakep---fnlgrlir  539 (820)
+                      ...+.|.+||.|.+|..++++|.++.. .+..+.++++++|.++..-..+ .++++..|.+.......+   .-...+-.
+T Consensus         4 ~~~i~v~iiG~G~vG~~~~~~l~~~~~-~~~~~~~~~vv~v~d~~~~~~~-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   81 (331)
+T 3c8m_A            4 MKTINLSIFGLGNVGLNLLRIIRSFNE-ENRLGLKFNVVFVADSLHSYYN-ERIDIGKVISYKEKGSLDSLEYESISASE   81 (331)
+T ss_dssp             CEEEEEEEECCSHHHHHHHHHHHHHHH-HCSSSEEEEEEEEECSSCEEEC-TTCCHHHHHHHHHTTCGGGCCSEECCHHH
+T ss_pred             CcEEEEEEEecCHHHHHHHHHHHhChH-HHhcCCcEEEEEEEECchhhcc-CCCCHHHHHhhhhccccccccccccCHHH
+Confidence            456788999999999999999987654 2456778999999887644332 356666666543322110   00011111
+
+
+Q gi|556503834|r  540 LVKEYHLLNPVIVDCTSSQA----VADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPV  615 (820)
+Q Consensus       540 lvkeyhllnpvivdctssqa----vadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpv  615 (820)
+                      +++   .-..++++||++..    ..+.+...++.|.|||+.|||..   .+.|.+|.-++++...+|+|...++.|+|+
+T Consensus        82 ~l~---~~~Dvvv~~t~~~~~~~~~~~~~~~~l~~G~~Vv~~nk~~~---~~~~~~l~~~a~~~g~~~~~~a~~~~g~p~  155 (331)
+T 3c8m_A           82 ALA---RDFDIVVDATPASADGKKELAFYKETFENGKDVVTANKSGL---ANFWPEIMEYARSNNRRIRYEATVAGGVPL  155 (331)
+T ss_dssp             HHH---SSCSEEEECSCCCSSSHHHHHHHHHHHHTTCEEEECCCHHH---HHHHHHHHHHHHHHTCCEECGGGSSTTSCC
+T ss_pred             HhC---CCCCEEEECCCCcccchHHHHHHHHHHHCCCeEEcCCcHHH---HHHHHHHHHHHHHcCCeEEEeecccccccH
+Confidence            221   23568999999986    77899999999999999999988   677888888888888899999999999999
+
+
+Q gi|556503834|r  616 IENLQNLLNAGDELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARET-GREL  694 (820)
+Q Consensus       616 ienlqnllnagdelmkfsgilsgslsyifgkldegmsfseattlaremgytepdprddlsgmdvarkllilaret-grel  694 (820)
+                      +..|++++. |+++.++.++++|..+||+.+..+|.+|+|+...|+++||+|+||++|++|.|.++|+.|+|++. |..+
+T Consensus       156 ~~~l~~~l~-~~~i~~i~~~~~g~~~~il~~~~~~~~~~~a~~~a~~~G~~e~d~~~dl~g~d~a~kl~ila~~~~g~~~  234 (331)
+T 3c8m_A          156 FSFIDYSVL-PSRIKKFRGIVSLTINYFIRELANKREFDDVLSEATKLGIVEKNYKDDLTGLDAARKSVILCNHLYGSSY  234 (331)
+T ss_dssp             HHHHHHHST-TCCCCEEEEECCHHHHHHHHHHHTTCCHHHHHHHHHHHTSSCSSCHHHHTTHHHHHHHHHHHHHHHCCCC
+T ss_pred             HHHHHHhhc-CCceEEEEEEEcCcHHHHHhhhhcCCCHHHHHHHHHHcCCCCCCcccCccChhHHHHHHHHHHhhcCCcc
+Confidence            999999887 89999999999999999999999999999999999999999999999999999999999999999 9999
+
+
+Q gi|556503834|r  695 ELADIEIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDGVCRVKIAEVDGNDPLFKVKNG  774 (820)
+Q Consensus       695 eladieiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedgvcrvkiaevdgndplfkvkng  774 (820)
+                      ++.|++++++.+.                  |..+..++       +.+||++..+..-..+|++..++.++|+..++..
+T Consensus       235 ~~~~v~~~~i~~~------------------d~~~~~~i-------~~~~~~~~~~~~~~~~v~~~~~~~~~~~~~~~~~  289 (331)
+T 3c8m_A          235 RLSDVFYEGILDQ------------------DRSFGKNE-------RLVTETGIVNGKPSAESRIKSLDSNDYLLTLGKG  289 (331)
+T ss_dssp             CGGGSEECCCC-C------------------CCCCCTTE-------EEEEEEEEETTEEEEEEEEEECCTTCGGGGSCTT
+T ss_pred             ChhhceecCChHH------------------HHHhCcce-------eeEEEEEEecCCeeEEEEEEEeCCCChhhhccCC
+Confidence            9999988775521                  11122222       5889998877666788898999999999999999
+
+
+Q gi|556503834|r  775 ENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       775 enalafyshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      +|+..|+...|  .|+++.|-|+|...||++++.|+++.+
+T Consensus       290 ~~~~~i~~~~~--~~~~~~g~~~g~~~Ta~~v~~dl~~~~  327 (331)
+T 3c8m_A          290 SLGYQLQTDTN--GTLNVSDLYDGPYETAGAVMNDLVILS  327 (331)
+T ss_dssp             CCEEEEECSSS--CEEEEECSSCCHHHHHHHHHHHHHHHH
+T ss_pred             ceEEEEECCcc--ccEEEEcCCCCHHHHHHHHHHHHHHHH
+Confidence            99999998877  578999999999999999999999765
+
+
+No 11
+>3ing_A Homoserine dehydrogenase; NP_394635.1, structural genomics, center for structural genomics, JCSG, protein structure INI PSI-2; HET: NDP; 1.95A {Thermoplasma acidophilum}
+Probab=99.93  E-value=1.1e-31  Score=244.11  Aligned_cols=306  Identities=23%  Similarity=0.376  Sum_probs=250.2  Template_Neff=9.400
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKE----P-FNLGRLI  538 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqake----p-fnlgrli  538 (820)
+                      ..+.|.+||.|.+|..+++++.++..-  .++.+++++||.++..-..+ .|.+.+.|.+.+.+...    . .++..++
+T Consensus         3 ~~~~V~iiG~G~vG~~~~~~l~~~~~~--~~~~~~~vv~v~d~~~~~~~-~g~~~~~l~~~~~~~~~~~~~~~~~~~~ll   79 (325)
+T 3ing_A            3 KEIRIILMGTGNVGLNVLRIIDASNRR--RSAFSIKVVGVSDSRSYASG-RNLDISSIISNKEKTGRISDRAFSGPEDLM   79 (325)
+T ss_dssp             CEEEEEEECCSHHHHHHHHHHHHHHHH--C--CEEEEEEEECSSBEEEC-SSCCHHHHHHHHHHHSCSCSSBCCSGGGGT
+T ss_pred             cEEEEEEEecCHHHHHHHHHHHhChhh--hcCCCEEEEEEEeccccccc-cCCCHHHHHHHhhhcccccccccCCHHHHh
+Confidence            356788999999999999999876543  45678899999887655433 47777777665543211    1 1222222
+
+
+Q gi|556503834|r  539 RLVKEYHLLNPVIVDCTSSQA----VADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       539 rlvkeyhllnpvivdctssqa----vadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                         .   .-..++++||.+..    ..+.+...++.|.|||+.|+|...   ..+.+|..++++...+|+|...++.|+|
+T Consensus        80 ---~---~~~DvVv~~t~~~~~~~~~~~~~~~al~~G~~Vv~~nekp~~---~~~~~l~~~a~~~g~~~~~~~~~~~g~p  150 (325)
+T 3ing_A           80 ---G---EAADLLVDCTPASRDGVREYSLYRMAFESGMNVVTANKSGLA---NKWHDIMDSANQNSKYIRYEATVAGGVP  150 (325)
+T ss_dssp             ---T---SCCSEEEECCCCCSSSHHHHHHHHHHHHTTCEEEECCCHHHH---HHHHHHHHHHHHHTCCEECGGGSSTTSC
+T ss_pred             ---C---CCCCEEEECCCCCccchHHHHHHHHHHHCcCeEEecCcHHHH---HHHHHHHHHHHHcCCeEEEecccccccc
+Confidence               1   13578999999987    889999999999999999988775   3788888889888888999999999999
+
+
+Q gi|556503834|r  615 VIENLQNLLNAGDELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILAR-ETGRE  693 (820)
+Q Consensus       615 vienlqnllnagdelmkfsgilsgslsyifgkldegmsfseattlaremgytepdprddlsgmdvarkllilar-etgre  693 (820)
+                      ++..+++++.. +++-++.+++++..+|++.++.+|.+|+|+...|+++||+|+||++|++|.|.++|+.++|+ .+|-+
+T Consensus       151 ~~~~l~~~l~~-~~I~~i~~~~~~~~~~i~~~~~~~~~~~~~~~~a~~~G~~e~~~~~dl~g~d~a~kl~ila~~~~g~~  229 (325)
+T 3ing_A          151 LFSVLDYSILP-SKVKRFRGIVSSTINYVIRNMANGRSLRDVVDDAIKKGIAESNPQDDLNGLDAARKSVILVNHIFGTE  229 (325)
+T ss_dssp             CHHHHHHTCTT-CCEEEEEEECCHHHHHHHHHHHTTCCHHHHHHHHHHHTCSCSSTHHHHTTHHHHHHHHHHHHHHHCCC
+T ss_pred             hHHHHHHHhcc-CceeEEEEEEcCchHHHHHhhhcCCCHHHHHHHHHHcCCCCCCccccccChhHHHHHHHHHHHHcCCC
+Confidence            99999999965 89999999999999999999999999999999999999999999999999999999999999 69999
+
+
+Q gi|556503834|r  694 LELADIEIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDG---VCRVKIAEVDGNDPLFK  770 (820)
+Q Consensus       694 leladieiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedg---vcrvkiaevdgndplfk  770 (820)
+                      +++.||+++.+.|...                              |..+||++...-||   +++|+...++.++|+..
+T Consensus       230 ~~~~~i~~~~~~~~~~------------------------------g~~~r~~~~~~~~~~~~~~~v~~~~~~~~~~~~~  279 (325)
+T 3ing_A          230 YTLNDVEYSGVDERSY------------------------------NANDRLVTEVYVDDRRPVAVSRIISLNKDDFLMS  279 (325)
+T ss_dssp             CCGGGSBCCCCCSSCC------------------------------CTTEEEEEEEEEETTEEEEEEEEEECCTTCGGGG
+T ss_pred             CCcccccccCccccch------------------------------hhhhcEEEEEEecCCceEEEEeeeEeCCCChhhh
+Confidence            9999998777766531                              23356666665544   67788778888899998
+
+
+Q gi|556503834|r  771 VKNGENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       771 vkngenalafyshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      ++..+|++.++...+.  ++++.|.++|-+.||++++.|+++-.
+T Consensus       280 ~~~~~~~v~i~~~~~~--~~~~~~~~~g~~~tA~~~~~di~~~~  321 (325)
+T 3ing_A          280 IGMDGLGYQIETDSNG--TVNVSDIYDGPYETAGAVVNDILLLS  321 (325)
+T ss_dssp             SCTTCCEEEEEESSSC--EEEEECSCCCHHHHHHHHHHHHHHHH
+T ss_pred             ccCCceEEEEEecccC--cEEEEECCCCHHHHHHHHHHHHHHHH
+Confidence            8888999999998876  47888999999999999999987643
+
+
+No 12
+>3mtj_A Homoserine dehydrogenase; rossmann-fold, PSI, MCSG, structural genomics, midwest cente structural genomics; 2.15A {Thiobacillus denitrificans}
+Probab=99.93  E-value=6.5e-31  Score=254.37  Aligned_cols=312  Identities=25%  Similarity=0.386  Sum_probs=247.8  Template_Neff=8.500
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNK-HIDLRVCGVANSKA--LLTNVHGLNLENWQEELAQAKEPFNLG  535 (820)
+Q Consensus       459 lfntdqvievfvigvggvggalleqlkrqqswlknk-hidlrvcgvanska--lltnvhglnlenwqeelaqakepfnlg  535 (820)
+                      ++.....+.|.+||.|.+|..+++.|+++...++.+ +.++++++|.....  ......+..+.+            ++.
+T Consensus         4 ~~~~~~~~~I~IiG~G~vG~~~~~~l~~~~~~l~~~~~~~~~i~~v~~~~~~~~~~~~~~~~~~~------------d~~   71 (444)
+T 3mtj_A            4 YFQGMKPIHVGLLGLGTVGGGTLTVLRRNAEEITRRAGREIRVVRAAVRNLDKAEALAGGLPLTT------------NPF   71 (444)
+T ss_dssp             -CCSCSCEEEEEECCHHHHHHHHHHHHHTHHHHHHHHSSCEEEEEEECSCHHHHHHHHTTCCEES------------CTH
+T ss_pred             cccCCCeeeEEEEecCHHHHHHHHHHHhhHHHHHHhcCCcEEEEEEEEeCcHHhhhcccCCCCcC------------CHH
+Confidence            345566788999999999999999998877666543 35788877764321  111001111100            111
+
+
+Q gi|556503834|r  536 RLIRLVKEYHLLNPVIVDCTSS-QAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       536 rlirlvkeyhllnpvivdctss-qavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                         .++..  .---++++||.+ ....+.+...|+.|.||++.||..   ...++.+|..++++...+++|...++.+.|
+T Consensus        72 ---~ll~~--~~~DiVvi~t~~~~~~~~~i~~aL~~Gk~Vv~enk~~---~~~~~~eL~~~a~~~g~~~~~ea~v~~~~P  143 (444)
+T 3mtj_A           72 ---DVVDD--PEIDIVVELIGGLEPARELVMQAIANGKHVVTANKHL---VAKYGNEIFAAAQAKGVMVTFEAAVAGGIP  143 (444)
+T ss_dssp             ---HHHTC--TTCCEEEECCCSSTTHHHHHHHHHHTTCEEEECCHHH---HHHHHHHHHHHHHHHTCCEECGGGSSTTSC
+T ss_pred             ---HHhcC--CCCCEEEECCCCcHHHHHHHHHHHHCCCEEEecCCHH---HHhhHHHHHHHHHHcCCEEEEeeeccccCh
+Confidence               11111  112378899998 467788889999999999999875   347888898889888889999999999999
+
+
+Q gi|556503834|r  615 VIENLQNLLNAGDELMKFSGILSGSLSYIFGKLDE-GMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILAR-ETGR  692 (820)
+Q Consensus       615 vienlqnllnagdelmkfsgilsgslsyifgklde-gmsfseattlaremgytepdprddlsgmdvarkllilar-etgr  692 (820)
+                      ++..|++++. ++++-+..|+++|..+||+.++.+ |.+|+++...|+++||+|+||++|++|+|.++|+.+||+ ..|.
+T Consensus       144 ~i~~l~~~l~-~~~Ig~I~~i~~gt~nyil~~~~~~g~~~~~~l~~A~~~G~ae~dp~~d~~G~D~a~kl~iLa~~~fg~  222 (444)
+T 3mtj_A          144 IIKALREGLT-ANRIEWLAGIINGTSNFILSEMRDKGAAFDDVLKEAQRLGYAEADPTFDIEGIDAAHKLTILSAIAFGI  222 (444)
+T ss_dssp             HHHHHHTTTT-TSCEEEEEEECCHHHHHHHHHHHHHCCCHHHHHHHHHHHTSSCSSCHHHHTSHHHHHHHHHHHHHHHTC
+T ss_pred             HHHHHHHHhh-ccccceEEEEEecccchhHHHhccCCCCHHHHHHHHHHcCCCCCCcccCCcCHHHHHHHHHHHHHhcCC
+Confidence            9999999986 588999999999999999999876 999999999999999999999999999999999999999 7898
+
+
+Q gi|556503834|r  693 ELELADIEIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDG---VCRVKIAEVDGNDPLF  769 (820)
+Q Consensus       693 eleladieiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedg---vcrvkiaevdgndplf  769 (820)
+                      .+++.++.++.+-               +++      ...+..+...|.++||++....+|   .++|....++.++|+.
+T Consensus       223 ~~~~~~i~~~gi~---------------~i~------~~di~~a~~~G~~ik~~a~~~~~~~~~~~~v~p~~v~~~~~l~  281 (444)
+T 3mtj_A          223 PMQFERAYTEGIS---------------QLT------REDVRYAEELGYRIKLLGIARRAENGIELRVHPTLIPERRLIA  281 (444)
+T ss_dssp             CCCGGGCEECCST---------------TCC------HHHHHHHHHTTEEEEEEEEEEECSSSEEEEEEEEEEETTSTGG
+T ss_pred             ccCHHHhhhhhhh---------------cCC------HHHHHHHHHCCCEEEEEEEEEecCCcEEEEEEEEEeCCCChhh
+Confidence            8877777664421               121      122345788999999999987643   7899999999999999
+
+
+Q gi|556503834|r  770 KVKNGENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       770 kvkngenalafyshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      .+++.+|+..++..++  .++++.|-|||...||++|+.|++.-.
+T Consensus       282 ~v~~~~n~v~i~g~~~--~~~~~~g~gaG~~~Ta~av~~di~~i~  324 (444)
+T 3mtj_A          282 NVDGAMNAVLVKGDAV--GPTLYYGAGAGSEPTASAVVADLVDVT  324 (444)
+T ss_dssp             GCCTTEEEEEEEETTT--EEEEEEEECSSHHHHHHHHHHHHHHHH
+T ss_pred             cCCCcceEEEEEcccc--CccEEEcCCCChHHhHHHHHHHHHHHH
+Confidence            9999999999999876  588899999999999999999998643
+
+
+No 13
+>4ydr_A Homoserine dehydrogenase; oxidized form, oxidoreductase; 1.60A {Sulfolobus tokodaii} PDB: 5avo_A
+Probab=99.90  E-value=8.1e-29  Score=220.53  Aligned_cols=293  Identities=26%  Similarity=0.450  Sum_probs=239.3  Template_Neff=9.800
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEYHL  546 (820)
+Q Consensus       467 evfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkeyhl  546 (820)
+                      .|.+||.|.+|..+++.|.+..+-   ++.+++++||.+...-..+.    .+.|...     -.-++   -.++++  .
+T Consensus         2 ~v~iiG~G~vG~~~~~~l~~~~~~---~~~~~~vv~v~d~~~~~~~~----~~~~~~~-----~~~~~---~~~l~~--~   64 (304)
+T 4ydr_A            2 KLLLFGYGNVGKAFRKLLHEKRSP---ELNDVIIGGIVTRRGIMLQD----KEDFTPD-----LEGDV---FKAFEK--I   64 (304)
+T ss_dssp             EEEEECCSHHHHHHHHHHHTTCCG---GGTTCEEEEEEETTEEECSC----CSSCCCS-----BCCCH---HHHHHH--H
+T ss_pred             EEEEEecCHHHHHHHHHHHhchhh---cCCCeEEEEEEeCChhhcCc----cccCCcc-----cccCH---HHHHhc--C
+Confidence            467899999999999998865432   35677888886643221110    0111100     00011   112211  2
+
+
+Q gi|556503834|r  547 LNPVIVDCTSS-----QAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQN  621 (820)
+Q Consensus       547 lnpvivdctss-----qavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqn  621 (820)
+                      -.-++++||++     ....+.+...++.|.||++.|+|....   .+.++..++++...+++|+..++.++|.+..++.
+T Consensus        65 ~~Dvvv~~t~~~~~~~~~~~~~~~~~l~~G~~Vi~~~e~p~~~---~~~~l~~~a~~~g~~~~~~~~~~~~~p~~~~~~~  141 (304)
+T 4ydr_A           65 KPDIIVDVSSANYNNGEPSLSLYKEAIKDGVNIITTNKAPLAL---AFNEIFSLARSKGVKIGFQGTVMSGTPSINLYRV  141 (304)
+T ss_dssp             CCSEEEECSCCCTTTCTTHHHHHHHHHHTTCEEEECCHHHHHH---HHHHHHHHHHHHTCCEECGGGSSTTSCSHHHHHT
+T ss_pred             CCCEEEECCCCccccchHHHHHHHHHHHCCCEEEecCchhhcc---cHHHHHHHHHHcCCeEEEcccccccccHHHHHHH
+Confidence            34678999998     788888999999999999999777655   3778888888877789999999999999998887
+
+
+Q gi|556503834|r  622 LLNAGDELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILAR-ETGRELELADIE  700 (820)
+Q Consensus       622 llnagdelmkfsgilsgslsyifgkldegmsfseattlaremgytepdprddlsgmdvarkllilar-etgreleladie  700 (820)
+                      +  .++++.++.++.++...|++.++..+.+|+|+...|+++|++++||++|++|+|.++|+.++|+ ..|-.+++.+++
+T Consensus       142 ~--~~~~i~~i~~~~~~~~~~i~~~~~~~~~~~e~~~~a~~~G~~~~~~~~~~~g~d~~~kl~ila~~~~g~~~~~~~i~  219 (304)
+T 4ydr_A          142 L--PGSRVIKIRGILNGTTNFILTLMNKGVSFEEALKEAQRRGYAEEDPTLDINGFDAAAKITILANFMIGNSVTIKDVK  219 (304)
+T ss_dssp             S--TTCCEEEEEEECCHHHHHHHHHHTTTCCHHHHHHHHHHTTSSCSSCGGGSSSHHHHHHHHHHHHHHTCCCCCGGGCE
+T ss_pred             h--cCCCeEEEEEEECCCCccchhhhcCCCCHHHHHHHHHHcCCCCCCchhcccChHHHHHHHHHHHHHcCCCcChhhcc
+Confidence            5  6789999999999999999999998999999999999999999999999999999999999999 699999999999
+
+
+Q gi|556503834|r  701 IEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDGVCRVKIAEVDGNDPLFKVKNGENALAF  780 (820)
+Q Consensus       701 iepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedgvcrvkiaevdgndplfkvkngenalaf  780 (820)
+                      +|++.+.+                             ..|+.+||+|.++. ...+|++..++.++|++.++..+|+..+
+T Consensus       220 ~~~~~~~~-----------------------------~~g~~~~~~~~~~~-~~~~v~~~~~~~~~p~~~~~~~~~~~~i  269 (304)
+T 4ydr_A          220 FEGINRDL-----------------------------PKNEKIKLIAYADE-KEVWVKPLPISQDDPLYNVDGVENALEI  269 (304)
+T ss_dssp             ECCCCTTS-----------------------------CSSSCEEEEEEEES-SCEEEEEEECCTTSTTTTCCTTEEEEEE
+T ss_pred             cccccchh-----------------------------cCCceEEEEEEEec-eeEEEEEEEECCCCccccCCCCceEEEE
+Confidence            88888764                             16899999999987 7999999999999999999999999999
+
+
+Q gi|556503834|r  781 YSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       781 yshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      +.. +  .++.+.|-++|...||++++.|++.-.
+T Consensus       270 ~~~-~--~~~~~~~~~~g~~~ta~~~~~di~~~~  300 (304)
+T 4ydr_A          270 TTD-I--QSILIRGPGAGPVNAAYGALSDLILLK  300 (304)
+T ss_dssp             EES-S--CEEEEEEECCCHHHHHHHHHHHHHHHH
+T ss_pred             Eec-C--CcEEEEeCCCChHHHHHHHHHHHHHHH
+Confidence            998 4  789999999999999999999998643
+
+
+No 14
+>2ejw_A HDH, homoserine dehydrogenase; NAD-dependent, oxidoreductase; 1.70A {Thermus thermophilus}
+Probab=99.89  E-value=2.5e-28  Score=225.28  Aligned_cols=299  Identities=29%  Similarity=0.412  Sum_probs=236.2  Template_Neff=9.000
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      .+.|.+||.|.+|..+++.|.++..-+.+.+.++++++|.+...-.       .+.|.++.      ++.. .     .-
+T Consensus         3 ~~~V~iiG~G~~G~~~~~~l~~~~~~~~~~~~~~~vv~v~d~~~~~-------~~~~~~~~------~~~~-~-----~~   63 (332)
+T 2ejw_A            3 ALKIALLGGGTVGSAFYNLVLERAEELSAFGVVPRFLGVLVRDPRK-------PRAIPQEL------LRAE-P-----FD   63 (332)
+T ss_dssp             EEEEEEECCSHHHHHHHHHHHHTGGGGGGGTEEEEEEEEECSCTTS-------CCSSCGGG------EESS-C-----CC
+T ss_pred             eEEEEEEeCCHHHHHHHHHHHhChHHHHhcCCcEEEEEEEECChHH-------hHHHHHHh------hcCC-h-----hh
+Confidence            3568899999999999999987654455678889999987654311       11121111      1100 0     00
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSS-QAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLL  623 (820)
+Q Consensus       545 hllnpvivdctss-qavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnll  623 (820)
+                      ..-..++++||.+ ....+.+...|+.|.||++.|+|....+   +.+|..++++  ..++|.+.++.++|+++.++.++
+T Consensus        64 ~~~~DvVv~~t~~~~~~~~~~~~al~~G~~Vv~~nekp~~~~---~~~l~~~a~~--~~~~~~~~~~~~~p~~~~l~~l~  138 (332)
+T 2ejw_A           64 LLEADLVVEAMGGVEAPLRLVLPALEAGIPLITANKALLAEA---WESLRPFAEE--GLIYHEASVMAGTPALSFLETLR  138 (332)
+T ss_dssp             CTTCSEEEECCCCSHHHHHHHHHHHHTTCCEEECCHHHHHHS---HHHHHHHHHT--TCEECGGGTTTTSSSHHHHHHHT
+T ss_pred             cCCCCEEEECCCChHHHHHHHHHHHHCCCEEEEecCccccch---HHHHHHHHHh--CCeEEEeeccCCcchhhhHHHhh
+Confidence            1234588999998 8788889999999999999998887765   6677777765  36799999999999999999888
+
+
+Q gi|556503834|r  624 NAGDELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARETG-RELELADIEIE  702 (820)
+Q Consensus       624 nagdelmkfsgilsgslsyifgkldegmsfseattlaremgytepdprddlsgmdvarkllilaretg-releladieie  702 (820)
+                        ++++.++.++.++...|++.++..+.+|+|+...|+++||++++|.+|++|.|+++|+.++|++.| ..+++.+++.+
+T Consensus       139 --~~~I~~i~~~~~~~~~~i~~~~~~~~~~~eal~~a~~~G~~~~~~~~~l~g~d~a~kl~ila~~lg~~~~~~~~v~~~  216 (332)
+T 2ejw_A          139 --GSELLELHGILNGTTLYILQEMEKGRTYAEALLEAQRLGYAEADPTLDVEGIDAAHKLTLLARLLVDPGFPFAEVEAQ  216 (332)
+T ss_dssp             --TSEEEEEEEECCHHHHHHHHHHHTTCCHHHHHHHHHHTTSSCSSCHHHHTTHHHHHHHHHHHHHHTCTTCCGGGCEEC
+T ss_pred             --cCcceEEEEEEecccchhhHhhhcCCCHHHHHHHHHHcCCCccCcccccccchHHHHHhHhhhhhcCCCCCHhHCcee
+Confidence              679999999999999999999999999999999999999999999999999999999999999998 33444455432
+
+
+Q gi|556503834|r  703 PVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDG---VCRVKIAEVDGNDPLFKVKNGENALA  779 (820)
+Q Consensus       703 pvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnidedg---vcrvkiaevdgndplfkvkngenala  779 (820)
+                      .+-+                     +....+..+...|+++||++.+..+|   ..+|++..++.++|++.++ | |++.
+T Consensus       217 ~~~~---------------------~~~~~~~~~~~~G~v~r~~~~~~~~~~~~~~~v~~~~v~~~~~~~~~~-~-~~v~  273 (332)
+T 2ejw_A          217 GIAR---------------------LTPEVLQKAEARGERVRLVASLFGEGGRWRAAVAPRRLPQDHPLARAR-G-NALW  273 (332)
+T ss_dssp             CSTT---------------------CCHHHHHHHHHTTEEEEEEEEEEEETTEEEEEEEEEEEETTSHHHHCS-S-EEEE
+T ss_pred             cchh---------------------hhHHHHHHHHHCCCeEEEEEEEEecCCcEEEEEEEEEeCCCCcccccc-c-ceEE
+Confidence            2211                     11233444778899999999998766   6889999999999999987 3 8888
+
+
+Q gi|556503834|r  780 FYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       780 fyshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      ++.+.+  .++++.|-|+|...||++++.|++...
+T Consensus       274 i~~~~~--~~~~~~g~~~g~~~Ta~~v~~di~~v~  306 (332)
+T 2ejw_A          274 VRARPL--GEAFVTGPGAGGGATASGLFADLLRFL  306 (332)
+T ss_dssp             EEEETT--EEEEEEECCSSHHHHHHHHHHHHHHHH
+T ss_pred             EEeccC--CcEEEEeCCCChHHHHHHHHHHHHHHH
+Confidence            888775  567899999999999999999998754
+
+
+No 15
+>4pg7_A HDH, homoserine dehydrogenase; aspartic acid pathway, PH sensitivity, hydride transfer, ACT oxidoreductase; HET: LYS GOL; 2.10A {Staphylococcus aureus M1064} PDB: 4pg5_A 4pg6_A 4pg4_A* 4pg8_A
+Probab=99.89  E-value=3.6e-28  Score=242.88  Aligned_cols=315  Identities=22%  Similarity=0.369  Sum_probs=241.3  Template_Neff=7.300
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKN-KHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRL  537 (820)
+Q Consensus       459 lfntdqvievfvigvggvggalleqlkrqqswlkn-khidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrl  537 (820)
+                      .......+.|.+||.|.+|..+++.|.+++.-+++ ++.++++.||.+...-...  .+....+       +-..++..+
+T Consensus        17 ~~~~~~~irVgIIG~G~vG~~~~~~L~~~~~~l~~~~~~~~~lv~V~d~~~~~~~--~~~~~g~-------~~~~d~~el   87 (468)
+T 4pg7_A           17 RGSHMKKLNIALLGLGTVGSGVVKIIEENRQQIQDTLNKDIVIKHILVRDKSKKR--PLNISQY-------HLTEDVNEI   87 (468)
+T ss_dssp             ---CCEEEEEEEECCSHHHHHHHHHHHHHHHHHHHHHCEEEEEEEEECSCSSSCC--CTTGGGS-------CEESCHHHH
+T ss_pred             cccCCCCCEEEEEecCHHHHHHHHHHHhCchhhhhccCCCeEEEEEEECCHHHHh--hccccCC-------eeeCCHHHH
+Confidence            34456678899999999999999999877665554 3457788887665432111  1111110       000111121
+
+
+Q gi|556503834|r  538 IRLVKEYHLLNPVIVDCTSS-QAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVI  616 (820)
+Q Consensus       538 irlvkeyhllnpvivdctss-qavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvi  616 (820)
+                         +..  .-..++++||.+ +...+.+...|+.|.||++.|||....   .+.+|.-++++....|+|+.++..|+|.+
+T Consensus        88 ---L~~--~~~DvVViatp~~~~h~e~i~~aL~~GkhVV~ankkpla~---~~~eL~~la~~~g~~l~~~a~v~~g~P~i  159 (468)
+T 4pg7_A           88 ---LND--DSLDIIVEVMGGIEPTVDWLRTALKNKKHVITANKDLLAV---HLKLLEDLAEENGVALKFEASVAGGIPIV  159 (468)
+T ss_dssp             ---HTC--TTCCEEEECCCCSTTHHHHHHHHHHTTCEEEECCTTCCHH---HHHHHHHHHHHTTCCEECGGGSCCC-C--
+T ss_pred             ---hcC--CCCCEEEECCCCHHHHHHHHHHHHHCCCEEEeCCCcccch---HHHHHHHHHHHcCCceeeccccccchHHH
+Confidence               111  124688999998 578899999999999999999887665   47778888888888899999999999999
+
+
+Q gi|556503834|r  617 ENLQNLLNAGDELMKFSGILSGSLSYIFGKLDE-GMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARET-GREL  694 (820)
+Q Consensus       617 enlqnllnagdelmkfsgilsgslsyifgklde-gmsfseattlaremgytepdprddlsgmdvarkllilaret-grel  694 (820)
+                      ..++++++. +++.++.++++|..+|++.++.. |.+|+|+...|+++||+++||++|++|+|+++|+.++|+.. |..+
+T Consensus       160 ~~l~~ll~~-g~I~~I~~v~sgt~n~il~~~~~~g~~~~eal~~A~~~G~~e~dp~~dl~G~D~a~Kl~ilA~~lfG~~i  238 (468)
+T 4pg7_A          160 NAINNGLNA-NNISKFMGILNGTSNFILSKMTKEQTTFEEALDEAKRLGFAEADPTDDVEGVDAARKVVITSYLSFNQVI  238 (468)
+T ss_dssp             ----------CCEEEEEEECCHHHHHHHHHHHHHTCCHHHHHHHHHHTTSSCSSCHHHHTSHHHHHHHHHHHHHHHSCCC
+T ss_pred             HHHHHHHhc-CCcceeeeEEeccchhhhhhhhccCCcHHHHHHHHHHcCCChhHhhhhhcchhHHHHHHHHHHhhcCCCC
+Confidence            999999987 78999999999999999999976 58999999999999999999999999999999999999999 9999
+
+
+Q gi|556503834|r  695 ELADIEIEPVLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDED---GVCRVKIAEVDGNDPLFKV  771 (820)
+Q Consensus       695 eladieiepvlpaefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnided---gvcrvkiaevdgndplfkv  771 (820)
+                      ++.||+.+.+-|....                     .+.+++..|+++||++.+.-+   ..++|++..++.++|+..+
+T Consensus       239 ~l~di~~~~i~~~~~~---------------------~i~~a~~~G~~~r~va~~~~~~~~~~~~V~~~~v~~~~pl~~~  297 (468)
+T 4pg7_A          239 KLNDVKRRGISGVTLT---------------------DINVADQLGYKIKLIGKGIYENGKVNASVEPTLIDKKHQLAAV  297 (468)
+T ss_dssp             CGGGSEECCSTTCCHH---------------------HHHHHHHHTEEEEEEEEEEEETTEEEEEEEEEEEETTSGGGGC
+T ss_pred             CccccceeeEEEehhc---------------------chHHHHHcCCEEEEEEEEEecCCeEEEEEEEEEEeCCCccccc
+Confidence            9999987666554322                     378889999999999996655   3578888899999999999
+
+
+Q gi|556503834|r  772 KNGENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTL  814 (820)
+Q Consensus       772 kngenalafyshyyqplplvlrgygagndvtaagvfadllrtl  814 (820)
+                      ++.+|++.++...+..+  ++.|-|+|...||++++.|++.-.
+T Consensus       298 ~~~~n~v~i~g~~~~~~--~i~g~gaG~~~TA~avv~dI~~v~  338 (468)
+T 4pg7_A          298 EDEYNAIYVIGDAVGDT--MFYGKGAGSLATGSAVVSDLLNVA  338 (468)
+T ss_dssp             CTTCEEEEEEESSSCCE--EEEECCCCHHHHHHHHHHHHHHHH
+T ss_pred             CCCceEEEEEccccCCe--EEECCCCcHHHHHHHHHHHHHHHH
+Confidence            99999999999888765  788999999999999999998754
+
+
+No 16
+>4go7_X Aspartokinase; transferase; 2.00A {Mycobacterium tuberculosis} PDB: 4go5_X
+Probab=99.57  E-value=4.3e-19  Score=154.46  Aligned_cols=175  Identities=23%  Similarity=0.358  Sum_probs=137.5  Template_Neff=8.800
+
+Q gi|556503834|r  297 ASRDEDELPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSE-----YSISFCVPQSDCVRAE  371 (820)
+Q Consensus       297 asrdedelpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssse-----ysisfcvpqsdcvrae  371 (820)
+                      -.|+.+.-++++|+-.+|++++++.+  +....+..+++|..+++.+|.+.+++++.++     .+++||+++.+-.++.
+T Consensus        17 ~~~~~~~~~v~~It~~~~~~li~i~~--~~~~~~~~~~i~~~l~~~~i~v~~i~~~~~~~~~~~~~i~~~l~~~~~~~~~   94 (200)
+T 4go7_X           17 RGNHMEDPILTGVAHDRSEAKVTIVG--LPDIPGYAAKVFRAVADADVNIDMVLQNVSKVEDGKTDITFTCSRDVGPAAV   94 (200)
+T ss_dssp             ---CCCSCEEEEEEEECSEEEEEEEE--EECSTTHHHHHHHHHHHTTCCCCCEECCCCC--CCEEEEEEEEEGGGHHHHH
+T ss_pred             cccccccCceEEEEEcCCEEEEEEec--CCCChhHHHHHHHHHHHcCCCEEEEEeCcccCCCCcceEEEEEeHHHHHHHH
+Confidence            34456677899999999999999986  6677799999999999999999999998765     7899999976544333
+
+
+Q gi|556503834|r  372 RAMQEEFYLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTG  451 (820)
+Q Consensus       372 ramqeefylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattg  451 (820)
+                      ...++ +..+++   .....+.+.+++|+++|++|+.-.++.+++|.+|++.+|||..+.  +++.+++++++.+|...-
+T Consensus        95 ~~L~~-~~~~~~---~~~i~~~~~~a~IsviG~~~~~~~~v~~~i~~~L~~~~I~i~~~~--~s~~~is~vv~~~~~~~a  168 (200)
+T 4go7_X           95 EKLDS-LRNEIG---FSQLLYDDHIGKVSLIGAGMRSHPGVTATFCEALAAVGVNIELIS--TSEIRISVLCRDTELDKA  168 (200)
+T ss_dssp             HHHHT-THHHHC---CSEEEEECCEEEEEEEEESCTTCHHHHHHHHHHHHHTTCCCCEEE--ECSSEEEEEEEGGGHHHH
+T ss_pred             HHHHH-HHHhcC---CceEEEeCCeEEEEEECCCcccCccHHHHHHHHHHHCCCeEEEEe--cCCCEEEEEEEhHHHHHH
+Confidence            32222 222222   245667789999999999999999999999999999999998877  788999999999999999
+
+
+Q gi|556503834|r  452 VRVTHQMLFNTDQVIEVFVIGVGGVGGA  479 (820)
+Q Consensus       452 vrvthqmlfntdqvievfvigvggvgga  479 (820)
+                      ++.-|+.+|...+.+.|+++|.|.||++
+T Consensus       169 v~~Lh~~~~~~~~~i~v~~~G~G~ig~~  196 (200)
+T 4go7_X          169 VVALHEAFGLGGDEEATVYAGTGRLEHH  196 (200)
+T ss_dssp             HHHHHHHHTC----CCEECC-C------
+T ss_pred             HHHHHHHHhccCCeEEEEEEecccccCc
+Confidence            9999999999999999999999999986
+
+
+No 17
+>4ndo_B Molybdenum storage protein subunit beta; rossmann fold, ATP binding, molybdenum B metal binding protein; HET: ATP 8M0; 1.35A {Azotobacter vinelandii} PDB: 2ogx_B* 4ndp_B* 4ndq_B* 4ndr_B* 4f6t_B*
+Probab=99.29  E-value=8.6e-16  Score=138.75  Aligned_cols=208  Identities=20%  Similarity=0.204  Sum_probs=132.2  Template_Neff=8.900
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAER--FLRVADILESNARQGQVATVLSAPAKITNHLVAMIEKTISGQDALPNISDAERIFAELLTGL   78 (820)
+Q Consensus         1 mrvlkfggtsvanaer--flrvadilesnarqgqvatvlsapakitnhlvamiektisgqdalpnisdaerifaelltgl   78 (820)
+                      |.|+||||+.+.+.++  +.++++.+....+ |.-.-+.++...+++.+....+                +         
+T Consensus        38 ~~ViKlGGs~i~~~~~~~~~~~~~~i~~~~~-~~~vVvV~Ggg~~~~~~~~~~~----------------~---------   91 (270)
+T 4ndo_B           38 ATVIKIGGQSVIDRGRAAVYPLVDEIVAARK-NHKLLIGTGAGTRARHLYSIAA----------------G---------   91 (270)
+T ss_dssp             EEEEEECTTTTGGGTHHHHHHHHHHHHHHTT-TCEEEEEECCCHHHHHHHHHHH----------------H---------
+T ss_pred             eEEEEecchhcCCCcHHHHHHHHHHHHHhcc-CCeEEEEeCCcHHHHHHHHHHh----------------h---------
+Confidence            5689999999998774  5466665554333 6666666777777766532100                0         
+
+
+Q gi|556503834|r   79 AAAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVG  158 (820)
+Q Consensus        79 aaaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvekllavg  158 (820)
+                            +                           .+++..-..+...++.++..++...|..+|.++..++|.+...   
+T Consensus        92 ------~---------------------------~~~~~~~~~~~~~~~~l~~~~i~~~L~~~gi~~~~l~~~~~~~---  135 (270)
+T 4ndo_B           92 ------L---------------------------GLPAGVLAQLGSSVADQNAAMLGQLLAKHGIPVVGGAGLSAVP---  135 (270)
+T ss_dssp             ------T---------------------------TCCHHHHHHHHHHHHHHHHHHHHHHHGGGTCCBCSCGGGCTTG---
+T ss_pred             ------c---------------------------CCCHHHHHHHHHHHHHHHHHHHHHHHHhcCCCeEEeccccccc---
+Confidence                  0                           0111111222234566665666777888888888888765431   
+
+
+Q gi|556503834|r  159 HYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPR  238 (820)
+Q Consensus       159 hylestvdiaestrriaasripadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdpr  238 (820)
+                       +  +.   ++..... ......-..+.+.++.....     +   .++|+.|+.||.++.|+.+.+||||||+|++||+
+T Consensus       136 -~--~~---~~~~~~~-~~~~~~~~~i~~~l~~g~ip-----~---~ssD~~A~~lA~~l~A~~li~ltDv~GVy~~dp~  200 (270)
+T 4ndo_B          136 -L--SL---AEVNAVV-FSGMPPYKLWMRPAAEGVIP-----P---YRTDAGCFLLAEQFGCKQMIFVKDEDGLYTANPK  200 (270)
+T ss_dssp             -G--GC---TTCCEEE-EECSCSCGGGCCCCSSSSSC-----S---SCHHHHHHHHHHHHTCSEEEEEESSSSEESSCTT
+T ss_pred             -h--hh---hhhccce-eeccCCCceEEEcccccCCC-----C---CCchHHHHHHHHHcCCCEEEEEeCCCceecCCCc
+Confidence             0  11   1100000 01101122233333322222     1   7899999999999999999999999999999999
+
+
+Q gi|556503834|r  239 QVPDARLLKSMSYQEAMELSYFG-----AKVLHPRTITPIAQFQIPCLIKNTGNPQ  289 (820)
+Q Consensus       239 qvpdarllksmsyqeamelsyfg-----akvlhprtitpiaqfqipclikntgnpq  289 (820)
+                      ..|++++++.++|+|+.++. ++     .+++++..   .++..+|+.|.|...|.
+T Consensus       201 ~~~~a~~I~~is~~e~~~~~-~~~~~~~~~~~~~~~---aa~~gi~v~I~ng~~~~  252 (270)
+T 4ndo_B          201 TSKDATFIPRISVDEMKAKG-LHDSILEFPVLDLLQ---SAQHVREVQVVNGLVPG  252 (270)
+T ss_dssp             TCTTCCEESEEEHHHHHHTT-CTTSSSCHHHHHHHH---HCSSCCEEEEEETTSTT
+T ss_pred             CCCcceeeeeCCHHHHHHhh-cccCCCCccchhHHH---HHHCCCcEEEECCCCcc
+Confidence            99999999999999998876 33     45555544   23678899999887764
+
+
+No 18
+>3ll9_A Isopentenyl phosphate kinase; mevalonate biosynthesis isoprenoid, transferase; HET: ADP; 2.15A {Methanothermobacter thermautotrophicusorganism_taxid}
+Probab=99.27  E-value=1.2e-15  Score=135.62  Aligned_cols=110  Identities=25%  Similarity=0.289  Sum_probs=88.1  Template_Neff=9.400
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSY-QEAMEL  257 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsy-qeamel  257 (820)
+                      +....++++.|+..-+++|+.. .++.++|+.|+.+|..++|+.+-+|||+||+|++||+..|++++++.++| +|+.++
+T Consensus       133 l~~g~ipVv~g~~~~~~~g~~~-~~~~~sD~~A~~lA~~l~A~~li~ltdv~Gv~~~dp~~~~~a~~i~~i~~~~e~~~~  211 (269)
+T 3ll9_A          133 LEEGMVPVVYGDVVLDSDRRLK-FSVISGDQLINHFSLRLMPERVILGTDVDGVYTRNPKKHPDARLLDVIGSLDDLESL  211 (269)
+T ss_dssp             HHTTCEEEEECEEEEBSCTTTS-EEEECHHHHHHHHHHHHCCSEEEEEESSSSCBSSCTTTCTTCCBCSBCCC-------
+T ss_pred             HhCCcEEEecCcceecCCCCee-ecccCHHHHHHHHHHhcCCCEEEEEecCCeeecCCCCcCccceeehhcccchhhHHh
+Confidence            3446678888888888888876 67889999999999999999999999999999999999999999999998 677666
+
+
+Q gi|556503834|r  258 ------SYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQ  289 (820)
+Q Consensus       258 ------syfgakvlhprtitpiaqfqipclikntgnpq  289 (820)
+                            ...|..+.|++.+.+.++..+|+.|.|..+|.
+T Consensus       212 ~~~~~~~~~Ggm~~k~~aa~~a~~~gi~v~I~n~~~~~  249 (269)
+T 3ll9_A          212 DGTLNTDVTGGMVGKIRELLLLAEKGVESEIINAAVPG  249 (269)
+T ss_dssp             ------------SHHHHHHHHHHHTTCCEEEEESSSTT
+T ss_pred             hccccceeecChHHHHHHHHHHHHcCCeEEEEeCCCcc
+Confidence                  47899999999999999999999999976663
+
+
+No 19
+>4a7w_A Uridylate kinase; transferase; HET: GTP; 1.80A {Helicobacter pylori} PDB: 4a7x_A*
+Probab=99.25  E-value=2e-15  Score=131.84  Aligned_cols=89  Identities=25%  Similarity=0.293  Sum_probs=81.4  Template_Neff=9.500
+
+Q gi|556503834|r  204 RNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIK  283 (820)
+Q Consensus       204 rngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclik  283 (820)
+                      +.++|+.|+.+|.++.|+.+.+|||+||+|++||+.+|++++++..||+|+.+   +|.+++||+.+.+..+..+|+.|.
+T Consensus       141 ~~~sD~~A~~lA~~l~A~~li~~tdv~Gv~~~dp~~~~~a~~i~~is~~e~~~---~~~~~~~~~a~~~a~~~~v~v~I~  217 (240)
+T 4a7w_A          141 FFTTDTAATLRAIEIGSDLIIKATKVDGIYDKDPNKFKDAKKLDTLSYNDALI---GDIEVMDDTAISLAKDNKLPIVVC  217 (240)
+T ss_dssp             TSCHHHHHHHHHHHTTCSEEEEEESSSSEESSCTTTCTTCCEESEECHHHHHH---SSCCSSCHHHHHHHHHTTCCEEEE
+T ss_pred             CCChHHHHHHHHHHcCCCEEEEEecCCeeECCCCCcCCcceeCCccCHHHHHH---cCCceeCHHHHHHHHHcCCcEEEE
+Confidence            46899999999999999999999999999999999999999999999999876   478999999999998889999999
+
+
+Q gi|556503834|r  284 NTGNPQAPGTLI  295 (820)
+Q Consensus       284 ntgnpqapgtli  295 (820)
+                      |..+|...++.+
+T Consensus       218 ~~~~~~~l~~~l  229 (240)
+T 4a7w_A          218 NMFKKGNLLQVI  229 (240)
+T ss_dssp             ESSSTTHHHHHH
+T ss_pred             eCCCCchhhhhe
+Confidence            998887766544
+
+
+No 20
+>1gs5_A Acetylglutamate kinase; carbamate kinase, amino acid kinase, arginine biosynthesis, phosphoryl group transfer, transferase; HET: NLG ANP; 1.5A {Escherichia coli} SCOP: c.73.1.2 PDB: 1gsj_A* 1oh9_A* 1oha_A* 1ohb_A* 2wxb_A 2x2w_A* 3t7b_A*
+Probab=99.23  E-value=2.8e-15  Score=131.72  Aligned_cols=222  Identities=16%  Similarity=0.188  Sum_probs=132.3  Template_Neff=9.600
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNAR-QGQVATVLSAPAKITNHLVAMIEKTISGQDALPNISDAERIFAELLTGLA   79 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnar-qgqvatvlsapakitnhlvamiektisgqdalpnisdaerifaelltgla   79 (820)
+                      +.|+||||+++.+.+.+.++++++.+..+ .+...-++++..+.++++...+.......+.+...+              
+T Consensus         4 ~~ViK~GGs~l~~~~~~~~~~~~i~~~~~~~~~~vvvV~g~g~~~~~~~~~~~~~~~~~~~~~~~~--------------   69 (258)
+T 1gs5_A            4 PLIIKLGGVLLDSEEALERLFSALVNYRESHQRPLVIVHGGGCVVDELMKGLNLPVKKKNGLRVTP--------------   69 (258)
+T ss_dssp             CEEEEECGGGGGCHHHHHHHHHHHHHHHTTCCSCEEEEECCHHHHHHHHHHHTCCCCEETTEECBC--------------
+T ss_pred             EEEEEEChhHhcCchHHHHHHHHHHHHHHcCCCcEEEEECCHHHHHHHHHHcCCCCceeCCEecCC--------------
+Confidence            36899999999999999999998875543 355667788888888887654432211000000000              
+
+
+Q gi|556503834|r   80 AAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAV--  157 (820)
+Q Consensus        80 aaqpgfplaqlktfvdqefaqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvekllav--  157 (820)
+                                     ..+...++.++-+         ..|            +.+...|..+|.++..+++.+.-+..  
+T Consensus        70 ---------------~~~~~~~~~~~~~---------~~~------------~~l~~~l~~~gi~a~~l~~~~~~~~~~~  113 (258)
+T 1gs5_A           70 ---------------ADQIDIITGALAG---------TAN------------KTLLAWAKKHQIAAVGLFLGDGDSVKVT  113 (258)
+T ss_dssp             ---------------HHHHHHHHHHHHT---------HHH------------HHHHHHHHHTTCCEEEECTTGGGCEEEE
+T ss_pred             ---------------HHHHHHHHHHHHH---------HHH------------HHHHHHHHhCCCcEEEeecccCceEEEE
+Confidence                           0001111100000         001            11113344455555544444321111  
+
+
+Q gi|556503834|r  158 ------GHYLES-TVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVD  230 (820)
+Q Consensus       158 ------ghyles-tvdiaestrriaasripadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvd  230 (820)
+                            +|+-+. .++    ++.|. ..+....++++.|. +.++.|+...+   +||+.|+.+|++++|+ |.+|||+|
+T Consensus       114 ~~~~~~~~~~~~~~~~----~~~i~-~~l~~~~ipVv~g~-~~~~~g~~~~~---~sD~~A~~lA~~l~A~-li~~tdv~  183 (258)
+T 1gs5_A          114 QLDEELGHVGLAQPGS----PKLIN-SLLENGYLPVVSSI-GVTDEGQLMNV---NADQAATALAATLGAD-LILLSDVS  183 (258)
+T ss_dssp             ECCGGGBSBEEEEECC----CHHHH-HHHHTTCEEEECSE-EECTTSCEEEC---CHHHHHHHHHHHHTCE-EEEEESSS
+T ss_pred             eccCcCCCccceeecC----HHHHH-HHHHCCCEEEEcCC-cccCCCcEEee---cHHHHHHHHHHHcCCC-EEEEeCCh
+Confidence                  111111 111    12222 12234567778883 44567877554   8999999999999999 78999999
+
+
+Q gi|556503834|r  231 GVYTCDPRQVPDARLLKSMSYQEAMELSYFG-----AKVLHPRTITPIAQFQIPCLIKNTGNP  288 (820)
+Q Consensus       231 gvytcdprqvpdarllksmsyqeamelsyfg-----akvlhprtitpiaqfqipclikntgnp  288 (820)
+                      |||++||+      +++.+||+|+.++++.+     .+...+..+....+..+|+.|-|..+|
+T Consensus       184 Gv~~~~p~------~i~~is~~e~~~l~~~~~~~~gm~~k~~~a~~~~~~~~~~v~I~~~~~~  240 (258)
+T 1gs5_A          184 GILDGKGQ------RIAEMTAAKAEQLIEQGIITDGMIVKVNAALDAARTLGRPVDIASWRHA  240 (258)
+T ss_dssp             SCBCTTSC------BCCEECHHHHHHHHHTTCSCTHHHHHHHHHHHHHHHHTSCEEEEESSCG
+T ss_pred             hhccCCCc------cccccCHHHHHHHHHcCCCCCChHHHHHHHHHHHHhCCCEEEEEcCCCh
+Confidence            99999985      56889999999998764     344444466666677788888887765
+
+
+No 21
+>3ek6_A Uridylate kinase; UMPK unique GTP B site, allosteric regulation, ATP-binding, nucleotid binding, pyrimidine biosynthesis, transferase; 2.34A {Xanthomonas campestris PV} PDB: 3ek5_A
+Probab=99.21  E-value=4.3e-15  Score=130.75  Aligned_cols=83  Identities=29%  Similarity=0.353  Sum_probs=77.6  Template_Neff=9.300
+
+Q gi|556503834|r  205 NGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKN  284 (820)
+Q Consensus       205 ngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikn  284 (820)
+                      .++|+.|+.+|.+++|+.+-+||||||+|++||+.+|++++++.++|.|+.+   +|.+.+||+.+.+..+..+|+.|.|
+T Consensus       143 ~~sD~~A~~lA~~l~A~~li~~tdv~Gv~~~dp~~~~~a~~i~~is~~e~~~---~~~~~m~~~a~~~a~~~gi~v~I~~  219 (243)
+T 3ek6_A          143 FTTDSGAALRAIEIGADLLLKATKVDGVYDKDPKKHSDAVRYDSLTYDEVIM---QGLEVMDTAAFALARDSDLPLRIFG  219 (243)
+T ss_dssp             CCHHHHHHHHHHHHTCSEEEEECSSSSCBSSCGGGCTTCCBCSEECHHHHHH---HTCCSSCHHHHHHHHHTTCCEEEEC
+T ss_pred             CCcHHHHHHHHHHhCCCEEEEeeCCCcCcCCCCCCCCcceEeeecCHHHHHH---hCcchhhHHHHHHHHHCCCeEEEEe
+Confidence            6799999999999999999999999999999999999999999999999876   6899999999999989999999999
+
+
+Q gi|556503834|r  285 TGNPQA  290 (820)
+Q Consensus       285 tgnpqa  290 (820)
+                      ..+|..
+T Consensus       220 ~~~~~~  225 (243)
+T 3ek6_A          220 MSEPGV  225 (243)
+T ss_dssp             CCSTTH
+T ss_pred             CCChHH
+Confidence            887754
+
+
+No 22
+>1ybd_A Uridylate kinase; alpha/beta/alpha fold, hexamer, structural genomics, structure initiative, PSI; 2.60A {Neisseria meningitidis} SCOP: c.73.1.3
+Probab=99.18  E-value=7.2e-15  Score=128.20  Aligned_cols=143  Identities=20%  Similarity=0.268  Sum_probs=103.3  Template_Neff=9.500
+
+Q gi|556503834|r  127 EKMSIAIMAGVLEARGHNVTVIDPVEKLLAVGHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNG  206 (820)
+Q Consensus       127 ekmsiaimagvlearghnvtvidpvekllavghylestvdiaestrriaasripadhmvlmagftagnekgelvvlgrng  206 (820)
+                      +.|+..++...|..+|.++..+++.+...     ++.+.    ....| ..-+....++++.||.     |.    ...+
+T Consensus        82 ~~~~~~~i~~~l~~~gi~a~~~~~~~~~~-----~~~~~----~~~~i-~~~l~~g~i~V~~~~~-----g~----~~~~  142 (239)
+T 1ybd_A           82 TVMNALALKDAFETLGIKARVQSALSMQQ-----IAETY----ARPKA-IQYLEEGKVVIFAAGT-----GN----PFFT  142 (239)
+T ss_dssp             HHHHHHHHHHHHHHTTCCEEEEESSCBSS-----SCEEC----CHHHH-HHHHHTTCEEEEESTT-----SS----TTCC
+T ss_pred             HHHHHHHHHHHHHHCCCCeEEecHHHHHH-----HhhHH----HHHHH-HHHHhcCCEEEEeCCc-----cC----CCCC
+Confidence            34444466667777787777666654421     11110    01111 1223344556666662     21    1567
+
+
+Q gi|556503834|r  207 SDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTG  286 (820)
+Q Consensus       207 sdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikntg  286 (820)
+                      +|+.|+.||..+.|+.+.+||||||||++||+.+||+++++.+|++|+.+   ++.+.++++.+.+..+..+++.|.|..
+T Consensus       143 sD~~A~~lA~~l~A~~li~~tdv~GVy~~dp~~~~~~~~i~~is~~e~~~---~~~~~m~~~a~~~a~~~gv~v~I~~g~  219 (239)
+T 1ybd_A          143 TDTAAALRGAEMNCDVMLKATNVDGVYTADPKKDPSATRYETITFDEALL---KNLKVMDATAFALCRERKLNIVVFGIA  219 (239)
+T ss_dssp             HHHHHHHHHHHTTCSEEEEECSSSSCBSSCGGGCTTCCBCSEEEHHHHHH---TTCCSSCHHHHHHHHHTTCCEEEECTT
+T ss_pred             ccHHHHHHHHhcCCCEEEEecCCCceEcCCCCcCCCCeEcccCCHHHHHH---hccCCcCHHHHHHHHHcCCeEEEEcCC
+Confidence            99999999999999999999999999999999999999999999998876   477788999988888888999999987
+
+
+Q gi|556503834|r  287 NPQAP  291 (820)
+Q Consensus       287 npqap  291 (820)
+                      +|..-
+T Consensus       220 ~~~~l  224 (239)
+T 1ybd_A          220 KEGSL  224 (239)
+T ss_dssp             STTHH
+T ss_pred             ChhhH
+Confidence            76544
+
+
+No 23
+>1z9d_A Uridylate kinase, UK, UMP kinase; structural genomics, protein structure initiative, NYSGXRC, PYRH, putative uridylate kinase, PSI; 2.80A {Streptococcus pyogenes} SCOP: c.73.1.3
+Probab=99.18  E-value=7.7e-15  Score=130.18  Aligned_cols=144  Identities=22%  Similarity=0.302  Sum_probs=102.4  Template_Neff=9.200
+
+Q gi|556503834|r  125 RGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVGHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGR  204 (820)
+Q Consensus       125 rgekmsiaimagvlearghnvtvidpvekllavghylestvdiaestrriaasripadhmvlmagftagnekgelvvlgr  204 (820)
+                      .++.++..++...|..+|.++..+++.+.-    .+-+..++    .+.|  ..+....++++.||.     |..    +
+T Consensus        80 ~~~~l~~~li~~~l~~~gi~~~~~~~~~~~----~~~~~~~~----~~~i--~~l~~~~i~v~~g~~-----g~~----~  140 (252)
+T 1z9d_A           80 LGTVMNALVMADSLQHYGVDTRVQTAIPMQ----NVAEPYIR----GRAL--RHLEKNRIVVFGAGI-----GSP----Y  140 (252)
+T ss_dssp             HHHHHHHHHHHHHHHTTTCCEEEEESSCBT----TTBEECCH----HHHH--HHHHTTCEEEEESTT-----SCT----T
+T ss_pred             HHHHHHHHHHHHHHHHcCCCeeEEeeeecc----cccchhhh----HHHH--HHhhCCCEEEEcCCc-----cCC----C
+Confidence            344555555666677777776544432210    00000000    0111  112334445555542     221    3
+
+
+Q gi|556503834|r  205 NGSDYSAAVLAACLRADCCEIW-TDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIK  283 (820)
+Q Consensus       205 ngsdysaavlaaclradcceiw-tdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclik  283 (820)
+                      .++|+.|+.+|..+.|+-+.+| |||||+|++||+.+|++++++.++|+|+.+   +|..+.+++.+.+..+..+|+.|.
+T Consensus       141 ~~sD~~Aa~lA~~l~A~~li~lkTdV~Gv~~~dp~~~~~a~~i~~i~~~e~~~---~g~~~~~~~a~~~a~~~gi~v~I~  217 (252)
+T 1z9d_A          141 FSTDTTAALRAAEIEADAILMAKNGVDGVYNADPKKDANAVKFDELTHGEVIK---RGLKIMDATASTLSMDNDIDLVVF  217 (252)
+T ss_dssp             CCHHHHHHHHHHHTTCSEEEEEESSCCSCBSSCTTTCTTCCBCSEEEHHHHHT---TTCCCSCHHHHHHHHHTTCEEEEE
+T ss_pred             CCchHHHHHHHHHcCCCEEEEEecCCCceeccCCCCCCCCcccceeCHHHHHH---cCCCccCHHHHHHHHHCCCeEEEE
+Confidence            7899999999999999999999 999999999999999999999999999765   689999999999999999999999
+
+
+Q gi|556503834|r  284 NTGNPQA  290 (820)
+Q Consensus       284 ntgnpqa  290 (820)
+                      |..+|..
+T Consensus       218 ~~~~~~~  224 (252)
+T 1z9d_A          218 NMNEAGN  224 (252)
+T ss_dssp             ETTSTTH
+T ss_pred             eCCChhH
+Confidence            9888764
+
+
+No 24
+>2dtj_A Aspartokinase; protein-ligand complex, regulatory subunit, transferase; HET: CIT; 1.58A {Corynebacterium glutamicum} PDB: 3aaw_B* 3ab2_B 3ab4_B*
+Probab=99.16  E-value=1.2e-14  Score=122.59  Aligned_cols=163  Identities=29%  Similarity=0.442  Sum_probs=132.7  Template_Neff=9.300
+
+Q gi|556503834|r  304 LPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSE-----YSISFCVPQSDCVRAERAMQEEF  378 (820)
+Q Consensus       304 lpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssse-----ysisfcvpqsdcvraeramqeef  378 (820)
+                      -++++|+-..|.+++++.+  +....|..+++|..+.+.+|++.+++++.++     .+++||++.++-.++.+..++.+
+T Consensus         4 ~~v~~It~~~~i~~i~i~~--~~~~~~~~~~i~~~l~~~~i~v~~i~~~~~~~~~~~~~i~~~i~~~~~~~~~~~L~~~~   81 (178)
+T 2dtj_A            4 AVLTGVATDKSEAKVTVLG--ISDKPGEAAKVFRALADAEINIDMVLQNVSSVEDGTTDITFTCPRSDGRRAMEILKKLQ   81 (178)
+T ss_dssp             CEEEEEEEECSEEEEEEEE--EECSTTHHHHHHHHHHHTTCCCCEEEECCCCTTTCEEEEEEEEEHHHHHHHHHHHHTTT
+T ss_pred             CCceEEEecCCEEEEEEec--CCCCCcHHHHHHHHHHHcCCeEEEEEeCCccCCCCcceEEEEEeHHHHHHHHHHHHHHH
+Confidence            4589999999999999985  6677788999999999999999999998764     68899998765323322222111
+
+
+Q gi|556503834|r  379 YLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQM  458 (820)
+Q Consensus       379 ylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqm  458 (820)
+                          +........+.+.+++|+++|.+++.-.|+.+++|.+|+..+||+..+.  +++.+++++|+.+|...-++.-|+.
+T Consensus        82 ----~~~~~~~i~~~~~~a~IslvG~~l~~~~gi~~~i~~~L~~~~I~i~~~~--~s~~~is~vv~~~~~~~av~~Lh~~  155 (178)
+T 2dtj_A           82 ----VQGNWTNVLYDDQVGKVSLVGAGMKSHPGVTAEFMEALRDVNVNIELIS--TSEIRISVLIREDDLDAAARALHEQ  155 (178)
+T ss_dssp             ----TTTTCSEEEEESCEEEEEEEEECCTTCHHHHHHHHHHHHHTTCCCCEEE--EETTEEEEEEEGGGHHHHHHHHHHH
+T ss_pred             ----hhCCCceeEEcCCcEEEEEEcCCcccCccHHHHHHHHHHhCCCeEEEEe--cCCCEEEEEEEHHHHHHHHHHHHHH
+Confidence                1222355667889999999999999999999999999999999998887  5778999999999999999999999
+
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVG  474 (820)
+Q Consensus       459 lfntdqvievfvigvg  474 (820)
+                      +|.++.-..+.-.|.|
+T Consensus       156 ~~~~~~~~~~~~~~~~  171 (178)
+T 2dtj_A          156 FQLGGEDEAVVYAGTG  171 (178)
+T ss_dssp             HTCCSSCCCEEC--C-
+T ss_pred             HhCCCCceEEEeeccC
+Confidence            9999998888777765
+
+
+No 25
+>2jjx_A Uridylate kinase, UMP kinase; structural genomics, pyrimidine biosynthesis, ATP-binding, nucleotide-binding, OPPF, PYRH, cytoplasm; HET: ATP; 2.82A {Bacillus anthracis}
+Probab=99.11  E-value=2.5e-14  Score=127.48  Aligned_cols=89  Identities=24%  Similarity=0.475  Sum_probs=80.1  Template_Neff=9.100
+
+Q gi|556503834|r  206 GSDYSAAVLAACLRADCCEIW-TDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKN  284 (820)
+Q Consensus       206 gsdysaavlaaclradcceiw-tdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikn  284 (820)
+                      .+|+.|+.||.++.++-+.+| ||+||||++||+.+|++++++.++|+|+.+   +|.+++|++.+.+.....+|+.|.|
+T Consensus       148 ssD~~A~~LA~~l~A~~li~l~tdv~GV~~~~p~~~~~a~~i~~is~~e~~~---~~~~~~~~~a~~~a~~~gi~v~I~~  224 (255)
+T 2jjx_A          148 TTDYPSVQRAIEMNSDAILVAKQGVDGVFTSDPKHNKSAKMYRKLNYNDVVR---QNIQVMDQAALLLARDYNLPAHVFN  224 (255)
+T ss_dssp             CSHHHHHHHHHHHTCSEEEEEESSCCSCBSSCTTTCSSCCBCSEEEHHHHHH---TTCCSSCHHHHHHHHHHTCCEEEEE
+T ss_pred             CcHHHHHHHHHHhCCCEEEEeccCCCeeeccCCCcCCCceeeeeeCHHHHHH---hCcCeEcHHHHHHHHHcCCeEEEEe
+Confidence            489999999999999999999 999999999999999999999999999987   5899999999998888899999999
+
+
+Q gi|556503834|r  285 TGNP---------QAPGTLIGA  297 (820)
+Q Consensus       285 tgnp---------qapgtliga  297 (820)
+                      ..+|         ...||+|-.
+T Consensus       225 ~~~~~~l~~~l~g~~~GT~i~~  246 (255)
+T 2jjx_A          225 FDEPGVMRRICLGEHVGTLIND  246 (255)
+T ss_dssp             TTSTTHHHHHHBTCCCSEEEES
+T ss_pred             CCChhHHHHHHcCCCCceEEec
+Confidence            7777         346666644
+
+
+No 26
+>2va1_A Uridylate kinase; UMPK, transferase, pyrimidine biosynthesis, amino acid kinase family; 2.50A {Ureaplasma parvum}
+Probab=99.11  E-value=2.6e-14  Score=128.67  Aligned_cols=142  Identities=20%  Similarity=0.304  Sum_probs=95.4  Template_Neff=8.800
+
+Q gi|556503834|r  126 GEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVGHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRN  205 (820)
+Q Consensus       126 gekmsiaimagvlearghnvtvidpvekllavghylestvdiaestrriaasripadhmvlmagftagnekgelvvlgrn  205 (820)
+                      ++.++..+++..|..+|.++..++|...        .. .....++..|. ..+..+.++++.||.     |    .++.
+T Consensus        97 ~~~~~~~l~~~~l~~~gi~~~~l~~~~~--------~~-~~~~~~~~~i~-~~l~~g~IpVv~~~~-----~----~~~~  157 (256)
+T 2va1_A           97 ATIINGLALENALNHLNVNTIVLSAIKC--------DK-LVHESSANNIK-KAIEKEQVMIFVAGT-----G----FPYF  157 (256)
+T ss_dssp             HHHHHHHHHHHHHHTTTCCEEEEESSCC--------TT-TCEECCHHHHH-HHHHTTCEEEEESTT-----S----SSSC
+T ss_pred             HHHHHHHHHHHHHHHcCCCeEEecchhc--------CC-cchHhHHHHHH-HHHhCCCEEEEECCc-----c----CCCC
+Confidence            4455555667788888888877777310        00 00111111111 112224455566542     1    2577
+
+
+Q gi|556503834|r  206 GSDYSAAVLAACLRADCCEI-WTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKN  284 (820)
+Q Consensus       206 gsdysaavlaaclradccei-wtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclikn  284 (820)
+                      ++|+.|+.+|.+++|+.+.+ |||+||+|++||+.+|++++++.+++.|+.++   +..++++..+....+..+|+.|.|
+T Consensus       158 ~sD~~Aa~lA~~l~A~~li~~ltdv~GV~~~dp~~~~~a~~i~~is~~e~~~~---~~~~~d~~a~~~a~~~gi~v~I~~  234 (256)
+T 2va1_A          158 TTDSCAAIRAAETESSIILMGKNGVDGVYDSDPKINPNAQFYEHITFNMALTQ---NLKVMDATALALCQENNINLLVFN  234 (256)
+T ss_dssp             CHHHHHHHHHHHHTCSEEEEEESSCCSBCSCC--------CBSEEEHHHHHHH---TCCSSCHHHHHHHHHTTCEEEEEE
+T ss_pred             CcHHHHHHHHHHcCCCEEEEeccCcCeeEcCCCCcCCCceEeeeeCHHHHHHc---ccCcccHHHHHHHHHCCCeEEEEe
+Confidence            89999999999999999999 99999999999999999999999999999765   667788998888888899999999
+
+
+Q gi|556503834|r  285 TGNPQ  289 (820)
+Q Consensus       285 tgnpq  289 (820)
+                      ..+|.
+T Consensus       235 g~~~~  239 (256)
+T 2va1_A          235 IDKPN  239 (256)
+T ss_dssp             SSSTT
+T ss_pred             CCChH
+Confidence            87764
+
+
+No 27
+>3mah_A Aspartokinase; aspartate kinase, structural genomics, MCSG, transferase, PSI-2; 2.31A {Porphyromonas gingivalis}
+Probab=99.11  E-value=2.7e-14  Score=116.76  Aligned_cols=153  Identities=19%  Similarity=0.300  Sum_probs=118.7  Template_Neff=9.700
+
+Q gi|556503834|r  299 RDEDELPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEF  378 (820)
+Q Consensus       299 rdedelpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeef  378 (820)
+                      -|.+.-++++|...+|.+++++.++.+.+..+...++|..+.++.|.+..++++  +.+++|++.+.+..  ++     .
+T Consensus         2 ~~~~~~~v~~it~~~~~~~i~i~~~~~~~~~~~~~~i~~~l~~~~i~v~~~~~~--~~~~~~~v~~~~~~--~~-----~   72 (157)
+T 3mah_A            2 LDTEKDCIKAVAAKDGITVIKVKSSNKLLSWHFMRKLFEIFEFYQEPVDMVATS--EVGVSLTIDNDKNL--PD-----I   72 (157)
+T ss_dssp             -----CCCCEEEEEEEEEEEEEEECTTSCHHHHHHHHHHHHHHTTCCCSCEECC--SSEEEEEESCCTTH--HH-----H
+T ss_pred             CCCCCCceEEEEecCCEEEEEEEeCCccCcccHHHHHHHHHHHcCCcEEEEEcC--CCeEEEEEcchhhH--HH-----H
+Confidence            356667899999999999999999999888899999999999999999999985  66888988766331  11     1
+
+
+Q gi|556503834|r  379 YLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQM  458 (820)
+Q Consensus       379 ylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqm  458 (820)
+                      -.+|++  .....+.+.+++|+++|.+|+.-.++.+++|.+|.  +++|..+.+++++.+++++++.+|...-++.-|+.
+T Consensus        73 ~~~l~~--~~~v~~~~~~a~islvG~~~~~~~~~~~~~~~~L~--~~~i~~i~~~~s~~sis~vv~~~~~~~a~~~Lh~~  148 (157)
+T 3mah_A           73 VRALSD--IGDVTVDKDMVIICIVGDMEWDNVGFEARIINALK--GVPVRMISYGGSNYNVSVLVKAEDKKKALIALSNK  148 (157)
+T ss_dssp             HHHHTT--TEEEEEEEEEEEEEEEC------CCHHHHHHHTTT--TSCCSEEEECSSSSCEEEEEEGGGHHHHHHHHHHH
+T ss_pred             HHHhhC--CCcEEEeCCEEEEEEEecCcccchhHHHHHHHHHh--cCCeEEEEecCCcceEEEEEeHHHHHHHHHHHHHH
+Confidence            123333  35567788999999999999999999999999995  55667889999999999999999999999999999
+
+
+Q gi|556503834|r  459 LFNTDQ  464 (820)
+Q Consensus       459 lfntdq  464 (820)
+                      +|..+.
+T Consensus       149 ~~~~~~  154 (157)
+T 3mah_A          149 LFNSRA  154 (157)
+T ss_dssp             HHC---
+T ss_pred             Hhcccc
+Confidence            998765
+
+
+No 28
+>3s1t_A Aspartokinase; ACT domain, threonine binding, regulatory domain of aspartok transferase; 1.63A {Mycobacterium tuberculosis}
+Probab=99.09  E-value=3.8e-14  Score=120.62  Aligned_cols=163  Identities=25%  Similarity=0.380  Sum_probs=128.1  Template_Neff=9.100
+
+Q gi|556503834|r  304 LPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSE-----YSISFCVPQSDCVRAERAMQEEF  378 (820)
+Q Consensus       304 lpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssse-----ysisfcvpqsdcvraeramqeef  378 (820)
+                      -+++||+-.+|++++.+.+  +....+..+++|..+.+++|++..++++.+.     .+++||+++.+-.+++..+++ +
+T Consensus         5 ~~v~~It~~~~~~li~l~~--~~~~~~~~~~l~~~l~~~~i~v~~i~~~~~~~~~~~~~i~~~i~~~~~~~~~~~L~~-~   81 (181)
+T 3s1t_A            5 PILTGVAHDRSEAKVTIVG--LPDIPGYAAKVFRAVADADVNIDMVLQNVSKVEDGKTDITFTCSRDVGPAAVEKLDS-L   81 (181)
+T ss_dssp             CEEEEEEEECSEEEEEEEE--EESSTTHHHHHHHHHHHTTCCCCCEEECCCCTTTCEEEEEEEEETTTHHHHHHHHHH-T
+T ss_pred             CceEEEEecCCEEEEEEcc--CCCCcCHHHHHHHHHHHCCCEEEEEEcCCcCCCCCcccEEEEEEHHHHHHHHHHHHH-H
+Confidence            4689999999999999985  6666788999999999999999999998764     688999987664444433332 3
+
+
+Q gi|556503834|r  379 YLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQM  458 (820)
+Q Consensus       379 ylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqm  458 (820)
+                      ..++.   .....+.+.+++|+++|++|+.-.++.++++.+|++.+|||..+.  +++.+++++++.+|...-++.-|+.
+T Consensus        82 ~~~~~---~~~i~~~~~~a~IsvvG~~~~~~~~v~~~i~~~L~~~~I~i~~~~--~s~~sis~lv~~~d~~~a~~~Lh~~  156 (181)
+T 3s1t_A           82 RNEIG---FSQLLYDDHIGKVSLIGAGMRSHPGVTATFCEALAAVGVNIELIS--TSEIRISVLCRDTELDKAVVALHEA  156 (181)
+T ss_dssp             HHHHC---CSEEEEESCEEEEEEEEECCTTCHHHHHHHHHHHHHTTCCCCEEE--EETTEEEEEEEGGGHHHHHHHHHHH
+T ss_pred             HHhcC---CCceEeeCCeEEEEEECCCccccHHHHHHHHHHHHHCCCeEEEEe--cCCCEEEEEEEHHHHHHHHHHHHHH
+Confidence            32222   245667788999999999999999999999999999999998887  6778999999999999999999999
+
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVG  474 (820)
+Q Consensus       459 lfntdqvievfvigvg  474 (820)
+                      +|.....+-..++|.|
+T Consensus       157 ~~~~~~~~~~~~~~~~  172 (181)
+T 3s1t_A          157 FGLGGDEEATVYAGTG  172 (181)
+T ss_dssp             HTCCC----C------
+T ss_pred             HhcCCCceEeccccch
+Confidence            9998887766666655
+
+
+No 29
+>2dt9_A Aspartokinase; protein-ligand complex, regulatory subunit, transferase; 2.15A {Thermus thermophilus} PDB: 2zho_A
+Probab=98.97  E-value=2.5e-13  Score=112.78  Aligned_cols=154  Identities=27%  Similarity=0.357  Sum_probs=122.3  Template_Neff=9.500
+
+Q gi|556503834|r  302 DELPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSS-----SEYSISFCVPQSDCVRAERAMQE  376 (820)
+Q Consensus       302 delpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqss-----seysisfcvpqsdcvraeramqe  376 (820)
+                      .+-+++||+--+|.+++++.+  +....|..+++|..++++++.+..++++.     ++..++||+...+-.++..... 
+T Consensus         3 ~~~~v~~I~~~~~~~~i~i~~--~~~~~~~~~~~~~~l~~~~i~i~~i~~~~~~~~~~~~~i~~~v~~~~~~~~~~~l~-   79 (167)
+T 2dt9_A            3 MDKAVTGVALDLDHAQIGLIG--IPDQPGIAAKVFQALAERGIAVDMIIQGVPGHDPSRQQMAFTVKKDFAQEALEALE-   79 (167)
+T ss_dssp             --CCEEEEEEECSEEEEEEEE--EECSTTHHHHHHHHHHHHTCCCSCEEBCCCCSCTTEEEEEEEEEGGGHHHHHHHHH-
+T ss_pred             CCCCeeEEEEeCCEEEEEEcC--CCCCcCHHHHHHHHHHHCCCcEEEEEcCCCCCCCCcceEEEEEeHHHHHHHHHHHH-
+Confidence            345789999999999999986  77777889999999999999999999875     5788999998654332221111 
+
+
+Q gi|556503834|r  377 EFYLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTH  456 (820)
+Q Consensus       377 efylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvth  456 (820)
+                          +..+....+..+.+.+++|+++|++|+.-.|+.+++|.+|++.+|||..+.  +++-+++++|+.+|....++.-|
+T Consensus        80 ----~~~~~~~~~v~~~~~~a~islvG~~l~~~~~~~~~i~~~L~~~~i~i~~i~--~s~~~i~~lv~~~~~~~av~~Lh  153 (167)
+T 2dt9_A           80 ----PVLAEIGGEAILRPDIAKVSIVGVGLASTPEVPAKMFQAVASTGANIEMIA--TSEVRISVIIPAEYAEAALRAVH  153 (167)
+T ss_dssp             ----HHHHHHCCEEEEECSEEEEEEEESSGGGSTHHHHHHHHHHHHTTCCCCEEE--ECSSEEEEEEEGGGHHHHHHHHH
+T ss_pred             ----HHHHhcCCceEecCCceEEEEECcCcccCccHHHHHHHHHHHCCCcEEEEE--ecCCEEEEEEEHHHHHHHHHHHH
+Confidence                111111125668899999999999999999999999999999999999888  56789999999999999999999
+
+
+Q gi|556503834|r  457 QMLFNTDQ  464 (820)
+Q Consensus       457 qmlfntdq  464 (820)
+                      +.+|+..+
+T Consensus       154 ~~~~~~~~  161 (167)
+T 2dt9_A          154 QAFELDKA  161 (167)
+T ss_dssp             HHTC----
+T ss_pred             HHHhcccc
+Confidence            99998654
+
+
+No 30
+>3nwy_A Uridylate kinase; allosterically activated form, AAK fold, UMP kinase, transfe; HET: GTP UDP; 2.54A {Mycobacterium tuberculosis}
+Probab=98.97  E-value=2.6e-13  Score=125.08  Aligned_cols=84  Identities=29%  Similarity=0.341  Sum_probs=73.4  Template_Neff=8.400
+
+Q gi|556503834|r  203 GRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLI  282 (820)
+Q Consensus       203 grngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipcli  282 (820)
+                      .+.++|+.|+.||..+.||-|-+||||||||++||+.+|++++++.++|+|+.+   +|..+++++.+....+..+||.|
+T Consensus       181 ~~~~sD~~Aa~lA~~l~A~~li~ltdVdGV~~~dp~~~~~a~~i~~is~~e~~~---~g~~~~kv~aa~~a~~~gi~v~I  257 (281)
+T 3nwy_A          181 PYFSTDTTAAQRALEIGADVVLMAKAVDGVFAEDPRVNPEAELLTAVSHREVLD---RGLRVADATAFSLCMDNGMPILV  257 (281)
+T ss_dssp             TTCCHHHHHHHHHHHTTCSEEEEEESSSSCBCC-----CCCCBCSEECHHHHHT---TTCCSSCHHHHHHHHTTTCCEEE
+T ss_pred             CCCCchHHHHHHHHHcCCCEEEEcCCCCcccCCCCCCCCCceeeeeccHHHHHh---cCCcccCHHHHHHHHhCCCeEEE
+Confidence            478999999999999999999999999999999999999999999999998865   68999999999999999999999
+
+
+Q gi|556503834|r  283 KNTGNPQ  289 (820)
+Q Consensus       283 kntgnpq  289 (820)
+                      .|..+|.
+T Consensus       258 ~ng~~~~  264 (281)
+T 3nwy_A          258 FNLLTDG  264 (281)
+T ss_dssp             EETTSTT
+T ss_pred             EeCCCch
+Confidence            9988775
+
+
+No 31
+>2rd5_A Acetylglutamate kinase-like protein; protein-protein complex, regulation of arginine biosynthesis nitrogen metabolism, kinase, transferase, transcription; HET: ARG ADP NLG ATP; 2.51A {Arabidopsis thaliana} PDB: 4usj_A*
+Probab=98.91  E-value=5.9e-13  Score=122.22  Aligned_cols=201  Identities=17%  Similarity=0.238  Sum_probs=127.3  Template_Neff=8.800
+
+Q gi|556503834|r    1 MRVLKFGGTSVANAERFLRVADILESNARQGQVATVLSAPAKITNHLVAMIEKTISGQDALPNISDAERIFAELLTGLAA   80 (820)
+Q Consensus         1 mrvlkfggtsvanaerflrvadilesnarqgqvatvlsapakitnhlvamiektisgqdalpnisdaerifaelltglaa   80 (820)
+                      +.|+||||+++.+.+++.++++.+....++|.-..+.++..+.++++..-+...           .  + |   ..    
+T Consensus        38 ~~ViKlGGs~i~~~~~~~~~~~~i~~l~~~g~~vIlV~Ggg~~~~~~~~~~~~~-----------~--~-~---~~----   96 (298)
+T 2rd5_A           38 TIVVKYGGAAMTSPELKSSVVSDLVLLACVGLRPILVHGGGPDINRYLKQLNIP-----------A--E-F---RD----   96 (298)
+T ss_dssp             EEEEEECTHHHHCHHHHHHHHHHHHHHHHTTCEEEEEECCHHHHHHHHHHTTCC-----------C--C-E---ET----
+T ss_pred             EEEEEEChHHhCCchhHHHHHHHHHHHHHCCCCEEEEECCcHHHHHHHHHcCCC-----------c--e-e---EC----
+Confidence            358999999999999888888888776665644445566777777654322100           0  0 0   00    
+
+
+Q gi|556503834|r   81 AQPGFPLAQLKTFVDQEF-AQIKHVLHGISLLGQCPDSINAALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVGH  159 (820)
+Q Consensus        81 aqpgfplaqlktfvdqef-aqikhvlhgisllgqcpdsinaalicrgekmsiaimagvlearghnvtvidpvekllavgh  159 (820)
+                         |+.      +.+.+. ..++     +.+.|++    |            ..+...|..+|.+...++|.+..+....
+T Consensus        97 ---g~r------~t~~~~l~~~~-----~~~~g~~----n------------~~i~~~L~~~gi~~~~l~~~~~~~~~~~  146 (298)
+T 2rd5_A           97 ---GLR------VTDATTMEIVS-----MVLVGKV----N------------KNLVSLINAAGATAVGLSGHDGRLLTAR  146 (298)
+T ss_dssp             ---TEE------CBCHHHHHHHH-----HHHHHTH----H------------HHHHHHHHHTTSCEEEEETTGGGCEEEE
+T ss_pred             ---CEe------CCCHHHHHHHH-----HHHHHHH----H------------HHHHHHHHhCCCCcceeecccCceEEEE
+Confidence               000      011110 0000     0112222    1            2344567778888888888766443332
+
+
+Q gi|556503834|r  160 YLESTVDIA------E-STRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGV  232 (820)
+Q Consensus       160 ylestvdia------e-strriaasripadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgv  232 (820)
+                      -...-+|..      . .+..| ...+....++++.|| .+++.|+...+   ++|+.|+.+|..+.|+.|.+|||||||
+T Consensus       147 ~~~~~~~~~~~g~v~~~~~~~i-~~~l~~g~IpVv~g~-~~~~~g~~~~l---~sD~~A~~lA~~l~A~~li~~tdv~GV  221 (298)
+T 2rd5_A          147 PVPNSAQLGFVGEVARVDPSVL-RPLVDYGYIPVIASV-AADDSGQAYNI---NADTVAGELAAALGAEKLILLTDVAGI  221 (298)
+T ss_dssp             ECTTHHHHBSEEEEEEECGGGH-HHHHHTTCEEEEESE-EECTTSCEEEE---CHHHHHHHHHHHHTCSEEEEEESSSSE
+T ss_pred             ecCcCCCCCceeeEEEECHHHH-HHHHhCCCeEEEeCC-ccCCCCcEEee---cHHHHHHHHHHHcCCCEEEEEeCchhh
+Confidence            222111111      0 11122 222455678899999 56778888776   899999999999999999999999999
+
+
+Q gi|556503834|r  233 YTCDPRQVPDARLLKSMSYQEAMELSYF  260 (820)
+Q Consensus       233 ytcdprqvpdarllksmsyqeamelsyf  260 (820)
+                      |+.||+   ++++++.++|+|+.++...
+T Consensus       222 ~~~dp~---~~~~i~~is~~e~~~l~~~  246 (298)
+T 2rd5_A          222 LENKED---PSSLIKEIDIKGVKKMIED  246 (298)
+T ss_dssp             ESSSSC---TTSEECEEEHHHHHHHHHT
+T ss_pred             hcCCCC---CCcchhcCCHHHHHHHHHc
+Confidence            999997   3789999999999887654
+
+
+No 32
+>2j4j_A Uridylate kinase; transferase, nucleoside monophosphate kinase, UMP kinase, aspartokinase fold, pyrimidine nucleotide synthesis; HET: U5P ACP 4TC; 2.1A {Sulfolobus solfataricus} PDB: 2j4k_A* 2j4l_A*
+Probab=98.90  E-value=7.4e-13  Score=115.09  Aligned_cols=96  Identities=24%  Similarity=0.360  Sum_probs=77.4  Template_Neff=9.400
+
+Q gi|556503834|r  182 DHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFG  261 (820)
+Q Consensus       182 dhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfg  261 (820)
+                      ..++++.+|..           ...+|+.|+.+|.++.||.+-+|||+||+|++||+..|++++++.++++|+.++...+
+T Consensus       105 g~i~v~~~~~~-----------~~~sD~~A~~lA~~l~a~~li~ltdv~Gv~~~~p~~~~~~~~i~~i~~~e~~~~~~~~  173 (226)
+T 2j4j_A          105 GKVVVTGGFQP-----------GQSTAAVAALVAEASSSKTLVVATNVDGVYEKDPRIYADVKLIPHLTTQDLRKILEGS  173 (226)
+T ss_dssp             SSBEEECCCST-----------TSCHHHHHHHHHHHTTCSEEEEEESSSSCBSSCTTTSSSCCBCSEEEHHHHHHHHC--
+T ss_pred             CCEEEEcCCCC-----------CCCccHHHHHHHHHcCCCEEEEecCCCcccCCCCCCCCCCeEeeEeCHHHHHHHHhcC
+Confidence            44566666542           2457999999999999999999999999999999999999999999999988776542
+
+
+Q gi|556503834|r  262 -------AKVLHPRTITPIAQFQIPCLIKNTGNP  288 (820)
+Q Consensus       262 -------akvlhprtitpiaqfqipclikntgnp  288 (820)
+                             ...++++......+..++|.|.|...|
+T Consensus       174 ~~~~~g~~~~~~~~a~~~a~~~g~~v~I~~g~~~  207 (226)
+T 2j4j_A          174 QSVQAGTYELLDPLAIKIVERSKIRVIVMNYRKL  207 (226)
+T ss_dssp             --------CCSCHHHHHHHHHTTCEEEEEEGGGG
+T ss_pred             CCCCCCccccchHHHHHHHHHCCCeEEEEeCCCh
+Confidence                   466777667777677889999887655
+
+
+No 33
+>4q1t_A Glutamate 5-kinase; structural genomics, niaid, national institute of allergy AN infectious diseases; 2.15A {Burkholderia thailandensis}
+Probab=98.89  E-value=7.9e-13  Score=125.29  Aligned_cols=104  Identities=20%  Similarity=0.214  Sum_probs=68.8  Template_Neff=8.700
+
+Q gi|556503834|r  182 DHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQ--EAMELSY  259 (820)
+Q Consensus       182 dhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyq--eamelsy  259 (820)
+                      ..+.++.|+.... .+++   ++.++|+.|+.+|..+.||.+-+||||||+|++||+..|++++++.++|+  |+.++..
+T Consensus       136 g~IPVv~g~~~~~-~~~~---~~~~sD~~Aa~lA~~l~A~~li~ltdVdGvy~~dp~~~~~a~~i~~is~~~~e~~~l~~  211 (376)
+T 4q1t_A          136 GVVPIINENDTVV-TDEI---KFGDNDTLGALVANLIEGDALIILTDQQGLFTADPRKDPGATLVAEASAGAPELEAMAG  211 (376)
+T ss_dssp             TCEEEEEECTTTC-CTTT---C--CCHHHHHHHHHHHTCSEEEEEESSCCC------------CCSEEETTCTTC-----
+T ss_pred             CcEEEEcCCCeec-ccce---eecCHHHHHHHHHHhcCCCEEEEeeccceEEcCCCCCCCcceEeeEeccCcHHHHHhhc
+Confidence            4455667764433 2343   66799999999999999999999999999999999999999999999999  8877653
+
+
+Q gi|556503834|r  260 -------FGAKVLHPRTITPIAQFQIPCLIKNTGNPQ  289 (820)
+Q Consensus       260 -------fgakvlhprtitpiaqfqipclikntgnpq  289 (820)
+                             .|..+.+++.+.+.++..+|+.|-|..+|.
+T Consensus       212 ~~~~~~~tGgm~~k~~aa~~a~~~gi~~~I~ng~~~~  248 (376)
+T 4q1t_A          212 GAGSSIGRGGMLTKILAAKRAAHSGANTVIASGRERD  248 (376)
+T ss_dssp             ----------CHHHHHHHHHHHTTTCEEEEEETTSTT
+T ss_pred             cccCCcccCchHHHHHHHHHHHHCCCCEEEEeCCCch
+Confidence                   577788889999999999999999877764
+
+
+No 34
+>2ij9_A Uridylate kinase; structural genomics, protein structure initiative, P nysgxrc; 2.90A {Archaeoglobus fulgidus} SCOP: c.73.1.3
+Probab=98.88  E-value=9.8e-13  Score=115.66  Aligned_cols=81  Identities=28%  Similarity=0.329  Sum_probs=68.6  Template_Neff=8.900
+
+Q gi|556503834|r  205 NGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYF-----G-AKVLHPRTITPIAQFQI  278 (820)
+Q Consensus       205 ngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyf-----g-akvlhprtitpiaqfqi  278 (820)
+                      .++|+.|+.+|.++++|-|.+|||+||+|++||+..|++++++.++|+|+.++..-     | -...++..+....+.++
+T Consensus       114 ~~sD~~A~~lA~~l~a~~li~ltdv~Gv~~~~p~~~~~~~~i~~i~~~~~~~~~~~~~~~~~~~~~~~~~a~~~a~~~gv  193 (219)
+T 2ij9_A          114 HTTDATAALLAEFIKADVFINATNVDGVYSADPKSDTSAVKYDRLSPQQLVEIVSRSSAKAGTNVVIDLLAAKIIERSKI  193 (219)
+T ss_dssp             SCTHHHHHHHHHHTTCSEEEEEESSSSCBCSSCSSSSSCCBCSEECHHHHHHHTCC-----CCCCCSCHHHHHHHHHHTC
+T ss_pred             CCcHHHHHHHHHHcCCCEEEEccCCCccccCCCCcCCCceEEEEeCHHHHHHHhcccccccCCCcccHHHHHHHHHHcCC
+Confidence            57999999999999999999999999999999999999999999999998877532     2 24455666666667788
+
+
+Q gi|556503834|r  279 PCLIKNT  285 (820)
+Q Consensus       279 pcliknt  285 (820)
+                      |+.|-|.
+T Consensus       194 ~v~I~~g  200 (219)
+T 2ij9_A          194 KTYVILG  200 (219)
+T ss_dssp             CEEEEEC
+T ss_pred             cEEEEEC
+Confidence            8888776
+
+
+No 35
+>2re1_A Aspartokinase, alpha and beta subunits; structural genomics, protein structure initiative, midwest center for structural genomics; 2.75A {Neisseria meningitidis MC58}
+Probab=98.84  E-value=1.7e-12  Score=106.66  Aligned_cols=152  Identities=29%  Similarity=0.394  Sum_probs=119.7  Template_Neff=9.800
+
+Q gi|556503834|r  302 DELPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSS---EYSISFCVPQSDCVRAERAMQEEF  378 (820)
+Q Consensus       302 delpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqsss---eysisfcvpqsdcvraeramqeef  378 (820)
+                      ..-++|+|+-.+|++++++.+  +.+..|..+++|..+.++++++..++++.+   ..+++|+++..+-.++....++++
+T Consensus        12 ~~~~v~~It~~~~~~ll~i~~--~~~~~~~~~~l~~~l~~~~i~v~~i~~~~~~~~~~~i~~~v~~~~~~~~~~~l~~~~   89 (167)
+T 2re1_A           12 ERAAVTGIAFDKNQARINVRG--VPDKPGVAYQILGAVADANIEVDMIIQNVGSEGTTDFSFTVPRGDYKQTLEILSERQ   89 (167)
+T ss_dssp             ---CCCEEEEECCCEEEEEEE--EECCTTHHHHHHHHHHTTTCCCCCEEEC----CEEEEEEEECGGGHHHHHHHHHHSS
+T ss_pred             ccCceEEEEeeCCEEEEEEec--CCCCccHHHHHHHHHHHcCCEEEEEEeCCccCCCccEEEEEeHHHHHHHHHHHHHHH
+Confidence            446799999999999999976  556678889999999999999999998854   368899998766433333222211
+
+
+Q gi|556503834|r  379 YLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQM  458 (820)
+Q Consensus       379 ylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqm  458 (820)
+                          .+.-.......+.+++|+++|.++..-.|+.++++.+|++.+||+..+.  +++.+++++|+.+|...-++.-|+.
+T Consensus        90 ----~~~~~~~i~~~~~~s~IslvG~~~~~~~~~~~~i~~~L~~~~I~i~~~~--~s~~~i~~vv~~~~~~~a~~~Lh~~  163 (167)
+T 2re1_A           90 ----DSIGAASIDGDDTVCKVSAVGLGMRSHVGVAAKIFRTLAEEGINIQMIS--TSEIKVSVLIDEKYMELATRVLHKA  163 (167)
+T ss_dssp             ----TTTTCSEEEEESSEEEEEEECSSCTTCCCHHHHHHHHHHHTTCCCCEEE--ECSSEEEEEEEGGGHHHHHHHHHHH
+T ss_pred             ----HhcCCceeeecCCEEEEEEECCCccCCccHHHHHHHHHHHCCCcEEEEe--cCCCeEEEEEeHHHHHHHHHHHHHH
+Confidence                1100133556778999999999999999999999999999999998887  5778999999999999999999988
+
+
+Q gi|556503834|r  459 LFN  461 (820)
+Q Consensus       459 lfn  461 (820)
+                      +|.
+T Consensus       164 ~~~  166 (167)
+T 2re1_A          164 FNL  166 (167)
+T ss_dssp             TTC
+T ss_pred             Hcc
+Confidence            875
+
+
+No 36
+>1gtm_A Glutamate dehydrogenase; oxidoreductase, NAD, NADP; 2.20A {Pyrococcus furiosus} SCOP: c.2.1.7 c.58.1.1 PDB: 1bvu_A 1euz_A
+Probab=98.80  E-value=2.9e-12  Score=126.07  Aligned_cols=201  Identities=17%  Similarity=0.165  Sum_probs=150.6  Template_Neff=7.700
+
+Q gi|556503834|r  451 GVRVTHQMLFN-----TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEEL  525 (820)
+Q Consensus       451 gvrvthqmlfn-----tdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeel  525 (820)
+                      ||....+.+++     ...-+.|.+.|.|.||+.+.++|.++.        ..+|++|++++..+.|-.|++++.|.+..
+T Consensus       193 Gv~~~~~~~~~~~~~~~~~~~~v~I~G~G~VG~~~a~~L~~~~--------g~~vv~Vsd~~g~i~~~~Gld~~~l~~~~  264 (419)
+T 1gtm_A          193 GASYTIREAAKVLGWDTLKGKTIAIQGYGNAGYYLAKIMSEDF--------GMKVVAVSDSKGGIYNPDGLNADEVLKWK  264 (419)
+T ss_dssp             HHHHHHHHHHHHTTCSCSTTCEEEEECCSHHHHHHHHHHHHTT--------CCEEEEEECSSCEEEEEEEECHHHHHHHH
+T ss_pred             hHHHHHHHHHHHcCCccccCceEEEecccchHHHHHHHHHHhc--------CCEEEEEEcCCCeEEcCCCCCHHHHHHHH
+Confidence            55554444443     346788999999999999999997541        36999999999999999999998887765
+
+
+Q gi|556503834|r  526 AQAKEPFNL--GRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKF  603 (820)
+Q Consensus       526 aqakepfnl--grlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkf  603 (820)
+                      .+.+..-..  ...+..-+-...-..++++|+.+..+.+++++.+ .+.+||+.||...|...   .+           +
+T Consensus       265 ~~~~~~~~~~~~~~~~~~~~l~~~~DIlipaa~~~~i~~~~~~~i-~~k~VVeaan~p~t~~a---~~-----------i  329 (419)
+T 1gtm_A          265 NEHGSVKDFPGATNITNEELLELEVDVLAPAAIEEVITKKNADNI-KAKIVAEVANGPVTPEA---DE-----------I  329 (419)
+T ss_dssp             HHHSSSTTCTTSEEECHHHHHHSCCSEEEECSCSCCBCTTGGGGC-CCSEEECCSSSCBCHHH---HH-----------H
+T ss_pred             HhcCCcccCCcceecChHHHhcCCCcEEEECCCcccccchhhHhh-CCcEEEecCcccCCHHH---HH-----------H
+Confidence            442210000  0111100111125678899999988888999998 59999999999887653   22           2
+
+
+Q gi|556503834|r  604 LYDTNVGAGLPVIENLQNLLNAGDELMKFSGILSGSLSYI-----FGKLDEG--MSFSEATTLAREMGYTEPDPRDDLSG  676 (820)
+Q Consensus       604 lydtnvgaglpvienlqnllnagdelmkfsgilsgslsyi-----fgkldeg--msfseattlaremgytepdprddlsg  676 (820)
+                      ||+    +|+|++..+... -.|+.+..|.+++++..+|+     +.++++.  -+|+++...|++.|++++|+.+++.-
+T Consensus       330 L~e----~Gi~vipd~~~n-agGv~vs~~E~v~n~t~~~~~~~~v~~~l~~~m~~~~~~vl~~A~~~g~~~~~aa~~~a~  404 (419)
+T 1gtm_A          330 LFE----KGILQIPDFLCN-AGGVTVSYFEWVQNITGYYWTIEEVRERLDKKMTKAFYDVYNIAKEKNIHMRDAAYVVAV  404 (419)
+T ss_dssp             HHH----TTCEEECHHHHT-THHHHHHHHHHHHHHHCCCCCHHHHHHHHHHHHHHHHHHHHHHHHHTTCCHHHHHHHHHH
+T ss_pred             HHH----CCeEEechHHhc-CCCceEehhheecCcccccCCHHHHHHHHHHHHHHHHHHHHHHHHHcCCCHHHHHHHHHH
+Confidence            454    499999998863 25899999999999999999     9999984  59999999999999999999887654
+
+
+Q gi|556503834|r  677 MDV  679 (820)
+Q Consensus       677 mdv  679 (820)
+                      ..+
+T Consensus       405 ~r~  407 (419)
+T 1gtm_A          405 QRV  407 (419)
+T ss_dssp             HHH
+T ss_pred             HHH
+Confidence            433
+
+
+No 37
+>4ndo_A Molybdenum storage protein subunit alpha; rossmann fold, ATP binding, molybdenum B metal binding protein; HET: ATP 8M0; 1.35A {Azotobacter vinelandii} PDB: 2ogx_A* 4ndp_A* 4ndq_A* 4ndr_A* 4f6t_A*
+Probab=98.71  E-value=8.5e-12  Score=114.13  Aligned_cols=85  Identities=25%  Similarity=0.260  Sum_probs=69.3  Template_Neff=8.600
+
+Q gi|556503834|r  202 LGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVP--DARLLKSMSYQEAMELSY---FGAKVLHPRTITPIAQF  276 (820)
+Q Consensus       202 lgrngsdysaavlaaclradcceiwtdvdgvytcdprqvp--darllksmsyqeamelsy---fgakvlhprtitpiaqf  276 (820)
+                      +++.++|..|+.+|..++|+.|.+|||+||+|++||+..|  ++++++..+++|+.++..   ...|+.++...   +++
+T Consensus       165 ~~~~~sD~~Aa~lA~~l~A~~Li~ltdv~GVy~~dp~~~~~~~~~~i~~is~~e~~~l~~~~~~~~kl~~~~~a---~~~  241 (276)
+T 4ndo_A          165 IPPHRADTGAFLLADAFGAAGLTIVENVDGIYTADPNGPDRGQARFLPETSATDLAKSEGPLPVDRALLDVMAT---ARH  241 (276)
+T ss_dssp             SCSSCHHHHHHHHHHHHTCSEEEEEESSSSCBSSCTTSTTGGGCCBCSEEEHHHHHHCCSCCSSCHHHHHHHHT---CSS
+T ss_pred             CCCCChHHHHHHHHHHcCCCEEEEEecCcccccCCCcccccccceecccCCHHHHHHHhccCChHHHHHHHHHH---HhC
+Confidence            4578899999999999999999999999999999999886  999999999999887653   22444444432   266
+
+
+Q gi|556503834|r  277 QIPCLIKNTGNPQ  289 (820)
+Q Consensus       277 qipclikntgnpq  289 (820)
+                      .+++.|.|..+|.
+T Consensus       242 gi~v~I~ng~~~~  254 (276)
+T 4ndo_A          242 IERVQVVNGLVPG  254 (276)
+T ss_dssp             CCEEEEEETTSTT
+T ss_pred             CCeEEEEeCCCch
+Confidence            7899999887774
+
+
+No 38
+>2a1f_A Uridylate kinase; PYRH, structural genomics, PSI, protein ST initiative, NEW YORK SGX research center for structural GEN nysgxrc; 2.10A {Haemophilus influenzae} SCOP: c.73.1.3 PDB: 2bne_A* 2bnf_A* 2v4y_A* 2bnd_A*
+Probab=98.71  E-value=8.6e-12  Score=110.78  Aligned_cols=84  Identities=35%  Similarity=0.506  Sum_probs=67.8  Template_Neff=9.100
+
+Q gi|556503834|r  204 RNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIK  283 (820)
+Q Consensus       204 rngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhprtitpiaqfqipclik  283 (820)
+                      +.++|+.|+.+|..++|+-|-+|||+||+|++||+..|++++++.+|+.|+.++   |..+.+++......+..+++.|-
+T Consensus       141 ~~ssD~~A~~lA~~l~A~~li~ltdv~Gv~~~dp~~~~~~~~i~~is~~e~~~~---~~~~~k~~a~~~a~~~gv~v~I~  217 (247)
+T 2a1f_A          141 FFTTDSTACLRGIEIEADVVLKATKVDGVYDCDPAKNPDAKLYKNLSYAEVIDK---ELKVMDLSAFTLARDHGMPIRVF  217 (247)
+T ss_dssp             SCCHHHHHHHHHHHTTCSEEEEEESSSSCBCC-------CCBCSEECHHHHHHT---TCCSSCHHHHHHHHHHTCCEEEE
+T ss_pred             CCCcHHHHHHHHHHcCCCEEEEcCCCCcccCCCCCCCCCceeeeecCHHHHHHc---CCceeCHHHHHHHHHCCCeEEEE
+Confidence            677999999999999999999999999999999999999999999999997664   66778888888888888899888
+
+
+Q gi|556503834|r  284 NTGNPQA  290 (820)
+Q Consensus       284 ntgnpqa  290 (820)
+                      |..+|..
+T Consensus       218 ~~~~~~~  224 (247)
+T 2a1f_A          218 NMGKPGA  224 (247)
+T ss_dssp             ETTSTTH
+T ss_pred             eCCCcch
+Confidence            8766643
+
+
+No 39
+>2ako_A Glutamate 5-kinase; structural genomics, PSI, protein structure initiative, NEW YORK SGX research center for structural genomics, nysgxrc; HET: ADP; 2.20A {Campylobacter jejuni} SCOP: c.73.1.3
+Probab=98.66  E-value=1.6e-11  Score=107.91  Aligned_cols=103  Identities=17%  Similarity=0.183  Sum_probs=82.4  Template_Neff=9.500
+
+Q gi|556503834|r  182 DHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYF-  260 (820)
+Q Consensus       182 dhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyf-  260 (820)
+                      ..+.++.|+.... .|+   +.+..+|..|+.+|..+.||.|-+||||||+|+.||+..||++++..+++.++.++..+ 
+T Consensus       121 g~ipVv~~~~~~~-~~~---~~~~~sD~~A~~lA~~l~A~~li~ltdv~Gv~~~~p~~~~~a~~i~~i~~~~~~~~~~~~  196 (251)
+T 2ako_A          121 GILPIINENDATA-IEE---IVFGDNDSLSAYATHFFDADLLVILSDIDGFYDKNPSEFSDAKRLEKITHIKEEWLQATI  196 (251)
+T ss_dssp             TCEEEEEECTTTC-CHH---HHBTTTHHHHHHHHHHTTCSEEEEEESSCSCBSSCTTTCTTCCBCCEESCCCGGGC----
+T ss_pred             CceEEEcCCCccc-ccc---eeecChHHHHHHHHHHhCCCEEEEEecCCceEcCCCCCCccceeeeeeccCCHHHHHHhc
+Confidence            3455666655542 243   45778999999999999999999999999999999999999999999999865444332 
+
+
+Q gi|556503834|r  261 --------GAKVLHPRTITPIAQFQIPCLIKNTGNP  288 (820)
+Q Consensus       261 --------gakvlhprtitpiaqfqipclikntgnp  288 (820)
+                              |..+.+++.+...+...+||.|.|...|
+T Consensus       197 ~~~~~~~~ggm~~k~~a~~~a~~~gi~v~I~~g~~~  232 (251)
+T 2ako_A          197 KTGSEHGTGGIVTKLKAAKFLLEHNKKMFLASGFDL  232 (251)
+T ss_dssp             -----CBSCHHHHHHHHHHHHHHTTCEEEEEESSSC
+T ss_pred             CCCCccccCChHHHHHHHHHHHHCCCeEEEecCCCc
+Confidence                    5678899999998888999999887655
+
+
+No 40
+>3wyc_A MESO-diaminopimelate D-dehydrogenase; rossmann fold, oxidoreductase; HET: NAP NES; 2.07A {Ureibacillus thermosphaericus} PDB: 3wyb_A*
+Probab=98.64  E-value=2e-11  Score=115.63  Aligned_cols=189  Identities=14%  Similarity=0.193  Sum_probs=140.8  Template_Neff=8.200
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      .+.|.+||.|.+|..+++.++++.        ++++.||.+...-....     +.|.  +. . ..+      .-..+.
+T Consensus         3 ~irI~IIG~G~iG~~~~~~l~~~~--------~~elvaV~d~~~~~~~~-----~~~~--~~-~-~~~------~d~~el   59 (334)
+T 3wyc_A            3 KIRIGIVGYGNLGRGVEAAIQQNP--------DMELVAVFTRRDPKTVA-----VKSN--VK-V-LHV------DDAQSY   59 (334)
+T ss_dssp             CEEEEEECCSHHHHHHHHHHTTCT--------TEEEEEEEESSCGGGCC-----CTTC--CE-E-EEG------GGSGGG
+T ss_pred             CcEEEEEcchHHHHHHHHHHHcCC--------CCEEEEEECCCHHHHHH-----HHcC--CC-c-Eee------CCHHHH
+Confidence            467889999999999999887642        57888887765422110     1111  00 0 000      011111
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQAVAD----QYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQ  620 (820)
+Q Consensus       545 hllnpvivdctssqavad----qyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlq  620 (820)
+                      -.-..++++||.+....+    .+..++. +.||+    |......+++.+|.-++++..+++++.+   .+.|.+..++
+T Consensus        60 l~~~DvVii~t~~~~~~~~~~~~~~~al~-~~~V~----kp~a~~~~~~~~L~~~A~~~g~~~~v~~---~~~P~~~~l~  131 (334)
+T 3wyc_A           60 KDEIDVMILCGGSATDLPEQGPYFAQYFN-TIDSF----DTHARIPDYFDAVNAAAEQSGKVAIISV---GWDPGLFSLN  131 (334)
+T ss_dssp             TTTCSEEEECCCTTTHHHHHHHHHHTTSE-EEECC----CCGGGHHHHHHHHHHHHHHHTCEEECSC---SBTTBHHHHH
+T ss_pred             hcCCCEEEEcCCchhhHHHHHHHHHHHHh-hCccc----cCCCCCHHHHHHHHHHHHHcCCEEEEEc---CCCHHHHHHH
+Confidence            133568899999987777    6666774 79999    3334567888999999999889999986   7899999999
+
+
+Q gi|556503834|r  621 NLLNAG--------------------DELMKFSGILSGSLSYI-----FGKLD-EGMSFSEATTLAREMGYTEPDPRDDL  674 (820)
+Q Consensus       621 nllnag--------------------delmkfsgilsgslsyi-----fgkld-egmsfseattlaremgytepdprddl  674 (820)
+                      +++..|                    |.+..+.|++++...+|     +.+.. ++.++++++..+.+++|.|+||+.|+
+T Consensus       132 ~~i~~g~lg~~~~~~~w~~~~s~hh~d~i~~i~Gv~~~~~~~i~~~~~l~~~~~~~~~~~~~~~~~~~~~~~e~d~~~d~  211 (334)
+T 3wyc_A          132 RLLGEVVLPVGNTYTFWGKGVSQGHSDAIRRIQGVKNAVQYTIPIDEAVNRVRSGENPELSTREKHARECFVVLEEGADP  211 (334)
+T ss_dssp             HHHHHHHCSSEEEEEEECSEECHHHHHHHHTSTTEEEEEEEEEECHHHHHHHHTTCCCCCCHHHHEEEEEEEEECTTCCH
+T ss_pred             HHHHhCCCCCCeEeecCCccCCcChhhhhHhhcCCCCcEEEEEeccchhhhccccCCcccccccceeEEEEEEecCCCCH
+Confidence            998887                    99999999999999998     44444 55788889999999999999999999
+
+
+Q gi|556503834|r  675 SGMDVARKLL  684 (820)
+Q Consensus       675 sgmdvarkll  684 (820)
+                      +|.+.+.|..
+T Consensus       212 ~~i~~~~~~~  221 (334)
+T 3wyc_A          212 AKVEHEIKTM  221 (334)
+T ss_dssp             HHHHHHHHTC
+T ss_pred             HHHHHHHHhC
+Confidence            9999887753
+
+
+No 41
+>2ap9_A NAG kinase, acetylglutamate kinase, AGK; structural genomics, protein structure initiative, NYSGXRC, PSI; 2.80A {Mycobacterium tuberculosis} SCOP: c.73.1.2
+Probab=98.57  E-value=4.2e-11  Score=110.97  Aligned_cols=106  Identities=17%  Similarity=0.187  Sum_probs=72.5  Template_Neff=8.500
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELS  258 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamels  258 (820)
+                      +....++++.|+ ..+..|+...+   ++|+.|+.+|..++|+.+-+|||+||+|++||+..+..+.+....+++.....
+T Consensus       166 L~~g~IpV~~g~-~~~~~g~~~~~---~sD~~A~~lA~~l~A~~li~ltdv~GVy~~~p~~~~~i~~i~~~~~~~~~~~~  241 (299)
+T 2ap9_A          166 VAAGRIPVVSTL-APDADGVVHNI---NADTAAAAVAEALGAEKLLMLTDIDGLYTRWPDRDSLVSEIDTGTLAQLLPTL  241 (299)
+T ss_dssp             HHTTCEEEEESE-EECTTCCEEEE---CHHHHHHHHHHHTTCSEEEEEESSSSEETTTTCTTCEESEEEHHHHHHHGGGS
+T ss_pred             HhcCCcEEEcCC-ccCCCCcEEEE---CHHHHHHHHHHHcCCCEEEEEeCchhhhcCCCCCCcchhhCCHHHHHHHHhhc
+Confidence            445677888888 56667877654   78999999999999999999999999999999877655555544455444434
+
+
+Q gi|556503834|r  259 YFGAKVLHPRTITPIAQFQI-PCLIKNTGNPQ  289 (820)
+Q Consensus       259 yfgakvlhprtitpiaqfqi-pclikntgnpq  289 (820)
+                      ..|.+ .+.+......+..+ ++.|.|...|.
+T Consensus       242 ~~gm~-~kl~aa~~a~~~gv~~v~I~~g~~~~  272 (299)
+T 2ap9_A          242 ELGMV-PKVEACLRAVIGGVPSAHIIDGRVTH  272 (299)
+T ss_dssp             CTTTH-HHHHHHHHHHHHTCSEEEEEETTSTT
+T ss_pred             cCchH-HHHHHHHHHHHcCCCeEEEecCCCCc
+Confidence            33332 23333334444555 55666655443
+
+
+No 42
+>2brx_A Uridylate kinase; UMP kinase, amino acid kinase, phosphoryl group transfer, pyrimidine biosynthesis, transferase; 2.40A {Pyrococcus furiosus} SCOP: c.73.1.3 PDB: 2ji5_A* 2bmu_A* 2bri_A*
+Probab=98.54  E-value=5.8e-11  Score=104.99  Aligned_cols=80  Identities=36%  Similarity=0.517  Sum_probs=61.3  Template_Neff=9.200
+
+Q gi|556503834|r  205 NGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFG------AKVLHPRTITPIAQFQI  278 (820)
+Q Consensus       205 ngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfg------akvlhprtitpiaqfqi  278 (820)
+                      ..+|..|+.+|..+.||.|.+|||+||+|++||+..|++++++.++++|+.++...+      ...+.+.......+..+
+T Consensus       137 ~~~D~~A~~lA~~l~A~~li~ltdv~Gv~~~~p~~~~~a~~i~~i~~~e~~~~~~~~~~~~g~~~~~d~~aa~~a~~~gv  216 (244)
+T 2brx_A          137 HTTDAVAALLAEFLKADLLVVITNVDGVYTADPKKDPTAKKIKKMKPEELLEIVGKGIEKAGSSSVIDPLAAKIIARSGI  216 (244)
+T ss_dssp             CCHHHHHHHHHHHTTCSEEEEECSSSSCBSSCTTTCTTCCBCSEECHHHHHHHHHC--------CCSCHHHHHHHHHHTC
+T ss_pred             CCchHHHHHHHHHcCCCEEEEeecCCccccCCCCCCCCCeEeeEeCHHHHHHHHhcCCcCCCCCCcchHHHHHHHHHCCC
+Confidence            368999999999999999999999999999999999999999999999976655432      12223344444444555
+
+
+Q gi|556503834|r  279 PCLIKN  284 (820)
+Q Consensus       279 pclikn  284 (820)
+                      ++.|-|
+T Consensus       217 ~v~Ii~  222 (244)
+T 2brx_A          217 KTIVIG  222 (244)
+T ss_dssp             CEEEEC
+T ss_pred             eEEEEc
+Confidence            665554
+
+
+No 43
+>2buf_A Acetylglutamate kinase; acetyglutamate kinase, ADP, arginine biosynthesis, FEED-BACK inhibition, hexamer, transferase; HET: NLG ADP; 2.95A {Pseudomonas aeruginosa} SCOP: c.73.1.2
+Probab=98.37  E-value=3.3e-10  Score=104.83  Aligned_cols=98  Identities=20%  Similarity=0.230  Sum_probs=71.9  Template_Neff=8.600
+
+Q gi|556503834|r  181 ADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYF  260 (820)
+Q Consensus       181 adhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyf  260 (820)
+                      ...+.++.|+ +.+..|+..   ..++|+.|+.||..+.|+.+-+|||+||+|+.||+      +++.+++.|+.++...
+T Consensus       175 ~g~IpVv~~~-~~~~~g~~~---~~~sD~~A~~lA~~l~A~~li~ltdv~Gv~~~dp~------~i~~i~~~e~~~l~~~  244 (300)
+T 2buf_A          175 GDFIPVIAPI-GVGSNGESY---NINADLVAGKVAEALKAEKLMLLTNIAGLMDKQGQ------VLTGLSTEQVNELIAD  244 (300)
+T ss_dssp             TTCEEEEEEE-EECTTSCEE---ECCHHHHHHHHHHHHTCSEEEEEESSSCCBCTTSC------BCCEECHHHHHHHHHT
+T ss_pred             CCCEEEEcCC-ccCCCCCEE---EeCHHHHHHHHHHHcCCCEEEEEeCCccccCCCCc------ccccCCHHHHHHHHHc
+Confidence            3456677887 445667654   55899999999999999999999999999999985      5577788887766544
+
+
+Q gi|556503834|r  261 G----AKVLHPRTITPIAQFQIP-CLIKNTGNP  288 (820)
+Q Consensus       261 g----akvlhprtitpiaqfqip-clikntgnp  288 (820)
+                      +    .-..+.+.....++..++ +.|-|...|
+T Consensus       245 ~~~~ggm~~kl~~a~~a~~~gv~~v~I~~g~~~  277 (300)
+T 2buf_A          245 GTIYGGMLPKIRCALEAVQGGVTSAHIIDGRVP  277 (300)
+T ss_dssp             TCSCTTHHHHHHHHHHHHHTTCSEEEEEETTST
+T ss_pred             CCCCCchHHHHHHHHHHHHcCCCEEEEecCCCC
+Confidence            2    233445666666766676 777766554
+
+
+No 44
+>3d2m_A Putative acetylglutamate synthase; protein-COA-Glu ternary complex, transferase; HET: COA GLU; 2.21A {Neisseria gonorrhoeae} PDB: 2r8v_A* 3b8g_A* 2r98_A* 3d2p_A* 4i49_A*
+Probab=98.36  E-value=3.5e-10  Score=105.96  Aligned_cols=93  Identities=24%  Similarity=0.160  Sum_probs=70.7  Template_Neff=9.900
+
+Q gi|556503834|r  183 HMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGA  262 (820)
+Q Consensus       183 hmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfga  262 (820)
+                      .++++.+ .+.+.+|+...++   +|+.|+.+|+.+.|+.+-+||||||+|+.||      ++++.++++|+-++...++
+T Consensus       186 ~ipVv~~-~~~~~~g~~~~i~---sD~~A~~lA~~l~a~~li~ltdv~Gv~~~d~------~~i~~i~~~e~~~l~~~~~  255 (456)
+T 3d2m_A          186 NIVWMPP-LGHSYGGKTFNLD---MVQAAASVAVSLQAEKLVYLTLSDGISRPDG------TLAETLSAQEAQSLAEHAA  255 (456)
+T ss_dssp             CEEEECS-EEECTTSCEEECC---HHHHHHHHHHHHTCSEEEEEESSSSCBCTTS------CBCSEEEHHHHHHHHTTCC
+T ss_pred             CEEEECC-ceECCCCCEEeeC---HHHHHHHHHHHCCCCEEEEEeCchhhccCCC------CcccccCHHHHHHHHHhhh
+Confidence            3344443 4456678887775   9999999999999999999999999999987      5788899999877877777
+
+
+Q gi|556503834|r  263 KVLHPR--TITPIAQFQIP-CLIKNT  285 (820)
+Q Consensus       263 kvlhpr--titpiaqfqip-cliknt  285 (820)
+                      ...+|+  ...+..+..++ +.|-|.
+T Consensus       256 ~~~~~k~~a~~~a~~~g~~~v~I~~~  281 (456)
+T 3d2m_A          256 SETRRLISSAVAALEGGVHRVQILNG  281 (456)
+T ss_dssp             HHHHHHHHHHHHHHHTTCSEEEEEET
+T ss_pred             chHHHHHHHHHHHHHhCCCEEEeCCC
+Confidence            677766  45555555565 555553
+
+
+No 45
+>3bio_A Oxidoreductase, GFO/IDH/MOCA family; structural genomics, MCSG, PSI-2, GFO/IDH/MO family, protein structure initiative; HET: MSE EPE; 1.80A {Porphyromonas gingivalis}
+Probab=98.34  E-value=4.2e-10  Score=100.83  Aligned_cols=183  Identities=15%  Similarity=0.183  Sum_probs=115.9  Template_Neff=9.700
+
+Q gi|556503834|r  457 QMLFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGR  536 (820)
+Q Consensus       457 qmlfntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgr  536 (820)
+                      ||..+.++.+.|.++|.|.+|..+++.+.++.        ++.+++|.+...-..+   -..       ...+-.-++..
+T Consensus         1 ~~~~~~~~~~~v~iiG~G~~G~~~~~~l~~~~--------~~~lv~v~d~~~~~~~---~~~-------~~~~~~~~~~~   62 (304)
+T 3bio_A            1 SNAMTDDKKIRAAIVGYGNIGRYALQALREAP--------DFEIAGIVRRNPAEVP---FEL-------QPFRVVSDIEQ   62 (304)
+T ss_dssp             -------CCEEEEEECCSHHHHHHHHHHHHCT--------TEEEEEEECC----------CC-------TTSCEESSGGG
+T ss_pred             CCcccCCCCCEEEEECChHHHHHHHHHHHcCC--------CcEEEEEEcCCHHHHh---hhc-------cCCceeCCHHH
+Confidence            46677788899999999999999999887642        4566666554321110   000       00000001111
+
+
+Q gi|556503834|r  537 LIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVI  616 (820)
+Q Consensus       537 lirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvi  616 (820)
+                      +        .-..++++||.+....+.+..+++.|.|+++.+ +..+...+.+++|.-++++....++|.++...|+   
+T Consensus        63 l--------~~~DvVi~~t~~~~~~~~~~~~l~~G~~vv~~~-~~~~~~~e~~~~l~~~a~~~~~~~~~~~~~~pg~---  130 (304)
+T 3bio_A           63 L--------ESVDVALVCSPSREVERTALEILKKGICTADSF-DIHDGILALRRSLGDAAGKSGAAAVIASGWDPGS---  130 (304)
+T ss_dssp             S--------SSCCEEEECSCHHHHHHHHHHHHTTTCEEEECC-CCGGGHHHHHHHHHHHHHHHTCEEECSCBBTTBH---
+T ss_pred             h--------cCCCEEEECCCcHHHHHHHHHHHHCCCeEEEcc-ccccCCHHHHHHHHHHHHHcCCEEEEeCCcChHH---
+Confidence            1        334689999999999999999999999999855 3444445778888877777778889999988887   
+
+
+Q gi|556503834|r  617 ENLQNLLNAGDELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDD  673 (820)
+Q Consensus       617 enlqnllnagdelmkfsgilsgslsyifgkldegmsfseattlaremgytepdprdd  673 (820)
+                      ..|.+++..+..+.......++...    ....+..++.+..+|..+|+++|+|+++
+T Consensus       131 ~~l~~~l~~~~~~~~v~~~~~~~~~----~~~~~~~~~~~~~~a~~lg~~~~~~~~~  183 (304)
+T 3bio_A          131 DSVVRTLMQAIVPKGITYTNFGPGM----SMGHTVAVKAIDGVKAALSMTIPLGTGV  183 (304)
+T ss_dssp             HHHHHHHHHHHSCEEEEEEEECSEE----CHHHHHHHHTSTTEEEEEEEEEECSTTC
+T ss_pred             HHHHHHHHhcCCcceEEEEEecCCC----CCCcchHHHHHHHHHhhcCCcccCCCCc
+Confidence            5677777554544444443333321    1112246677888999999999998764
+
+
+No 46
+>2bty_A Acetylglutamate kinase; N-acetyl-L-glutamate kinase, amino acid kinase, phosphoryl group transfer, arginine metabolism, transferase; HET: ARG NLG; 2.75A {Thermotoga maritima} SCOP: c.73.1.2
+Probab=98.33  E-value=4.7e-10  Score=102.07  Aligned_cols=71  Identities=32%  Similarity=0.365  Sum_probs=59.0  Template_Neff=8.900
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELS  258 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamels  258 (820)
+                      +..+.++++.|+ +-++.|+...+   ++|+.|+.+|..+.|+.|-+|||+||+|+ ||      ++++.++|+|+.++.
+T Consensus       157 L~~g~IpVv~~~-~~~~~g~~~~~---~sD~~A~~lA~~l~A~~li~ltdv~Gv~~-d~------~~i~~i~~~e~~~l~  225 (282)
+T 2bty_A          157 IENDYIPVIAPV-GIGEDGHSYNI---NADTAAAEIAKSLMAEKLILLTDVDGVLK-DG------KLISTLTPDEAEELI  225 (282)
+T ss_dssp             HHTTCEEEEESE-EECSSSCEEEC---CHHHHHHHHHHHHTCSEEEEEESSSSCEE-TT------EECCEECHHHHHHHH
+T ss_pred             HhCCCEEEECCe-EECCCCCEEEE---CHHHHHHHHHHHhCCCEEEEEeCCccccc-CC------ccccccCHHHHHHHH
+Confidence            445677788886 55667877655   79999999999999999999999999998 76      588899999988776
+
+
+Q gi|556503834|r  259 YF  260 (820)
+Q Consensus       259 yf  260 (820)
+                      ..
+T Consensus       226 ~~  227 (282)
+T 2bty_A          226 RD  227 (282)
+T ss_dssp             TT
+T ss_pred             Hc
+Confidence            54
+
+
+No 47
+>2v5h_A Acetylglutamate kinase; amino-acid biosynthesis, transcription regulation, transfera cyanobacteria, transcription; HET: NLG; 2.75A {Synechococcus elongatus} PDB: 2jj4_A*
+Probab=98.29  E-value=6.8e-10  Score=104.68  Aligned_cols=101  Identities=21%  Similarity=0.317  Sum_probs=72.9  Template_Neff=8.200
+
+Q gi|556503834|r  182 DHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYF-  260 (820)
+Q Consensus       182 dhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyf-  260 (820)
+                      +.+.++.|+ +-++.|+...+   ++|+.|+.+|..+.||.|-+|||+||+|+ ||+. |+ ++++.++|+|+.++... 
+T Consensus       187 g~IpVi~g~-~~d~~g~~~~l---~sD~~A~~lA~~l~A~~li~ltdv~Gvy~-dp~~-~~-~~i~~is~~e~~~l~~~~  259 (321)
+T 2v5h_A          187 GYIPVISSV-AADENGQSFNI---NADTVAGEIAAALNAEKLILLTDTRGILE-DPKR-PE-SLIPRLNIPQSRELIAQG  259 (321)
+T ss_dssp             TCEEEEESE-EECTTSCEEEC---CHHHHHHHHHHHTTCSEEEEEESSSSCBS-STTC-TT-CBCCEEEHHHHHHHHHTT
+T ss_pred             CCEEEEcCc-ccCCCCcEEee---CHHHHHHHHHHHcCCCEEEEEeCChhhhc-CCCC-cc-chhhhCCHHHHHHHHHcC
+Confidence            445566674 44566765555   78999999999999999999999999999 8886 55 89999999998776533 
+
+
+Q gi|556503834|r  261 ---GAKVLHPRTITPIAQFQIP-CLIKNTGNPQ  289 (820)
+Q Consensus       261 ---gakvlhprtitpiaqfqip-clikntgnpq  289 (820)
+                         |.-....+...+..+..+| +.|-|...|.
+T Consensus       260 ~~tggm~~kl~aa~~a~~~gi~~v~I~ng~~~~  292 (321)
+T 2v5h_A          260 IVGGGMIPKVDCCIRSLAQGVRAAHIIDGRIPH  292 (321)
+T ss_dssp             SSCTTHHHHHHHHHHHHHTTCSEEEEEETTSTT
+T ss_pred             CCCCcHHHHHHHHHHHHHcCCCEEEEEcCCCCc
+Confidence               2222234555554455676 6777665553
+
+
+No 48
+>3l76_A Aspartokinase; allostery, ACT domains, kinase transferase; HET: LYS; 2.54A {Synechocystis}
+Probab=98.15  E-value=2.4e-09  Score=105.66  Aligned_cols=153  Identities=35%  Similarity=0.481  Sum_probs=127.7  Template_Neff=9.300
+
+Q gi|556503834|r  306 VKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQS--------SSEYSISFCVPQSDCVRAERAMQEE  377 (820)
+Q Consensus       306 vkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqs--------sseysisfcvpqsdcvraeramqee  377 (820)
+                      +++++--.+.++.++.|  |....|.++++|..+.+..|.+.+++++        ++..+++|+++..|..++.+.+++ 
+T Consensus       435 i~~i~~~~~~alIsl~~--~~~~~~~~~~v~~~L~~~~I~v~~i~~~~~~~~~~~~~~~~~~~~v~~~d~~~~~~~L~~-  511 (600)
+T 3l76_A          435 VRGVALDQDQAQIAIRH--VPDRPGMAAQLFTALAEANISVDMIIQSQRCRINQGTPCRDIAFMVAEGDSSQAEAILQP-  511 (600)
+T ss_dssp             CCEEEEECSEEEEEEEE--EESSTTHHHHHHHHHHHTTCCCCEEEEEEECCCSSSSCEEEEEEEEEHHHHHHHHHHHHH-
+T ss_pred             cceEEEeCCeEEEEEec--CCCCccHHHHHHHHHHHcCceEEEEecccccccccCCccceEEEEecHHHHHHHHHHHHH-
+Confidence            57788889999999954  7777899999999999999999988854        456788999998887777664432 
+
+
+Q gi|556503834|r  378 FYLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQ  457 (820)
+Q Consensus       378 fylelkeglleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthq  457 (820)
+                         .++...+....+.+.+++++++|.+++.-.++.++++++|+.++||+..+.+  ++.+++++++.+|....++.-|+
+T Consensus       512 ---~~~~~~~~~~~~~~~~alisvvg~~~~~~~~~~~~i~~~L~~~~i~i~~~~~--s~~sis~~v~~~~~~~a~~~Lh~  586 (600)
+T 3l76_A          512 ---LIKDWLDAAIVVNKAIAKVSIVGSGMIGHPGVAAHFFAALAQENINIEMIAT--SEIKISCVVPQDRGVDALKAAHS  586 (600)
+T ss_dssp             ---HTTTSTTCEEEEECCEEEEEEECGGGTTCTTHHHHHHHHHHTTTCCCCEEEE--CSSEEEEEEEGGGHHHHHHHHHH
+T ss_pred             ---HHhhcCCceEEeeCCEEEEEEEcCCCCCCCCHHHHHHHHHHhCCCcEEEEEc--ccCeEEEEEeHHHHHHHHHHHHH
+Confidence               1222224456788999999999999999999999999999999999988884  77899999999999999999999
+
+
+Q gi|556503834|r  458 MLFNTDQVI  466 (820)
+Q Consensus       458 mlfntdqvi  466 (820)
+                      .++..+.-+
+T Consensus       587 ~~~~~~~~~  595 (600)
+T 3l76_A          587 AFNLAGTKT  595 (600)
+T ss_dssp             HTTTTSSCC
+T ss_pred             HHhcCCCcc
+Confidence            999887643
+
+
+No 49
+>3k4o_A Isopentenyl phosphate kinase; small molecule kinase, ATP-binding, transferase, methanocald jannaschii, isopentenyl monophosphate; 2.05A {Methanocaldococcus jannaschii} PDB: 3k4y_A* 3k52_A* 3k56_A*
+Probab=98.13  E-value=2.7e-09  Score=95.19  Aligned_cols=139  Identities=18%  Similarity=0.174  Sum_probs=95.6  Template_Neff=9.300
+
+Q gi|556503834|r  135 AGVLEARGHNVTVIDPVEKLLAVGHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVL  214 (820)
+Q Consensus       135 agvlearghnvtvidpvekllavghylestvdiaestrriaasripadhmvlmagftagnekgelvvlgrngsdysaavl  214 (820)
+                      ...|..+|.++..++|..-. ..|...  .++    . +.....+....+.++.|+..-++.|.+   .+.++|+.|+.+
+T Consensus       104 ~~~l~~~gi~~~~l~~~~~~-~~~~~~--~~~----~-~~l~~~l~~g~ipV~~g~~~~~~~~~~---~~~~sD~~A~~l  172 (266)
+T 3k4o_A          104 IDTLQSYDIPAVSIQPSSFV-VFGDKL--IFD----T-SAIKEMLKRNLVPVIHGDIVIDDKNGY---RIISGDDIVPYL  172 (266)
+T ss_dssp             HHHHHTTTCCEEEECGGGTC-EESSSC--BCC----C-HHHHHHHHTTCEEEEECEEEEESSSCE---EEECHHHHHHHH
+T ss_pred             HHHHHHCCCCEEEechHHee-eecCcc--ccc----H-HHHHHHHHCCCeEEecCCceECCCCce---eeeCHHHHHHHH
+Confidence            44566677777777765421 112110  011    1 111222344556677776666655543   567899999999
+
+
+Q gi|556503834|r  215 AACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFGAKVLHPR-----TITPIAQFQIPCLIKNTGNPQ  289 (820)
+Q Consensus       215 aaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfgakvlhpr-----titpiaqfqipclikntgnpq  289 (820)
+                      |..++||.|-+|||+||+|+.||.    .+.++..+|++..++.. +.+..+++     .+....+..+++.|-|..+|.
+T Consensus       173 A~~l~A~~li~~tdv~Gvy~~~~~----~~~i~~~~~~~~~~~~~-~~~~~d~~ggm~~kl~~a~~~~~~v~I~~~~~~~  247 (266)
+T 3k4o_A          173 ANELKADLILYATDVDGVLIDNKP----IKRIDKNNIYKILNYLS-GSNSIDVTGGMKYKIEMIRKNKCRGFVFNGNKAN  247 (266)
+T ss_dssp             HHHHTCSEEEEEESSSSSBSSSSB----CSEECTTTHHHHHHHHH-STTCSCCSSHHHHHHHHHHHTTCEEEEEETTSTT
+T ss_pred             HHhcCCCEEEEEcCCCccccCCcc----ccccchhhHHHHHHHhc-CCCCcccCCcHHHHHHHHHHcCCeEEEEECCCcc
+Confidence            999999999999999999999953    55566777888777655 77777776     688888888999998877664
+
+
+No 50
+>1f06_A MESO-diaminopimelate D-dehydrogenase; enzyme-NADPH-inhibitor ternary complex, oxidoreductase; HET: NDP 2NP; 2.10A {Corynebacterium glutamicum} SCOP: c.2.1.3 d.81.1.3 PDB: 1dap_A* 2dap_A* 3dap_A*
+Probab=98.08  E-value=4.1e-09  Score=96.91  Aligned_cols=239  Identities=16%  Similarity=0.198  Sum_probs=150.9  Template_Neff=9.100
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      .+.|.+||.|.+|..+.+.|.++.        ++++.+|.+...-..       ++|.     .....++..++      
+T Consensus         3 ~~~IgiiG~G~vG~~~~~~L~~~~--------~~~lv~v~d~~~~~~-------~~~~-----~~~~~d~~~l~------   56 (320)
+T 1f06_A            3 NIRVAIVGYGNLGRSVEKLIAKQP--------DMDLVGIFSRRATLD-------TKTP-----VFDVADVDKHA------   56 (320)
+T ss_dssp             CEEEEEECCSHHHHHHHHHHTTCS--------SEEEEEEEESSSCCS-------SSSC-----EEEGGGGGGTT------
+T ss_pred             CcEEEEECCcHHHHHHHHHHHcCC--------CCEEEEEEeCCHHHh-------ccCC-----CcccCCHHHHh------
+Confidence            467889999999999999887543        455656555433210       1111     01111222222      
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQA-VADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGL-PVIENLQNL  622 (820)
+Q Consensus       545 hllnpvivdctssqa-vadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgagl-pvienlqnl  622 (820)
+                       .-.-++++|+.+.. ..+.+..+++.|.||+  +++..+++.+++.++..++++..+.+++++..-.|+ |++..+...
+T Consensus        57 -~~~DvVv~~~~~~~~~~~~~~~al~~G~~v~--~~~~~~~~~~~~~~l~~~a~~~~~~~~~~~g~~pg~~~~~~~l~~~  133 (320)
+T 1f06_A           57 -DDVDVLFLCMGSATDIPEQAPKFAQFACTVD--TYDNHRDIPRHRQVMNEAATAAGNVALVSTGWDPGMFSINRVYAAA  133 (320)
+T ss_dssp             -TTCSEEEECSCTTTHHHHHHHHHTTTSEEEC--CCCCGGGHHHHHHHHHHHHHHHTCEEECSCSBTTBHHHHHHHHHHH
+T ss_pred             -hcCCEEEEeCCchhhHHHHHHHHHHcCCEEE--EcCCcCCCHHHHHHHHHHHHHcCCEEEEecCcCcchhHHHHHHHHh
+Confidence             12448899999887 7888889999999983  566666678899999998886666666666554444 777777665
+
+
+Q gi|556503834|r  623 LNAGDEL-MKFS--GILSGSLSYIF------GKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMD-VARKLLILARETGR  692 (820)
+Q Consensus       623 lnagdel-mkfs--gilsgslsyif------gkldegmsfseattlaremgytepdprddlsgmd-varkllilaretgr  692 (820)
+                      .. .+++ ..+.  |+.+|...|+.      .....|++++++...+++     +++ .++++.+ -.|.++..+++   
+T Consensus       134 ~~-~~~i~~~i~g~g~~~g~~~~~~~~~~v~~~~~~g~~~~~~~~~~~~-----~~~-~~l~~~~~~~r~~~~~~~~---  203 (320)
+T 1f06_A          134 VL-AEHQQHTFWGPGLSQGHSDALRRIPGVQKAVQYTLPSEDALEKARR-----GEA-GDLTGKQTHKRQCFVVADA---  203 (320)
+T ss_dssp             HC-SSEEEEEEECSEECHHHHHHHHTSTTCSEEEEEEEECHHHHHHHHH-----TCC-TTCCHHHHEEEEEEEECCG---
+T ss_pred             cc-CCCceEEEEccchhhhhHHHHhcCcchhhhcccCCCHHHHHHHhhc-----CCC-ccCccccceeeeEEEEecc---
+Confidence            43 4778 8999  99999998854      566778888887766664     344 5566443 36788888776   
+
+
+Q gi|556503834|r  693 ELELADIEIEPVLP---AEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNID  750 (820)
+Q Consensus       693 eleladieiepvlp---aefnaegdvaafmanlsqlddlfaarvakardegkvlryvgnid  750 (820)
+                       .+..+  |+..++   ..|........+....     -+..+..+..-.+.++|+.|..+
+T Consensus       204 -~~~~~--i~~~i~~~~~~~~~~~~~v~~i~~~-----~~~~~~~~~~~~~~~~~~~~~~~  256 (320)
+T 1f06_A          204 -ADHER--IENDIRTMPDYFVGYEVEVNFIDEA-----TFDSEHTGMPHGGHVITTGDTGG  256 (320)
+T ss_dssp             -GGHHH--HHHHHHTCTTTTTTSEEEEEECCHH-----HHHHHSSCCCEEEEEEEEEESSS
+T ss_pred             -CCHHH--HHHHHHhCcCcccCCCeEEEEECcH-----hhHhhcCCCCCceEEEEEEecCC
+Confidence             22222  233333   2332211111222111     13345556677889999998876
+
+
+No 51
+>3ll5_A Gamma-glutamyl kinase related protein; alternate mevalonate pathway, isopentenyl phsophate kinase, beta-alpha sandwich fold; HET: MSE ADP IPE ATP IP8; 1.99A {Thermoplasma acidophilum} PDB: 3lkk_A*
+Probab=97.99  E-value=8.5e-09  Score=91.46  Aligned_cols=105  Identities=22%  Similarity=0.268  Sum_probs=70.1  Template_Neff=9.200
+
+Q gi|556503834|r  181 ADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAM-ELSY  259 (820)
+Q Consensus       181 adhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeam-elsy  259 (820)
+                      ...++++.|+....+ |  ..++...+|+.|+.+|.+++++-|-+|||+||+|++||+..|++++++.+++.|+. +++.
+T Consensus       124 ~g~ipV~~g~~~~~~-~--~~~~~~~~D~~a~~lA~~l~a~~li~~tdv~Gv~~~~p~~~~~~~~i~~i~~~~~~~~~~~  200 (249)
+T 3ll5_A          124 AGFVPVSYGDVYIKD-E--HSYGIYSGDDIMADMAELLKPDVAVFLTDVDGIYSKDPKRNPDAVLLRDIDTNITFDRVQN  200 (249)
+T ss_dssp             TTCEEEEECEEEEEE-T--TEEEEECHHHHHHHHHHHHCCSEEEEEESSSSCBSSCTTTCTTCCBCCEECCCC-------
+T ss_pred             CCCEEEecCCceecC-c--ccCCccChhHHHHHHHHhcCCCEEEEEecCCeeECCCCCCCccceEehhcchhhhccccCC
+Confidence            355666777765433 3  23455588999999999999999999999999999999999999999999998754 3444
+
+
+Q gi|556503834|r  260 FGAKVLHPRT---ITPIAQFQIPCLIKNTGNP  288 (820)
+Q Consensus       260 fgakvlhprt---itpiaqfqipclikntgnp  288 (820)
+                      ++..-.+|.-   +....+..+++.|-|...|
+T Consensus       201 ~~~ggm~~kl~~~~~~~~~~~~~v~I~~g~~~  232 (249)
+T 3ll5_A          201 DVTGGIGKKFESMVKMKSSVKNGVYLINGNHP  232 (249)
+T ss_dssp             ------HHHHHHHHHHHTTCTTCEEEEETTSG
+T ss_pred             eeECCHHHHHHHHHHHHHhCCCcEEEEECCCc
+Confidence            5444445521   1122335567777776554
+
+
+No 52
+>4jz8_A Carbamate kinase; modified rossmann fold, ATP carbamate phosphotransferase, AD carbamoyl phosphate, transferase; HET: CIT; 2.10A {Giardia lamblia} PDB: 3kzf_A* 4jz7_A* 4jz9_A* 4olc_A*
+Probab=97.99  E-value=8.6e-09  Score=96.86  Aligned_cols=96  Identities=25%  Similarity=0.277  Sum_probs=71.6  Template_Neff=8.300
+
+Q gi|556503834|r  184 MVLMAGFTAG---NEK----GELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAME  256 (820)
+Q Consensus       184 mvlmagftag---nek----gelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeame  256 (820)
+                      .|+..++...   ++.    |+.   ...++|+.|+.+|.++.|+.+-+|||+||+|+.|+  .|++++++.++++|+.+
+T Consensus       190 ~vI~~~g~~~P~~~~~d~~~~~~---~~~~~D~~A~~lA~~l~A~~li~ltdv~Gv~~~~~--~~~a~~i~~is~~e~~~  264 (317)
+T 4jz8_A          190 LVICTNGGGIPCKRENKVISGVD---AVIDKDLATSLLAKTLNSDYLMILTDVLNACINYK--KPDERKLEEIKLSEILA  264 (317)
+T ss_dssp             EEEEEETSCEEEEEETTEEEECS---CCCCHHHHHHHHHHHTTCSEEEEEESSSSCEESTT--STTCEECCEEEHHHHHH
+T ss_pred             eEEEeCccCccccccCCcccceE---eccCHHHHHHHHHHHcCCCEEEEEeCCCccccCCC--CCCCccCccCCHHHHHH
+Confidence            5666665543   232    333   57789999999999999999999999999999995  58899999999999887
+
+
+Q gi|556503834|r  257 LSY---FGAKVLHP--RTITPIAQFQIP-CLIKN  284 (820)
+Q Consensus       257 lsy---fgakvlhp--rtitpiaqfqip-clikn  284 (820)
+                      +..   ++...++|  +.+...++..++ +.|-|
+T Consensus       265 l~~~~~~~~ggm~~Kl~aa~~a~~~gv~~v~I~~  298 (317)
+T 4jz8_A          265 LEKDGHFAAGSMGPKVRAAIEFTQATGKMSIITS  298 (317)
+T ss_dssp             HHHTTSSSSSTTHHHHHHHHHHHHHHCCEEEEEE
+T ss_pred             HHhcCCCCCCccHHHHHHHHHHHHcCCCEEEEcC
+Confidence            653   33344544  556666666677 66655
+
+
+No 53
+>3l76_A Aspartokinase; allostery, ACT domains, kinase transferase; HET: LYS; 2.54A {Synechocystis}
+Probab=97.90  E-value=1.6e-08  Score=99.76  Aligned_cols=165  Identities=26%  Similarity=0.431  Sum_probs=126.1  Template_Neff=9.300
+
+Q gi|556503834|r  306 VKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELKE-  384 (820)
+Q Consensus       306 vkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelke-  384 (820)
+                      ..-++.-+|+++.++.|.+|....|.++++|.++++..|.+.++++  ++++++|+++..+..++.+...++|..++.. 
+T Consensus       346 ~~~i~~~~~~alIsi~g~~~~~~~~~~~~i~~~L~~~~i~i~~i~~--s~~sis~~v~~~~~~~a~~~l~~~~~~~~~~~  423 (600)
+T 3l76_A          346 EAEIIVEKGIAKIAIAGAGMIGRPGIAAKMFKTLADVGVNIEMIST--SEVKVSCVIDQRDADRAIAALSNAFGVTLSPP  423 (600)
+T ss_dssp             SSEEEEECSEEEEEEECGGGTTCTTHHHHHHHHHHHTTCCCCEEEE--CSSEEEEEEEGGGHHHHHHHHHHHTTCCBCCC
+T ss_pred             cceeEEeCCeeEEEEECCccccCcchHHHHHHHHHhCCCCEEEEec--CCCeEEEEEehhHHHHHHHHHHHHHhhccccc
+Confidence            3446667899999999999998889999999999999999999885  5889999999999988888888877654432 
+
+
+Q gi|556503834|r  385 ---------GLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIA--------QGSSERSISVVVNNDD  447 (820)
+Q Consensus       385 ---------glleplavterlaiisvvgdgmrtlrgisakffaalaraninivaia--------qgssersisvvvnndd  447 (820)
+                               .......+.+.++.|++.+  +..--++.++.|..|.+++||+..+.        |+++..+++++++..|
+T Consensus       424 ~~~~~~~~~~~i~~i~~~~~~alIsl~~--~~~~~~~~~~v~~~L~~~~I~v~~i~~~~~~~~~~~~~~~~~~~~v~~~d  501 (600)
+T 3l76_A          424 KNQTDTSHLPAVRGVALDQDQAQIAIRH--VPDRPGMAAQLFTALAEANISVDMIIQSQRCRINQGTPCRDIAFMVAEGD  501 (600)
+T ss_dssp             CCCCC---CCSCCEEEEECSEEEEEEEE--EESSTTHHHHHHHHHHHTTCCCCEEEEEEECCCSSSSCEEEEEEEEEHHH
+T ss_pred             ccCCccccccccceEEEeCCeEEEEEec--CCCCccHHHHHHHHHHHcCceEEEEecccccccccCCccceEEEEecHHH
+Confidence                     2245567888999999954  55555888899999999999998887        5567788999998877
+
+
+Q gi|556503834|r  448 ATTGVRVTHQML--------FNTDQVIEVFVIGVG  474 (820)
+Q Consensus       448 attgvrvthqml--------fntdqvievfvigvg  474 (820)
+                      ....++.-|.-+        -..+.+-.+-++|.|
+T Consensus       502 ~~~~~~~L~~~~~~~~~~~~~~~~~~alisvvg~~  536 (600)
+T 3l76_A          502 SSQAEAILQPLIKDWLDAAIVVNKAIAKVSIVGSG  536 (600)
+T ss_dssp             HHHHHHHHHHHTTTSTTCEEEEECCEEEEEEECGG
+T ss_pred             HHHHHHHHHHHHhhcCCceEEeeCCEEEEEEEcCC
+Confidence            655554433211        122334555666654
+
+
+No 54
+>3wwn_A Putative acetylglutamate kinase-like protein; zinc finger, amino acid kinase, metal binding protein-transf complex; 1.85A {Thermus thermophilus HB27} PDB: 3wwm_A 3u6u_A
+Probab=97.90  E-value=1.7e-08  Score=91.33  Aligned_cols=100  Identities=13%  Similarity=0.137  Sum_probs=73.1  Template_Neff=8.900
+
+Q gi|556503834|r  182 DHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFG  261 (820)
+Q Consensus       182 dhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfg  261 (820)
+                      ..+.++.|+.. +..|+.   .+..+|+.|+.+|..++++-+-+|||+||+|++||+   ++++++.+++.|+-++..-+
+T Consensus       150 g~ipVv~~~~~-~~~~~~---~~~~sD~~A~~lA~~l~a~~li~ltdv~Gv~~~~p~---~~~~i~~i~~~e~~~~~~~~  222 (269)
+T 3wwn_A          150 GYLPVLTPPAL-SYENEA---INTDGDQIAALLATLYGAEALVYLSNVPGLLARYPD---EASLVREIPVERIEDPEYLA  222 (269)
+T ss_dssp             TCEEEEECCEE-ETTSCE---EBCCHHHHHHHHHHHHTCSEEEEEESSSSCBTTTTC---GGGBCCEECCCSSSCCC---
+T ss_pred             CceEEEcCCcC-CCCCCe---eeeCHHHHHHHHHHHcCCCEEEEEeCCceeecCCCC---CccccccCCHHHHHHHHhcC
+Confidence            44566777733 345553   567899999999999999999999999999999998   67899999999876654422
+
+
+Q gi|556503834|r  262 ----AKVLHPRTITPIAQFQI-PCLIKNTGNP  288 (820)
+Q Consensus       262 ----akvlhprtitpiaqfqi-pclikntgnp  288 (820)
+                          .-....+......+..+ ++.|-|...|
+T Consensus       223 ~~~ggm~~kl~aa~~a~~~gi~~v~I~~g~~~  254 (269)
+T 3wwn_A          223 LAQGRMKRKVMGAVEAVRGGVKRVVFADARVE  254 (269)
+T ss_dssp             ---CHHHHHHHHHHHHHHTTCSCEEEEETTSS
+T ss_pred             CcCCCcHHHHHHHHHHHHcCCCEEEEecCCCc
+Confidence                22224455566667777 6777776655
+
+
+No 55
+>2j5v_A Glutamate 5-kinase; proline biosynthesis, gamma glutamyl kinase, amino-acid biosynthesis, transferase, feedback regulation, PUA domain; HET: RGP; 2.5A {Escherichia coli} PDB: 2j5t_A* 2w21_A
+Probab=97.67  E-value=8.1e-08  Score=90.71  Aligned_cols=88  Identities=25%  Similarity=0.345  Sum_probs=42.7  Template_Neff=8.800
+
+Q gi|556503834|r  202 LGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSM-SYQEAMELSY------F--GAKVLHPRTITP  272 (820)
+Q Consensus       202 lgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksm-syqeamelsy------f--gakvlhprtitp  272 (820)
+                      ++.+.+|+.|+.+|..+.||-+-+|||+||+|+.||+..|++++++.+ ||+|+.++..      +  |.-....+....
+T Consensus       144 ~~v~~~D~~A~~lA~~l~A~~Li~ltdv~Gv~~~~p~~~~~a~~i~~i~s~~e~~~~~~~~~~~~~~~gGm~~Kl~aa~~  223 (367)
+T 2j5v_A          144 IKVGDNDNLSALAAILAGADKLLLLTDQKGLYTADPRSNPQAELIKDVYGIDDALRAIAGDSVSGLGTGGMSTKLQAADV  223 (367)
+T ss_dssp             GCCCSHHHHHHHHHHHHTCSEEEEEECC------------------------------------------CHHHHHHHHH
+T ss_pred             eeecChHHHHHHHHHhcCCCEEEEEecccceEeCCCCCCccceEEEEecCccHHHHhhhccccCCcCcCcHHHHHHHHHH
+Confidence            566789999999999999999999999999999999999999999999 6998876532      1  211122245666
+
+
+Q gi|556503834|r  273 IAQFQIPCLIKNTGNPQ  289 (820)
+Q Consensus       273 iaqfqipclikntgnpq  289 (820)
+                      .++..+|+.|.|..+|.
+T Consensus       224 a~~~Gv~~~I~~g~~~~  240 (367)
+T 2j5v_A          224 ACRAGIDTIIAAGSKPG  240 (367)
+T ss_dssp             HHHTTCEEEEEETTSTT
+T ss_pred             HHHcCCcEEEEeCCCcc
+Confidence            67778888888876663
+
+
+No 56
+>2we5_A Carbamate kinase 1; arginine catabolism, arginine metabolism, ATP synthesys, open alpha/beta sheet, phosphotransferase, transferase; HET: ADP; 1.39A {Enterococcus faecalis} PDB: 1b7b_A 2we4_A*
+Probab=97.63  E-value=1e-07  Score=90.23  Aligned_cols=77  Identities=27%  Similarity=0.314  Sum_probs=63.0  Template_Neff=7.900
+
+Q gi|556503834|r  180 PADHMVLMAGFTA-----GNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEA  254 (820)
+Q Consensus       180 padhmvlmagfta-----gnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqea  254 (820)
+                      ..+.++++.||+.     -+.+|+...+   .+|..|+.+|..+.|+-+-+|||+||+|+.||.  |++++++.+++.|+
+T Consensus       180 ~~g~ipI~~g~~~~p~v~~~~~g~~~~v---~sD~~A~~lA~~l~A~~li~ltdv~Gv~~~~p~--~~a~~i~~i~~~e~  254 (310)
+T 2we5_A          180 KNDIITISCGGGGIPVVGQELKGVEAVI---DKDFASEKLAELVDADALVILTGVDYVCINYGK--PDEKQLTNVTVAEL  254 (310)
+T ss_dssp             HTTCEEECCGGGCEEEETTTTEECCCCC---CHHHHHHHHHHHTTCSEEEEECSCSSCEESTTS--TTCEECCEEEHHHH
+T ss_pred             hCCCEEEEeCCCCCCceecCCCCcEEEe---chHHHHHHHHHHcCCCEEEEeeCCCccccCCCC--CCccccccCCHHHH
+Confidence            3445677777542     2556776654   789999999999999999999999999999995  88999999999999
+
+
+Q gi|556503834|r  255 MELSYFG  261 (820)
+Q Consensus       255 melsyfg  261 (820)
+                      .++.+.|
+T Consensus       255 ~~~~~~~  261 (310)
+T 2we5_A          255 EEYKQAG  261 (310)
+T ss_dssp             HHHHHTT
+T ss_pred             HHHHHcC
+Confidence            8876543
+
+
+No 57
+>2e9y_A Carbamate kinase; transferase, structural genomics, NPPSFA, national project O structural and functional analyses; 1.80A {Aeropyrum pernix}
+Probab=97.49  E-value=2.6e-07  Score=87.53  Aligned_cols=100  Identities=20%  Similarity=0.181  Sum_probs=74.0  Template_Neff=8.000
+
+Q gi|556503834|r  184 MVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYFG--  261 (820)
+Q Consensus       184 mvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyfg--  261 (820)
+                      +.++.++.. .+.|+...+   ++|+.|+.||.+++|+-+.+|||+||+|+.||+  |++++++.+++.|+.++...+  
+T Consensus       197 iPVi~~~~~-~~~g~~~~v---~sD~~Aa~lA~~l~A~~Li~ltdv~Gv~~~~p~--~~a~~i~~i~~~e~~~l~~~~~v  270 (316)
+T 2e9y_A          197 VPVVERPGG-VLEPVEAVV---DKDLASSLLATQLNADLLVILTDVPGVAVNYGR--EGERWLRRAAASELKKYLREGHF  270 (316)
+T ss_dssp             EEEEECTTS-CEEECSCCC---CHHHHHHHHHHHTTCSEEEEEESSSSCEETTTS--TTCEECSEEEHHHHHHHHHTTCS
+T ss_pred             EEEEeCCCc-CCCCceecc---ChHHHHHHHHHHcCCCEEEEEeCCchhcccCCC--CCccccccCCHHHHHHHHHcCCC
+Confidence            334444432 455666544   789999999999999999999999999999995  789999999999988776544  
+
+
+Q gi|556503834|r  262 -AKVLHPR--TITPIAQFQIP-CLIKNTGNPQ  289 (820)
+Q Consensus       262 -akvlhpr--titpiaqfqip-clikntgnpq  289 (820)
+                       ..-.+|+  .....++..++ +.|-|...|.
+T Consensus       271 ~~ggm~~Kv~aa~~a~~~gv~~v~I~~g~~~~  302 (316)
+T 2e9y_A          271 PPGSMGPKVEAAISFVERTGKPAVIGSLEEAR  302 (316)
+T ss_dssp             CTTTHHHHHHHHHHHHHHHCSCEEEEESTTHH
+T ss_pred             CCCCcHHHHHHHHHHHHcCCCeEEEecCCChH
+Confidence             2345665  44445555565 7777766654
+
+
+No 58
+>3l86_A Acetylglutamate kinase; ARGB, amino-acid biosynthesis, arginine biosynthesi binding, nucleotide-binding, transferase; HET: ADP NLG; 2.06A {Streptococcus mutans}
+Probab=97.45  E-value=3.3e-07  Score=84.54  Aligned_cols=150  Identities=19%  Similarity=0.268  Sum_probs=93.1  Template_Neff=8.400
+
+Q gi|556503834|r  133 IMAGVLEARGHNVTVIDPVEKLLAVGHYLES-----TVDIAESTRRIAASRIPADHMVLMAGFTAGNEKGELVVLGRNGS  207 (820)
+Q Consensus       133 imagvlearghnvtvidpvekllavghyles-----tvdiaestrriaasripadhmvlmagftagnekgelvvlgrngs  207 (820)
+                      .+...|..+|.++..+++....+..+...+.     +-++.+--.+.....+....++++.|+... ..|+..   +-++
+T Consensus       118 ~l~~~L~~~Gi~~~~l~~~~~~~~~~~~~~~~~~~~~g~i~~~~~~~i~~~L~~g~IpVv~~~~~~-~~g~~~---~~~s  193 (279)
+T 3l86_A          118 NLQEKLRQAGVSCQQLKSDIKHVVAADYLDKDTYGYVGDVTHINKRVIEEFLENRQIPILASLGYS-KEGDML---NINA  193 (279)
+T ss_dssp             HHHHHHHHTTCCEEECSGGGGGTEEEEESCHHHHBSBEEEEEECHHHHHHHHHTTCEEEEESEEEC-TTSCEE---ECCH
+T ss_pred             HHHHHHHHCCCCeeeecccCCceEEEEeccccccceecccccccHHHHHHHHhCCCeEEEcCCccC-CCCCEE---EecH
+Confidence            4555666677777766654433332222110     001111111112223455667788888766 356664   4489
+
+
+Q gi|556503834|r  208 DYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYF----GAKVLHPRTITPIAQFQI-PCLI  282 (820)
+Q Consensus       208 dysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeamelsyf----gakvlhprtitpiaqfqi-pcli  282 (820)
+                      |..|+.+|..|.||.+-+|||+||||+. |      ++++.++|+|+-++...    |.-....+.........+ +..|
+T Consensus       194 D~~A~~lA~~l~A~~li~ltdv~GV~~~-~------~~i~~is~~ea~~l~~~~~~~ggm~~kl~aa~~a~~~gv~~v~I  266 (279)
+T 3l86_A          194 DYLATAVAVALAADKLILMTNVKGVLEN-G------AVLEKITSHQVQEKIDTAVITAGMIPKIESAAKTVAAGVGQVLI  266 (279)
+T ss_dssp             HHHHHHHHHHTTCSEEEEECSSSSCEET-T------EECCEEEGGGSHHHHHTTSSCTTHHHHHHHHHHHHHTTCSEEEE
+T ss_pred             HHHHHHHHHHcCCCEEEEEeCCcccccC-C------ccccccCHHHHHHHHHcCCCCCcHHHHHHHHHHHHHcCCCEEEE
+Confidence            9999999999999999999999999987 4      36888999998776543    322233455555666667 5666
+
+
+Q gi|556503834|r  283 KNTGNPQAPGTLIG  296 (820)
+Q Consensus       283 kntgnpqapgtlig  296 (820)
+                      -|...|   ||+|.
+T Consensus       267 ~~g~~~---gt~i~  277 (279)
+T 3l86_A          267 GDNLLT---GTLIT  277 (279)
+T ss_dssp             ESSSSC---SEEEE
+T ss_pred             ecCCCC---ccEEe
+Confidence            665544   77764
+
+
+No 59
+>3d40_A FOMA protein; fosfomycin, antibiotic resistance, kinase, phosphoryl transfer, transferase; 1.53A {Streptomyces wedmorensis} PDB: 3d41_A* 3qun_A* 3quo_A* 3qur_A* 3qvf_A* 3qvh_A*
+Probab=97.38  E-value=5e-07  Score=82.70  Aligned_cols=102  Identities=21%  Similarity=0.183  Sum_probs=71.6  Template_Neff=8.800
+
+Q gi|556503834|r  181 ADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRAD-CCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSY  259 (820)
+Q Consensus       181 adhmvlmagftagnekgelvvlgrngsdysaavlaaclrad-cceiwtdvdgvytcdprqvpdarllksmsyqeamelsy  259 (820)
+                      ...+.++.|...-++.|   .+++..+|+.|+.||..+.|+ -+-+||||||||+.||+.   +++++.+++.|+.++..
+T Consensus       146 ~g~IPVv~g~~~~~~~~---~~~~~~sD~~A~~lA~~l~A~~~li~ltdv~GVy~~dp~~---~~~i~~i~~~e~~~~~~  219 (286)
+T 3d40_A          146 HGALPVLAGDALFDEHG---KLWAFSSDRVPEVLLPMVEGRLRVVTLTDVDGIVTDGAGG---DTILPEVDARSPEQAYA  219 (286)
+T ss_dssp             TTCEEEEECEEEEBTTS---CEEEECGGGHHHHTTTTCCSCEEEEEEESSSSCEECC------CEECCEEETTSCHHHHH
+T ss_pred             CCCEEEEcCCceEcCCC---eEEEEcHHHHHHHHHHHhCCCceEEEEeCCCceeCCCCCc---cccchhcCcccHHHHHh
+Confidence            34455666643213334   456678999999999999999 599999999999999972   38899999998876532
+
+
+Q gi|556503834|r  260 ----------FGAKVLHPRTITPIAQFQIPCLIKNTGNP  288 (820)
+Q Consensus       260 ----------fgakvlhprtitpiaqfqipclikntgnp  288 (820)
+                                .|......+.+...++..+++.|-|..+|
+T Consensus       220 ~~~~~~~~~~tggm~~kl~aa~~a~~~gi~v~I~~g~~~  258 (286)
+T 3d40_A          220 ALWGSSEWDATGAMHTKLDALVTCARRGAECFIMRGDPG  258 (286)
+T ss_dssp             HHHHSCC----CHHHHHHHHHHHHHHTTCEEEEEECCTT
+T ss_pred             hcccccCCeeeCCHHHHHHHHHHHHHCCCCEEEEeCCCh
+Confidence                      12234455677777777888877776544
+
+
+No 60
+>4axs_A Carbamate kinase; oxidoreductase; 2.50A {Mycoplasma penetrans}
+Probab=97.37  E-value=5.1e-07  Score=86.07  Aligned_cols=106  Identities=17%  Similarity=0.233  Sum_probs=75.5  Template_Neff=8.000
+
+Q gi|556503834|r  181 ADHMVLMAGFTA---GNEKGELVVL-GRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAME  256 (820)
+Q Consensus       181 adhmvlmagfta---gnekgelvvl-grngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyqeame  256 (820)
+                      ...++++.||..   -++.|++.-. ....+|+.|+.||..+.|+.+-+|||+||+|+.||.  |++++++.++++|+.+
+T Consensus       202 ~g~ipV~~g~~g~~~~~~~g~~~~~~~~~~sD~~A~~lA~~l~A~~li~ltdv~Gv~~~~p~--~~a~~i~~is~~e~~~  279 (332)
+T 4axs_A          202 NGCVCIVGGGGGIPTIIQDNQYIGVDGVIDKDFALAKIADAVNADIFVVLTAVDYVYVDFNK--PTQKALKTVDVKALNN  279 (332)
+T ss_dssp             TTCEEECCGGGCEEEEESSSCEEECSSCCCHHHHHHHHHHHTTCSEEEEECSCSSCEESTTS--TTCEECSSCBHHHHHH
+T ss_pred             CCCEEEEeCCCCCCccCCCCceeecccccCHHHHHHHHHHHcCCCEEEEEeCCCcccccCCC--CCceeccccCHHHHHH
+Confidence            356778888752   2355555333 556699999999999999999999999999999995  9999999999999877
+
+
+Q gi|556503834|r  257 LSY---FGAKVLHPRT--ITPIAQFQ--IPCLIKNTGNP  288 (820)
+Q Consensus       257 lsy---fgakvlhprt--itpiaqfq--ipclikntgnp  288 (820)
+                      +..   |...-..|+-  ....++..  +++.|-|...|
+T Consensus       280 ~~~~~~~~~ggm~~kl~~a~~~~~~gv~~~v~I~~g~~~  318 (332)
+T 4axs_A          280 FINQDQFAKGSMLPKIKAAMGFVNGHPNRSAIIADLSKV  318 (332)
+T ss_dssp             HHHTTCSCTTTTHHHHHHHHHHHTTCTTCEEEEECSTTH
+T ss_pred             HHhcCCCCcCChHHHHHHHHHHHHcCCCeeEEEeeCCCh
+Confidence            653   2233333431  22223333  57777766555
+
+
+No 61
+>1e19_A Carbamate kinase; transferase, hyperthermophiles, ADP site, arginine metabolis phosphoryl group transfer; HET: ADP; 1.5A {Pyrococcus furiosus} SCOP: c.73.1.1
+Probab=97.26  E-value=9.4e-07  Score=83.88  Aligned_cols=72  Identities=25%  Similarity=0.291  Sum_probs=56.3  Template_Neff=7.900
+
+Q gi|556503834|r  182 DHMVLMAGFTA---GNEKGELVV--LGRNGSDYSAAVLAACLRADCCEIWTDVDG--VYTCDPRQVPDARLLKSMSYQEA  254 (820)
+Q Consensus       182 dhmvlmagfta---gnekgelvv--lgrngsdysaavlaaclradcceiwtdvdg--vytcdprqvpdarllksmsyqea  254 (820)
+                      ..++++.|+..   -|+.|+..-  + +..+|..|+.+|..+.|+-+-++||+||  +|+.||+.    ++++.+++.|+
+T Consensus       186 g~IvV~~g~~~~p~~~~~g~~~~~~~-~~~~D~~Aa~lA~~l~A~~lI~ltdv~Gv~v~~~dp~~----~~i~~i~~~e~  260 (314)
+T 1e19_A          186 GVIVIASGGGGVPVILEDGEIKGVEA-VIDKDLAGEKLAEEVNADIFMILTDVNGAALYYGTEKE----QWLREVKVEEL  260 (314)
+T ss_dssp             TCEEECSGGGCEEEEEETTEEEECCC-CCCHHHHHHHHHHHTTCSEEEEEESSSSCEETTTSTTC----EECCEEEHHHH
+T ss_pred             CCEEEEecccCCceeCCCCCEEccce-eechHHHHHHHHHHcCCCEEEEEeCCccccccCCCCcc----cccccCCHHHH
+Confidence            45566666532   355575443  2 6789999999999999999999999999  88888865    78999999888
+
+
+Q gi|556503834|r  255 MELS  258 (820)
+Q Consensus       255 mels  258 (820)
+                      .++.
+T Consensus       261 ~~l~  264 (314)
+T 1e19_A          261 RKYY  264 (314)
+T ss_dssp             HHHH
+T ss_pred             HHHH
+Confidence            7653
+
+
+No 62
+>3upl_A Oxidoreductase; rossmann fold, NADPH binding; 1.50A {Brucella melitensis biovar abortus 230ORGANISM_TAXID} PDB: 3upy_A*
+Probab=97.25  E-value=1e-06  Score=84.49  Aligned_cols=219  Identities=17%  Similarity=0.128  Sum_probs=134.1  Template_Neff=9.100
+
+Q gi|556503834|r  452 VRVTHQMLFN---TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKA-LL---TNVHGL--------  516 (820)
+Q Consensus       452 vrvthqmlfn---tdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanska-ll---tnvhgl--------  516 (820)
+                      +|..|..+++   .+..+.|.+||.|.+|..++.++.++.        ++++++|.+... ..   ..-.|.        
+T Consensus         7 ~~~~~~~~~~~~~~~~~~rV~IIG~G~vG~~~~~~l~~~~--------~~~v~~v~d~~~~~a~~~~~~~~~~~~~~~~~   78 (446)
+T 3upl_A            7 LVGLARDLAARAETGKPIRIGLIGAGEMGTDIVTQVARMQ--------GIEVGALSARRLPNTFKAIRTAYGDEENAREA   78 (446)
+T ss_dssp             CCHHHHHHHHHHHTTCCEEEEEECCSHHHHHHHHHHTTSS--------SEEEEEEECSSTHHHHHHHHHHHSSSTTEEEC
+T ss_pred             HHHHHHHHHhhhhcCCceEEEEECccHHHHHHHHHHHhCC--------CcEEEEEEeCCHHHHHHHHHHcCCChhheeec
+Confidence            5667888888   689999999999999999999887642        256777665421 11   111111        
+
+
+Q gi|556503834|r  517 -NLENWQEELAQAKEPFNLGRLIRLVKEYHLLNPVIVDCTSS-QAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRY  594 (820)
+Q Consensus       517 -nlenwqeelaqakepfnlgrlirlvkeyhllnpvivdctss-qavadqyadflregfhvvtpnkkantssmdyyhqlry  594 (820)
+                       +.+.|.+.+.... ......+..++++  .-.-++++||.+ ....+.....++.|.||++-+|..   ......+|.-
+T Consensus        79 ~~~~~~~~~~~~~~-~~~~~~~~~ll~~--~~~DvVv~~t~~p~~~~~~~~~al~~G~~vv~~~k~~---~~~~~~~l~~  152 (446)
+T 3upl_A           79 TTESAMTRAIEAGK-IAVTDDNDLILSN--PLIDVIIDATGIPEVGAETGIAAIRNGKHLVMMNVEA---DVTIGPYLKA  152 (446)
+T ss_dssp             SSHHHHHHHHHTTC-EEEESCHHHHHTC--TTCCEEEECSCCHHHHHHHHHHHHHTTCEEEECCHHH---HHHHHHHHHH
+T ss_pred             CCHHHHHHHhhcCC-ceecCCHHHHhcC--CCCCEEEECCCCHHHHHHHHHHHHHcCCcEEeechhh---hHHHHHHHHH
+Confidence             1222322221111 1111122222221  123588999996 888888889999999999976543   3345567766
+
+
+Q gi|556503834|r  595 AAEKSRRKFLYDTNVGAGLPVIENLQNLLNA-GDELMKFSGILSGSLS-YIFGKLDEGMSFSEATTLAREMGYTEPDPRD  672 (820)
+Q Consensus       595 aaeksrrkflydtnvgaglpvienlqnllna-gdelmkfsgilsgsls-yifgkldegmsfseattlaremgytepdprd  672 (820)
+                      ++++....+++..+...+  .+..+.+++.. |.++     +.+|..+ |.|   ....+.+.+..++.+.|++.+++..
+T Consensus       153 ~a~~~~~~~~~~~g~~p~--~~~~l~~~~~~~g~~i-----~~~g~~~~~~l---~~~a~~~~a~~~~~~~g~~~~~~~~  222 (446)
+T 3upl_A          153 QADKQGVIYSLGAGDEPS--SCMELIEFVSALGYEV-----VSAGKGKNNPL---NFDATPDDYRQEADRRNMNVRLLVE  222 (446)
+T ss_dssp             HHHHHTCCEEECTTSHHH--HHHHHHHHHHHTTCEE-----EEEEEEESSCC---CTTCCHHHHHHHHHHTTCCHHHHHH
+T ss_pred             HHHHcCCEEEeccCCcCc--hHHHHHHHHHhcCcEE-----EEEEEecCccC---cCCCChHHHHHHHHHcCCCcccccc
+Confidence            677766677666554433  23333333331 3332     2233322 222   1233445677788899999888889
+
+
+Q gi|556503834|r  673 DLSGMDVARKLLILARETGREL  694 (820)
+Q Consensus       673 dlsgmdvarkllilaretgrel  694 (820)
+                      ++.|.....+...+++.+|...
+T Consensus       223 ~~~G~~~~i~~~~l~n~~g~~~  244 (446)
+T 3upl_A          223 FIDGSKTMVEMAAIANATGLVP  244 (446)
+T ss_dssp             HHTSHHHHHHHHHHHHHHCCBC
+T ss_pred             ccchHHHHHHHHHHHhhcCCCC
+Confidence            9999988888888888887654
+
+
+No 63
+>3tvi_A Aspartokinase; structural genomics, ACT domains, regulatory domains, kinase transferase, PSI-2, protein structure initiative; HET: LYS; 3.00A {Clostridium acetobutylicum}
+Probab=97.09  E-value=2.4e-06  Score=83.85  Aligned_cols=76  Identities=28%  Similarity=0.427  Sum_probs=70.8  Template_Neff=8.300
+
+Q gi|556503834|r  305 PVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYL  380 (820)
+Q Consensus       305 pvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefyl  380 (820)
+                      +...+.-.+++++.|+-|.||....|+++++|.+++.+.|.+.+|+|++|+.+|||+|+++|+.+|.+++.++|+.
+T Consensus       364 ~~~~v~~~~~~a~IsvVG~gm~~~~gva~~v~~~L~~~~I~i~~Is~~~Se~~is~vV~~~d~~~av~~Lh~~f~~  439 (446)
+T 3tvi_A          364 NPDSIEIHPNMALVATVGTGMAKTKGIANKIFTALSKENVNIRMIDQGSSEINVIVGVETVDFEKAVKSIYNAFNE  439 (446)
+T ss_dssp             CCSEEEEEEEEEEEEEECGGGSSCTTHHHHHHHHHHHTTCCEEEEEECSCTTEEEEEEEGGGHHHHHHHHHHHHCC
+T ss_pred             CCceEEEeCCeEEEEEEcCCcccCccHHHHHHHHHHhCCCCEEEEEecCCCCEEEEEEEhHHHHHHHHHHHHHHHh
+Confidence            3445667789999999999999999999999999999999999999999999999999999999999999999875
+
+
+No 64
+>3au8_A 1-deoxy-D-xylulose 5-phosphate reductoisomerase; NADPH binding; HET: NDP; 1.86A {Plasmodium falciparum} PDB: 3au9_A* 3aua_A* 3wqq_A* 3wqr_A* 3wqs_B*
+Probab=96.98  E-value=4.1e-06  Score=85.10  Aligned_cols=194  Identities=15%  Similarity=0.106  Sum_probs=108.8  Template_Neff=7.200
+
+Q gi|556503834|r  462 TDQVIEVFVIGV-GGVGGALLEQLKRQQSWLKNKHIDLRVCGVAN-SK-ALLTNV-HGLNL-------ENWQEELAQA--  528 (820)
+Q Consensus       462 tdqvievfvigv-ggvggalleqlkrqqswlknkhidlrvcgvan-sk-alltnv-hglnl-------enwqeelaqa--  528 (820)
+                      ....+.|.++|. |.||...++.+++.+.  ..  -+++|.+++. +. ..+... ..+..       +.+.+++.+.  
+T Consensus        74 ~~~~irIaIiGaTGsIG~~~l~~L~~~~~--~~--~~~~Vvav~~~~n~~~l~~~a~~~~~~~v~~~~~~~~~~l~~~~~  149 (488)
+T 3au8_A           74 IKKPINVAIFGSTGSIGTNALNIIRECNK--IE--NVFNVKALYVNKSVNELYEQAREFLPEYLCIHDKSVYEELKELVK  149 (488)
+T ss_dssp             ---CEEEEEETTTSHHHHHHHHHHHHHHH--HS--CCEEEEEEEESSCHHHHHHHHHHHCCSEEEESCGGGTHHHHTGGG
+T ss_pred             cCCccEEEEECCCCHHHHHHHHHHHhccc--CC--CceEEEEEEcCCCHHHHHHHHHHcCCCeeEecCHHHHHHhhhhhc
+Confidence            455688999997 9999999999987531  00  1467777754 22 211110 11111       0111222110  
+
+
+Q gi|556503834|r  529 -----KEPF--NLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAE-KSR  600 (820)
+Q Consensus       529 -----kepf--nlgrlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaae-ksr  600 (820)
+                           ...+  ....+..++..  .---++++|++...-.+.+...++.|.||++.||+.-....+   .+.-.++ ++.
+T Consensus       150 ~~~~~~~~~~~g~~~l~ell~~--~~vDvVv~at~g~~~~~~~~~ALeaGk~Vl~ANKe~lv~~g~---~l~~~Ak~~~g  224 (488)
+T 3au8_A          150 NIKDYKPIILCGDEGMKEICSS--NSIDKIVIGIDSFQGLYSTMYAIMNNKIVALANKESIVSAGF---FLKKLLNIHKN  224 (488)
+T ss_dssp             GSTTCCCEEEEHHHHHHHHHHC--TTCCEEEECCCHHHHHHHHHHHHHTTCEEEECCSHHHHHHHH---HHHHHHHHSTT
+T ss_pred             ccccccceeecCcccHHHHhhC--CCCCEEEECCCcHHHHHHHHHHHHhCCEEEecCchHHHHHHH---HHHHHHHhhcC
+Confidence                 0000  00112222211  123578899998888888999999999999999987755443   3444455 444
+
+
+Q gi|556503834|r  601 RKFLYDTNVGAGLPVI---ENLQNLLNAGDELMKF------SGILSGSLSYIFGK------------LDEGMSFSEATTL  659 (820)
+Q Consensus       601 rkflydtnvgaglpvi---enlqnllnagdelmkf------sgilsgslsyifgk------------ldegmsfseattl  659 (820)
+                      .+++         |+.   ..++.++. ++++-++      .|++++.-.|++..            ++ |.+|++|.. 
+T Consensus       225 ~~i~---------Pvdseh~al~q~L~-~~~ig~i~~~~~~~g~~~~~~~~iltaSGG~f~~~~~~~l~-~~t~~~al~-  292 (488)
+T 3au8_A          225 AKII---------PVDSEHSAIFQCLD-NNKVLKTKCLQDNFSKINNINKIFLCSSGGPFQNLTMDELK-NVTSENALK-  292 (488)
+T ss_dssp             CEEE---------ECSHHHHHHHHHSC-HHHHTTSCTTCTTHHHHTTEEEEEEEECCCTTTTCCHHHHT-TCCTTTC---
+T ss_pred             cEEE---------EcchHHHHHHHHhh-cCcccceeeccccccccCCceEEEecCCCCccCCCChHHhc-cCCHHHHhh-
+Confidence            4444         888   88888887 4455444      67777777777764            44 455555443 
+
+
+Q gi|556503834|r  660 AREMGYTEPDPRDDLSGMDVARKLLILARET  690 (820)
+Q Consensus       660 aremgytepdprddlsgmdvarkllilaret  690 (820)
+                               +|     |+|.++|+.|++..-
+T Consensus       293 ---------hP-----~w~mg~KitIdsat~  309 (488)
+T 3au8_A          293 ---------HP-----KWKMGKKITIDSATM  309 (488)
+T ss_dssp             ---------------------CHHHHHHHSS
+T ss_pred             ---------CC-----CchhhhhhhhHHHHH
+Confidence                     34     999999999998655
+
+
+No 65
+>3c1m_A Probable aspartokinase; allosteric inhibition, threonine-sensitive, ACT DOMA amino-acid biosynthesis, threonine biosynthesis; HET: ANP; 2.30A {Methanocaldococcus jannaschii} PDB: 3c1n_A 3c20_A 2hmf_A*
+Probab=96.94  E-value=4.8e-06  Score=80.53  Aligned_cols=76  Identities=32%  Similarity=0.584  Sum_probs=71.4  Template_Neff=9.100
+
+Q gi|556503834|r  306 VKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLE  381 (820)
+Q Consensus       306 vkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefyle  381 (820)
+                      ++.++..+++++.++.|.||.++.|.++|+|.++++.+|.+.+|+|++++.+++|+|+++|..+|-+...++|...
+T Consensus       395 ~~~i~~~~~~alIsvvG~~~~~~~~i~~~i~~~L~~~~i~v~~i~~~~s~~~is~vv~~~~~~~a~~~Lh~~~~~~  470 (473)
+T 3c1m_A          395 IRDVSVDKDVCVISVVGAGMRGAKGIAGKIFTAVSESGANIKMIAQGSSEVNISFVIDEKDLLNCVRKLHEKFIEK  470 (473)
+T ss_dssp             EEEEEEEEEEEEEEEECTTTTTCTTHHHHHHHHHHHHTCCCCEEEESSCSSEEEEEEEGGGHHHHHHHHHHHHTTC
+T ss_pred             CceEEEECCEEEEEEEeeccCCCCCHHHHHHHHHHhCCCCEEEEEecCCCCeEEEEEeHHHHHHHHHHHHHHHhcc
+Confidence            5678889999999999999999999999999999999999999999999999999999999999999988888653
+
+
+No 66
+>2f06_A Conserved hypothetical protein; structural genomics hypothetical protein, PSI, protein struc initiative; HET: MSE HIS; 2.10A {Bacteroides thetaiotaomicron} SCOP: d.58.18.11 d.58.18.11
+Probab=96.50  E-value=3.1e-05  Score=59.52  Aligned_cols=132  Identities=17%  Similarity=0.177  Sum_probs=93.6  Template_Neff=10.900
+
+Q gi|556503834|r  310 SNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSE--YSISFCVPQSDCVRAERAMQEEFYLELKEGLL  387 (820)
+Q Consensus       310 snlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssse--ysisfcvpqsdcvraeramqeefylelkegll  387 (820)
+                      ||.+.+..+.+..|+..|   ..++++..+.+..+++..+.++.++  ..+.+++.+.+     +     +...|.+   
+T Consensus         1 ~~~~~~~~~~v~~~~~~g---~l~~v~~~l~~~~i~i~~i~~~~~~~~~~~~~~i~~~~-----~-----~~~~l~~---   64 (144)
+T 2f06_A            1 SNAMVAKQLSIFLENKSG---RLTEVTEVLAKENINLSALCIAENADFGILRGIVSDPD-----K-----AYKALKD---   64 (144)
+T ss_dssp             CCSSEEEEEEEEECSSSS---HHHHHHHHHHHTTCCEEEEEEEECSSCEEEEEEESCHH-----H-----HHHHHHH---
+T ss_pred             CCCcEEEEEEEEEcCCCc---HHHHHHHHHHHCCCCEEEEEeEecCCeEEEEEEEcCHH-----H-----HHHHHHH---
+Confidence            345556667777777654   5568888899999998888776542  34566653211     1     1112221   
+
+
+Q gi|556503834|r  388 EPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFN  461 (820)
+Q Consensus       388 eplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlfn  461 (820)
+                          ....++.+++++..+..-.|+-++++..|.+.++||..+.++.+..+++++++.++....+..-|+..|.
+T Consensus        65 ----~~~~~~~~~~v~~~~~~~~g~l~~i~~~L~~~~i~i~~~~~~~~~~~~~~~v~~~~~~~~~~~L~~~~~~  134 (144)
+T 2f06_A           65 ----NHFAVNITDVVGISCPNVPGALAKVLGFLSAEGVFIEYMYSFANNNVANVVIRPSNMDKCIEVLKEKKVD  134 (144)
+T ss_dssp             ----TTCCEEEEEEEEEEEESSTTHHHHHHHHHHHTTCCEEEEEEEEETTEEEEEEEESCHHHHHHHHHHTTCE
+T ss_pred             ----CCCceeeeEEEEEEecCCCchHHHHHHHHHHCCCCEEEEEEEccCCeEEEEEEeCCHHHHHHHHHHCCcE
+Confidence                1123457778888887778899999999999999999999988878889999988887777777776664
+
+
+No 67
+>3mah_A Aspartokinase; aspartate kinase, structural genomics, MCSG, transferase, PSI-2; 2.31A {Porphyromonas gingivalis}
+Probab=96.40  E-value=4.4e-05  Score=62.34  Aligned_cols=76  Identities=21%  Similarity=0.332  Sum_probs=59.3  Template_Neff=9.700
+
+Q gi|556503834|r  306 VKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELK  383 (820)
+Q Consensus       306 vkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelk  383 (820)
+                      .+.++..+++++.++-|+||+.+.|.++++|.+++  ++.+.++.+++++.+++|+++.+|..++-+.+.+.|...-+
+T Consensus        79 ~~~v~~~~~~a~islvG~~~~~~~~~~~~~~~~L~--~~~i~~i~~~~s~~sis~vv~~~~~~~a~~~Lh~~~~~~~~  154 (157)
+T 3mah_A           79 IGDVTVDKDMVIICIVGDMEWDNVGFEARIINALK--GVPVRMISYGGSNYNVSVLVKAEDKKKALIALSNKLFNSRA  154 (157)
+T ss_dssp             TEEEEEEEEEEEEEEEC------CCHHHHHHHTTT--TSCCSEEEECSSSSCEEEEEEGGGHHHHHHHHHHHHHC---
+T ss_pred             CCcEEEeCCEEEEEEEecCcccchhHHHHHHHHHh--cCCeEEEEecCCcceEEEEEeHHHHHHHHHHHHHHHhcccc
+Confidence            35677889999999999999999999999999996  45567889999999999999999999999999888876544
+
+
+No 68
+>1r0k_A 1-deoxy-D-xylulose 5-phosphate reductoisomerase; NADPH dependent, fosmidomycin, non- mevalonate pathway, oxidoreductase; 1.91A {Zymomonas mobilis} SCOP: a.69.3.1 c.2.1.3 d.81.1.3 PDB: 1r0l_A*
+Probab=96.39  E-value=4.6e-05  Score=73.75  Aligned_cols=187  Identities=17%  Similarity=0.169  Sum_probs=103.4  Template_Neff=8.200
+
+Q gi|556503834|r  465 VIEVFVIGV-GGVGGALLEQLKRQQSWLKNKHIDLRVCGVAN-S-KALLTNV-HGLNLE-------NWQEELAQAKEP--  531 (820)
+Q Consensus       465 vievfvigv-ggvggalleqlkrqqswlknkhidlrvcgvan-s-kalltnv-hglnle-------nwqeelaqakep--  531 (820)
+                      .+.|.++|. |.+|..+++.+++.+.       +++|.++.. + ...+... ...+..       ++.+++.+.-.+  
+T Consensus         4 ~~kV~IiGaTGsIG~~~l~~l~~~~~-------~~~vvav~~~~~~~~l~~~~~~~~~~~v~~~~~~~~~~~~~~~~~~~   76 (388)
+T 1r0k_A            4 PRTVTVLGATGSIGHSTLDLIERNLD-------RYQVIALTANRNVKDLADAAKRTNAKRAVIADPSLYNDLKEALAGSS   76 (388)
+T ss_dssp             CEEEEEETTTSHHHHHHHHHHHHTGG-------GEEEEEEEESSCHHHHHHHHHHTTCSEEEESCGGGHHHHHHHTTTCS
+T ss_pred             ceEEEEECCCcHHHHHHHHHHHcCCC-------CcEEEEEEcCCCHHHHHHHHHHcCCCEEEecCHHHHHHHHhhhccCC
+Confidence            467889996 9999999999986532       366777753 2 2222110 000000       011111100000  
+
+
+Q gi|556503834|r  532 --F--NLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDT  607 (820)
+Q Consensus       532 --f--nlgrlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydt  607 (820)
+                        +  ....+..+ .  ..-..++++||+...-.+.+...++.|.||++.||.....   ....+.-+++++..++    
+T Consensus        77 ~~~~~g~~~l~~~-~--~~~~DvVv~at~~~~~~~~~~~al~~Gk~V~~anK~~~v~---~~~~l~~~a~~~g~~i----  146 (388)
+T 1r0k_A           77 VEAAAGADALVEA-A--MMGADWTMAAIIGCAGLKATLAAIRKGKTVALANKESLVS---AGGLMIDAVREHGTTL----  146 (388)
+T ss_dssp             SEEEESHHHHHHH-H--TSCCSEEEECCCSGGGHHHHHHHHHTTSEEEECCSHHHHT---THHHHHHHHHHHTCEE----
+T ss_pred             ceEeeCchHHHHH-h--cCCCCEEEEcCCcHHHHHHHHHHHHhCCeEEecCchhhHH---HHHHHHHHHHHcCCEE----
+Confidence              0  00111111 1  1234688999999888999999999999999999975433   4556666676666655    
+
+
+Q gi|556503834|r  608 NVGAGLPVI---ENLQNLLNAGD--ELMKFSGILSGSLSYIFGKLDEGMSFSEATTLAREMGYTEPDPRDDLS--GMDVA  680 (820)
+Q Consensus       608 nvgaglpvi---enlqnllnagd--elmkfsgilsgslsyifgkldegmsfseattlaremgytepdprddls--gmdva  680 (820)
+                           +|+.   ..+.+++..|+  ++-++....|            |.+|.+.+.  .+|  ..+++.+.|.  +.+..
+T Consensus       147 -----~Pv~seh~ai~~~l~~~~~~~i~~i~lt~s------------gg~f~~~~~--~~l--~~~~~~~al~hp~w~mg  205 (388)
+T 1r0k_A          147 -----LPVDSEHNAIFQCFPHHNRDYVRRIIITAS------------GGPFRTTSL--AEM--ATVTPERAVQHPNWSMG  205 (388)
+T ss_dssp             -----EECSHHHHHHHHHCCTTCGGGEEEEEEEEC------------CCTTTTCCH--HHH--TTCCHHHHHC------C
+T ss_pred             -----EeccccHHHHHHHHhcccccCceEEEEecc------------CCccccCCH--HHh--cCcCHHHHhcCCCCCCc
+Confidence                 4887   88888888775  3322222222            233322211  112  2455666663  88889
+
+
+Q gi|556503834|r  681 RKLLILARE  689 (820)
+Q Consensus       681 rkllilare  689 (820)
+                      +|+.+.++.
+T Consensus       206 ~Ki~i~s~~  214 (388)
+T 1r0k_A          206 AKISIDSAT  214 (388)
+T ss_dssp             HHHHHHHHH
+T ss_pred             hHHHHHHHH
+Confidence            998777654
+
+
+No 69
+>2j0w_A Lysine-sensitive aspartokinase 3; feedback inhibition, allosteric regulation, ACT domain, transferase, amino acid biosynthesis; HET: ADP; 2.5A {Escherichia coli} SCOP: c.73.1.3 d.58.18.10 d.58.18.10 PDB: 2j0x_A*
+Probab=96.25  E-value=7.4e-05  Score=72.85  Aligned_cols=71  Identities=15%  Similarity=0.371  Sum_probs=64.4  Template_Neff=8.600
+
+Q gi|556503834|r  307 KGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFY  379 (820)
+Q Consensus       307 kgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefy  379 (820)
+                      ..+..-+++++.++-|.||+...|+++|+|.+++  .+.|-+|+|++|+.+|||.|+++|+.+|-++..++|.
+T Consensus       378 ~~i~v~~~~a~IsvVG~~~~~~~~i~~~~~~~L~--~~~I~~i~~~~S~~~is~vV~~~d~~~av~~LH~~f~  448 (449)
+T 2j0w_A          378 CRVEVEEGLALVALIGNDLSKACGVGKEVFGVLE--PFNIRMICYGASSHNLCFLVPGEDAEQVVQKLHSNLF  448 (449)
+T ss_dssp             SCEEEEEEEEEEEEEESSCTTSSSHHHHHHSSCT--TSCCCEEEESSCTTEEEEEEEGGGHHHHHHHHHHHHH
+T ss_pred             ceEEEeCCeEEEEEeccccccchhHHHHHHHHhc--cCCeEEEEecCCCCeEEEEEehHHHHHHHHHHHHHHh
+Confidence            3466678999999999999999999999999995  5667899999999999999999999999999998875
+
+
+No 70
+>2cdq_A Aspartokinase; aspartate kinase, amino acid metabolism, ACT domain, alloste S-adenosylmethionine, lysine, allosteric effector, plant; HET: TAR SAM LYS; 2.85A {Arabidopsis thaliana} SCOP: c.73.1.3 d.58.18.10 d.58.18.10
+Probab=96.18  E-value=9.1e-05  Score=74.08  Aligned_cols=73  Identities=22%  Similarity=0.332  Sum_probs=66.7  Template_Neff=8.200
+
+Q gi|556503834|r  309 ISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLEL  382 (820)
+Q Consensus       309 isnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylel  382 (820)
+                      ++.-+|+++.|+-|.+ ...-|+++++|.+++.+.|.|.+|+|++|+.+|||.|+.+||.+|.++..++|+..-
+T Consensus       414 v~~~~~~a~IsvVG~~-~~~~~v~~~~f~~L~~~~I~i~~Is~g~Se~sis~vV~~~d~~~al~~Lh~~f~~~~  486 (510)
+T 2cdq_A          414 VNLLKGRAIISLIGNV-QHSSLILERAFHVLYTKGVNVQMISQGASKVNISFIVNEAEAEGCVQALHKSFFESG  486 (510)
+T ss_dssp             EEEEEEEEEEEEEECG-GGHHHHHHHHHHHHHHHTCCCSEEEECTTCSEEEEEEEHHHHHHHHHHHHHHHHSSC
+T ss_pred             EEEecCccEEEEEecC-CCCCchHHHHHHHHHhCCCcEEEEEecCCCCEEEEEEEhHHHHHHHHHHHHHHhcCC
+Confidence            5667899999999975 567799999999999999999999999999999999999999999999999988653
+
+
+No 71
+>3ab4_A Aspartokinase; aspartate kinase, concerted inhibition, alternative initiati amino-acid biosynthesis, ATP-binding; HET: LYS; 2.47A {Corynebacterium glutamicum} PDB: 3aaw_A* 3ab2_A
+Probab=96.14  E-value=0.0001  Score=70.29  Aligned_cols=77  Identities=27%  Similarity=0.391  Sum_probs=69.2  Template_Neff=9.100
+
+Q gi|556503834|r  305 PVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELK  383 (820)
+Q Consensus       305 pvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelk  383 (820)
+                      +..-+.--+|+++.++-|.+|+...|.++++|.+++++.|.+..++  +|+.+++|++..+|+.+|.++..++|++.-+
+T Consensus       334 ~~~~i~~~~~~a~IsvvG~~~~~~~g~~~~~~~~L~~~~I~i~~i~--~s~~~is~vv~~~d~~~a~~~Lh~~f~~~~~  410 (421)
+T 3ab4_A          334 NWTNVLYDDQVGKVSLVGAGMKSHPGVTAEFMEALRDVNVNIELIS--TSEIRISVLIREDDLDAAARALHEQFQLGGE  410 (421)
+T ss_dssp             TCSEEEEECCEEEEEEECGGGTSCTTHHHHHHHHHHHTTCCCCEEE--EETTEEEEEEEGGGHHHHHHHHHHHTTCCCC
+T ss_pred             CCceEEEcCCceEEEEecCccccCcchHHHHHHHHHhCCCcEEEEe--cCCCEEEEEEEHHHHHHHHHHHHHHHhcCCC
+Confidence            3455667889999999999999999999999999999999999887  4577999999999999999999999987644
+
+
+No 72
+>3zzh_A Acetylglutamate kinase; transferase, arginine biosynthesis; HET: ARG NLG; 2.10A {Saccharomyces cerevisiae} PDB: 3zzg_A 3zzf_A*
+Probab=96.10  E-value=0.00012  Score=67.93  Aligned_cols=70  Identities=14%  Similarity=0.247  Sum_probs=55.7  Template_Neff=8.700
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQ-EAMEL  257 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyq-eamel  257 (820)
+                      +....++++.|+. .+.+|++..+   ++|..|+.+|..+.+|-+-++||+||+|+.||     +++++.+++. |+.++
+T Consensus       177 L~~g~IPVv~g~~-~~~~g~~~~~---ssD~~A~~lA~~l~A~~li~ltdv~GV~~~~~-----~~~i~~i~~~~e~~~l  247 (307)
+T 3zzh_A          177 IKAGALPILTSLA-ETASGQMLNV---NADVAAGELARVFEPLKIVYLNEKGGIINGST-----GEKISMINLDEEYDDL  247 (307)
+T ss_dssp             HHHTCEEEECCCE-ECTTCBEEBC---CHHHHHHHHHHHHCCSEEEEECSSCSCEETTT-----TEECCEEEHHHHHHHH
+T ss_pred             HhCCCeEEECCce-eCCCCCEEEE---CHHHHHHHHHHhCCCCEEEEEeCCCceecCCC-----CCeeeeecHHHHHHHH
+Confidence            3445677888876 4556776544   79999999999999999999999999999877     4568888886 66554
+
+
+No 73
+>2re1_A Aspartokinase, alpha and beta subunits; structural genomics, protein structure initiative, midwest center for structural genomics; 2.75A {Neisseria meningitidis MC58}
+Probab=96.04  E-value=0.00014  Score=59.70  Aligned_cols=76  Identities=25%  Similarity=0.441  Sum_probs=67.8  Template_Neff=9.800
+
+Q gi|556503834|r  303 ELPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYL  380 (820)
+Q Consensus       303 elpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefyl  380 (820)
+                      ++|.+.++...++++.++-|++++...|.+++++.++++..|.+..+.  +++.++++-++.+|+.++-+++.++|+.
+T Consensus        91 ~~~~~~i~~~~~~s~IslvG~~~~~~~~~~~~i~~~L~~~~I~i~~~~--~s~~~i~~vv~~~~~~~a~~~Lh~~~~~  166 (167)
+T 2re1_A           91 SIGAASIDGDDTVCKVSAVGLGMRSHVGVAAKIFRTLAEEGINIQMIS--TSEIKVSVLIDEKYMELATRVLHKAFNL  166 (167)
+T ss_dssp             TTTCSEEEEESSEEEEEEECSSCTTCCCHHHHHHHHHHHTTCCCCEEE--ECSSEEEEEEEGGGHHHHHHHHHHHTTC
+T ss_pred             hcCCceeeecCCEEEEEEECCCccCCccHHHHHHHHHHHCCCcEEEEe--cCCCeEEEEEeHHHHHHHHHHHHHHHcc
+Confidence            356677888999999999999999999999999999999999988877  4567999999999999999999988763
+
+
+No 74
+>2dtj_A Aspartokinase; protein-ligand complex, regulatory subunit, transferase; HET: CIT; 1.58A {Corynebacterium glutamicum} PDB: 3aaw_B* 3ab2_B 3ab4_B*
+Probab=95.97  E-value=0.00017  Score=60.85  Aligned_cols=78  Identities=27%  Similarity=0.367  Sum_probs=68.1  Template_Neff=9.300
+
+Q gi|556503834|r  304 LPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELK  383 (820)
+Q Consensus       304 lpvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelk  383 (820)
+                      .+...++.-+++++.++-|++++...|.++++|.+++...|.+..++  +++.+++|.|+.+++.+|-+.+.+.|...-+
+T Consensus        84 ~~~~~i~~~~~~a~IslvG~~l~~~~gi~~~i~~~L~~~~I~i~~~~--~s~~~is~vv~~~~~~~av~~Lh~~~~~~~~  161 (178)
+T 2dtj_A           84 GNWTNVLYDDQVGKVSLVGAGMKSHPGVTAEFMEALRDVNVNIELIS--TSEIRISVLIREDDLDAAARALHEQFQLGGE  161 (178)
+T ss_dssp             TTCSEEEEESCEEEEEEEEECCTTCHHHHHHHHHHHHHTTCCCCEEE--EETTEEEEEEEGGGHHHHHHHHHHHHTCCSS
+T ss_pred             CCCceeEEcCCcEEEEEEcCCcccCccHHHHHHHHHHhCCCeEEEEe--cCCCEEEEEEEHHHHHHHHHHHHHHHhCCCC
+Confidence            34456777889999999999999999999999999999999988888  4568999999999999999999888876543
+
+
+No 75
+>3s1t_A Aspartokinase; ACT domain, threonine binding, regulatory domain of aspartok transferase; 1.63A {Mycobacterium tuberculosis}
+Probab=95.88  E-value=0.00022  Score=60.78  Aligned_cols=78  Identities=24%  Similarity=0.326  Sum_probs=67.7  Template_Neff=9.100
+
+Q gi|556503834|r  305 PVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELKE  384 (820)
+Q Consensus       305 pvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelke  384 (820)
+                      +.+.++.-+++++.++-|++|+...|.+++++.++++..|.+..++  +++.+++|.++.+|..+|-+++.+.|...-++
+T Consensus        86 ~~~~i~~~~~~a~IsvvG~~~~~~~~v~~~i~~~L~~~~I~i~~~~--~s~~sis~lv~~~d~~~a~~~Lh~~~~~~~~~  163 (181)
+T 3s1t_A           86 GFSQLLYDDHIGKVSLIGAGMRSHPGVTATFCEALAAVGVNIELIS--TSEIRISVLCRDTELDKAVVALHEAFGLGGDE  163 (181)
+T ss_dssp             CCSEEEEESCEEEEEEEEECCTTCHHHHHHHHHHHHHTTCCCCEEE--EETTEEEEEEEGGGHHHHHHHHHHHHTCCC--
+T ss_pred             CCCceEeeCCeEEEEEECCCccccHHHHHHHHHHHHHCCCeEEEEe--cCCCEEEEEEEHHHHHHHHHHHHHHHhcCCCc
+Confidence            3455677789999999999999999999999999999999988887  56689999999999999999999998765443
+
+
+No 76
+>4go7_X Aspartokinase; transferase; 2.00A {Mycobacterium tuberculosis} PDB: 4go5_X
+Probab=95.59  E-value=0.00045  Score=60.30  Aligned_cols=76  Identities=24%  Similarity=0.316  Sum_probs=66.6  Template_Neff=8.800
+
+Q gi|556503834|r  305 PVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLEL  382 (820)
+Q Consensus       305 pvkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylel  382 (820)
+                      +.+.++..+++++.++-|++|+...|.++++|.++++..|.+..++  +++.+++|.++.+|..+|-+++.+.|...-
+T Consensus       105 ~~~~i~~~~~~a~IsviG~~~~~~~~v~~~i~~~L~~~~I~i~~~~--~s~~~is~vv~~~~~~~av~~Lh~~~~~~~  180 (200)
+T 4go7_X          105 GFSQLLYDDHIGKVSLIGAGMRSHPGVTATFCEALAAVGVNIELIS--TSEIRISVLCRDTELDKAVVALHEAFGLGG  180 (200)
+T ss_dssp             CCSEEEEECCEEEEEEEEESCTTCHHHHHHHHHHHHHTTCCCCEEE--ECSSEEEEEEEGGGHHHHHHHHHHHHTC--
+T ss_pred             CCceEEEeCCeEEEEEECCCcccCccHHHHHHHHHHHCCCeEEEEe--cCCCEEEEEEEhHHHHHHHHHHHHHHhccC
+Confidence            3355677789999999999999999999999999999999988887  677999999999999999999998887643
+
+
+No 77
+>3u3x_A Oxidoreductase; structural genomics, PSI-biology, NEW YORK structural genomi research consortium, nysgrc; 2.79A {Sinorhizobium meliloti}
+Probab=95.59  E-value=0.00045  Score=63.03  Aligned_cols=151  Identities=16%  Similarity=0.151  Sum_probs=83.5  Template_Neff=9.900
+
+Q gi|556503834|r  453 RVTHQMLFNTDQVIEVFVIGVGGV-GGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEP  531 (820)
+Q Consensus       453 rvthqmlfntdqvievfvigvggv-ggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakep  531 (820)
+                      -.||++.++.++.+.|.+||.|.+ |...+..|++       .  +..|++|.+...-       ..+.|.+++...+--
+T Consensus        14 ~~~~~~~~~~~~~~~i~iiG~G~~~~~~~~~~l~~-------~--~~~v~~v~d~~~~-------~~~~~~~~~~~~~~~   77 (361)
+T 3u3x_A           14 GTENLYFQSMMDELRFAAVGLNHNHIYGQVNCLLR-------A--GARLAGFHEKDDA-------LAAEFSAVYADARRI   77 (361)
+T ss_dssp             ------------CCEEEEECCCSTTHHHHHHHHHH-------T--TCEEEEEECSCHH-------HHHHHHHHSSSCCEE
+T ss_pred             ccccccccCCCCceEEEEEcCCchHHHHHHHHhhc-------c--CcEEEEEECCCHH-------HHHHHHHHcCCCccc
+Confidence            458999999999999999999985 5544444432       2  3455555543211       112233332211111
+
+
+Q gi|556503834|r  532 FNLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGA  611 (820)
+Q Consensus       532 fnlgrlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvga  611 (820)
+                      -++..++.   +  .--.+++.||....-.+.....++.|.||+.  .|.-+.+.+...+|..++++...++....+..-
+T Consensus        78 ~~~~~ll~---~--~~~D~v~i~t~~~~h~~~~~~~l~~g~~v~~--EKP~a~~~~~~~~l~~~a~~~~~~~~~~~~~r~  150 (361)
+T 3u3x_A           78 ATAEEILE---D--ENIGLIVSAAVSSERAELAIRAMQHGKDVLV--DKPGMTSFDQLAKLRRVQAETGRIFSILYSEHF  150 (361)
+T ss_dssp             SCHHHHHT---C--TTCCEEEECCCHHHHHHHHHHHHHTTCEEEE--ESCSCSSHHHHHHHHHHHHTTCCCEEEECHHHH
+T ss_pred             CCHHHHhc---C--CCCCEEEECCCchhHHHHHHHHHHCCCcEEE--eCCCCCCHHHHHHHHHHHHHcCCEEEEechhhh
+Confidence            12222221   1  1124778899998888999999999999997  344444556667777777776666654444333
+
+
+Q gi|556503834|r  612 GLPVIENLQNLLNAG  626 (820)
+Q Consensus       612 glpvienlqnllnag  626 (820)
+                      ..|.+..++.++..|
+T Consensus       151 ~~p~~~~lk~~i~~g  165 (361)
+T 3u3x_A          151 ESPATVKAGELVAAG  165 (361)
+T ss_dssp             TCHHHHHHHHHHHTT
+T ss_pred             CcHHHHHHHHHHHcC
+Confidence            258889999988765
+
+
+No 78
+>3db2_A Putative NADPH-dependent oxidoreductase; two domain protein, rossmann fold, putative dehydrogenase, S genomics; 1.70A {Desulfitobacterium hafniense dcb-2}
+Probab=95.44  E-value=0.00062  Score=60.42  Aligned_cols=140  Identities=13%  Similarity=0.200  Sum_probs=89.6  Template_Neff=10.600
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSK-ALLTNVHGLNLENWQEELAQAKEPFNLGRLIRL  540 (820)
+Q Consensus       462 tdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvansk-alltnvhglnlenwqeelaqakepfnlgrlirl  540 (820)
+                      +++.+.|.|||.|.+|...+..+++.        -+.++++|.+.. ...        +.+.++.. .+   ....+-.+
+T Consensus         2 ~~~~~~i~iiG~G~~~~~~~~~l~~~--------~~~~~~~v~~~~~~~~--------~~~~~~~~-~~---~~~~~~~l   61 (354)
+T 3db2_A            2 MYNPVGVAAIGLGRWAYVMADAYTKS--------EKLKLVTCYSRTEDKR--------EKFGKRYN-CA---GDATMEAL   61 (354)
+T ss_dssp             CCCCEEEEEECCSHHHHHHHHHHTTC--------SSEEEEEEECSSHHHH--------HHHHHHHT-CC---CCSSHHHH
+T ss_pred             CCCceEEEEECCcHHHHHHHHHHhhC--------CCeEEEEEECCCHHHH--------HHHHHHhC-CC---CcCCHHHH
+Confidence            45678899999999999888777542        134556554422 111        11111110 00   01122223
+
+
+Q gi|556503834|r  541 VKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQ  620 (820)
+Q Consensus       541 vkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlq  620 (820)
+                      ++.  .--.+++.||+.....+....+++.|.||+.  .|.-+.+.+...++..+++++...+....| .--.|.+..++
+T Consensus        62 ~~~--~~~D~V~i~~~~~~h~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~a~~~~~~~~~~~~-~r~~p~~~~~~  136 (354)
+T 3db2_A           62 LAR--EDVEMVIITVPNDKHAEVIEQCARSGKHIYV--EKPISVSLDHAQRIDQVIKETGVKFLCGHS-SRRLGALRKMK  136 (354)
+T ss_dssp             HHC--SSCCEEEECSCTTSHHHHHHHHHHTTCEEEE--ESSSCSSHHHHHHHHHHHHHHCCCEEEECG-GGGSHHHHHHH
+T ss_pred             hcC--CCCCEEEEeCChHHHHHHHHHHHHcCCcEEE--ccCCcCCHHHHHHHHHHHHHcCCeEEEccc-cccCHHHHHHH
+Confidence            332  1235788899999888888899999999988  355566778888998888877666555544 44577888888
+
+
+Q gi|556503834|r  621 NLLNAG  626 (820)
+Q Consensus       621 nllnag  626 (820)
+                      .++..|
+T Consensus       137 ~~i~~g  142 (354)
+T 3db2_A          137 EMIDTK  142 (354)
+T ss_dssp             HHHHTT
+T ss_pred             HHhhCC
+Confidence            888765
+
+
+No 79
+>2dt9_A Aspartokinase; protein-ligand complex, regulatory subunit, transferase; 2.15A {Thermus thermophilus} PDB: 2zho_A
+Probab=95.21  E-value=0.00097  Score=55.36  Aligned_cols=70  Identities=26%  Similarity=0.371  Sum_probs=61.7  Template_Neff=9.500
+
+Q gi|556503834|r  309 ISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYL  380 (820)
+Q Consensus       309 isnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefyl  380 (820)
+                      ++.-.++++.++-|++|+...|.++++|.++++..|.+..++  +++.+++|.++.+|+.+|-+++.++|+.
+T Consensus        89 v~~~~~~a~islvG~~l~~~~~~~~~i~~~L~~~~i~i~~i~--~s~~~i~~lv~~~~~~~av~~Lh~~~~~  158 (167)
+T 2dt9_A           89 AILRPDIAKVSIVGVGLASTPEVPAKMFQAVASTGANIEMIA--TSEVRISVIIPAEYAEAALRAVHQAFEL  158 (167)
+T ss_dssp             EEEECSEEEEEEEESSGGGSTHHHHHHHHHHHHTTCCCCEEE--ECSSEEEEEEEGGGHHHHHHHHHHHTC-
+T ss_pred             eEecCCceEEEEECcCcccCccHHHHHHHHHHHCCCcEEEEE--ecCCEEEEEEEHHHHHHHHHHHHHHHhc
+Confidence            455678899999999999999999999999999999988888  3467999999999999999988887753
+
+
+No 80
+>3cea_A MYO-inositol 2-dehydrogenase; NP_786804.1, oxidoreductase FA NAD-binding rossmann fold, structural genomics; HET: NAD; 2.40A {Lactobacillus plantarum WCFS1}
+Probab=94.71  E-value=0.0021  Score=56.37  Aligned_cols=146  Identities=10%  Similarity=0.116  Sum_probs=85.8  Template_Neff=10.800
+
+Q gi|556503834|r  460 FNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIR  539 (820)
+Q Consensus       460 fntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlir  539 (820)
+                      +..+..+-|-|||.|.+|...+..+.+.       +-+.++++|.....       -..+.|.++....+   -...+-.
+T Consensus         3 ~~~~~~~~i~iiG~G~~g~~~~~~~~~~-------~~~~~~~~v~d~~~-------~~~~~~~~~~~~~~---~~~~~~~   65 (346)
+T 3cea_A            3 VTTRKPLRAAIIGLGRLGERHARHLVNK-------IQGVKLVAACALDS-------NQLEWAKNELGVET---TYTNYKD   65 (346)
+T ss_dssp             --CCCCEEEEEECCSTTHHHHHHHHHHT-------CSSEEEEEEECSCH-------HHHHHHHHTTCCSE---EESCHHH
+T ss_pred             cccCCceeEEEEccCHHHHHHHHHHHHh-------CCCceEEEEecCCH-------HHHHHHHHHhCCCc---ccCCHHH
+Confidence            4556677889999999998766655432       22455555543210       00111222211100   0011112
+
+
+Q gi|556503834|r  540 LVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENL  619 (820)
+Q Consensus       540 lvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienl  619 (820)
+                      +++.  .---+++.||....-.+.....++.|-||+.  .|.-..+.+-..+|..+++++..++++-...---.|.+..+
+T Consensus        66 ~l~~--~~~d~v~i~t~~~~h~~~~~~~l~~g~~v~~--EKP~~~~~~~~~~l~~~~~~~~~~~~~~~~~~r~~p~~~~l  141 (346)
+T 3cea_A           66 MIDT--ENIDAIFIVAPTPFHPEMTIYAMNAGLNVFC--EKPLGLDFNEVDEMAKVIKSHPNQIFQSGFMRRYDDSYRYA  141 (346)
+T ss_dssp             HHTT--SCCSEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCCCSCHHHHHHHHHHHHTCTTSCEECCCGGGTCHHHHHH
+T ss_pred             Hhcc--cCCCEEEEECCchhHHHHHHHHHHCCCcEEE--eCCCCCCHHHHHHHHHHHHhcCCcEEEecchhhcCHHHHHH
+Confidence            2221  1123567788888888888999999999887  33333345556678777777656666655556667899999
+
+
+Q gi|556503834|r  620 QNLLNAG  626 (820)
+Q Consensus       620 qnllnag  626 (820)
+                      ++++..|
+T Consensus       142 ~~~i~~g  148 (346)
+T 3cea_A          142 KKIVDNG  148 (346)
+T ss_dssp             HHHHHTT
+T ss_pred             HHhhccC
+Confidence            9998765
+
+
+No 81
+>1j5p_A Aspartate dehydrogenase; TM1643, structural genomics, JCSG, protein structure initiative, joint center for structural G oxidoreductase; HET: NAD; 1.90A {Thermotoga maritima} SCOP: c.2.1.3 d.81.1.3 PDB: 1h2h_A*
+Probab=94.68  E-value=0.0023  Score=60.17  Aligned_cols=70  Identities=16%  Similarity=0.317  Sum_probs=60.8  Template_Neff=7.300
+
+Q gi|556503834|r  550 VIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQ  620 (820)
+Q Consensus       550 vivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlq  620 (820)
+                      ++|+|++.++..+.....|+.|.||++-++-+- +.-+++.+|.-++++...++.+...+-.|+|.+..+.
+T Consensus        63 vVVeaa~~~a~~e~~~~aL~aGk~Vv~~s~~al-a~~~~~~~L~~aAk~~g~~l~v~sgaiggld~i~a~~  132 (253)
+T 1j5p_A           63 TVVECASPEAVKEYSLQILKNPVNYIIISTSAF-ADEVFRERFFSELKNSPARVFFPSGAIGGLDVLSSIK  132 (253)
+T ss_dssp             EEEECSCHHHHHHHHHHHTTSSSEEEECCGGGG-GSHHHHHHHHHHHHTCSCEEECCCTTCCCHHHHHHHG
+T ss_pred             EEEECCCCHHHHHHHHHHHHcCCeEEECCcccc-cCHHHHHHHHHHHHHhCCEEEEcCCCccccHHHHHHh
+Confidence            567999999999999999999999999988663 3456688999999999999999999999999988775
+
+
+No 82
+>3l76_A Aspartokinase; allostery, ACT domains, kinase transferase; HET: LYS; 2.54A {Synechocystis}
+Probab=94.41  E-value=0.0032  Score=62.42  Aligned_cols=74  Identities=36%  Similarity=0.487  Sum_probs=66.0  Template_Neff=9.300
+
+Q gi|556503834|r  306 VKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLE  381 (820)
+Q Consensus       306 vkgisnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefyle  381 (820)
+                      ..+++.-++.+++++-|+||+.+-|.+++++.++..++|.+.++++  ++.+++++++..++.++.++..+.|+..
+T Consensus       518 ~~~~~~~~~~alisvvg~~~~~~~~~~~~i~~~L~~~~i~i~~~~~--s~~sis~~v~~~~~~~a~~~Lh~~~~~~  591 (600)
+T 3l76_A          518 DAAIVVNKAIAKVSIVGSGMIGHPGVAAHFFAALAQENINIEMIAT--SEIKISCVVPQDRGVDALKAAHSAFNLA  591 (600)
+T ss_dssp             TCEEEEECCEEEEEEECGGGTTCTTHHHHHHHHHHTTTCCCCEEEE--CSSEEEEEEEGGGHHHHHHHHHHHTTTT
+T ss_pred             CceEEeeCCEEEEEEEcCCCCCCCCHHHHHHHHHHhCCCcEEEEEc--ccCeEEEEEeHHHHHHHHHHHHHHHhcC
+Confidence            3457778889999999999999999999999999999999888884  6679999999999999999998887754
+
+
+No 83
+>3e9m_A Oxidoreductase, GFO/IDH/MOCA family; GFO/LDH/MOCA, PSI-II, dimeric dihydodiol dehydrogenase, structural genomics; 2.70A {Enterococcus faecalis}
+Probab=94.29  E-value=0.0037  Score=55.74  Aligned_cols=140  Identities=18%  Similarity=0.166  Sum_probs=84.9  Template_Neff=10.200
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKE  543 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvke  543 (820)
+                      ..+.|.+||.|.+|.+.+..+++..        +.++++|.....-       ..+.|.+.... ...|  ..+-.+++.
+T Consensus         4 ~~~~v~iiG~G~~g~~~~~~l~~~~--------~~~l~~v~d~~~~-------~~~~~~~~~~~-~~~~--~~~~~ll~~   65 (330)
+T 3e9m_A            4 DKIRYGIMSTAQIVPRFVAGLRESA--------QAEVRGIASRRLE-------NAQKMAKELAI-PVAY--GSYEELCKD   65 (330)
+T ss_dssp             CCEEEEECSCCTTHHHHHHHHHHSS--------SEEEEEEBCSSSH-------HHHHHHHHTTC-CCCB--SSHHHHHHC
+T ss_pred             CceEEEEEcccHHHHHHHHHHhhCC--------CcEEEEEEcCCHH-------HHHHHHHHcCC-Cccc--CCHHHHhcC
+Confidence            3567899999999998888777642        3455655443210       11112111100 0001  111122221
+
+
+Q gi|556503834|r  544 YHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLL  623 (820)
+Q Consensus       544 yhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnll  623 (820)
+                        .-..+++.||......+.....++.|.||+.  .|.-+.+.+...++...++++..++... -.....|.+..+.+++
+T Consensus        66 --~~~d~v~i~~~~~~~~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~~~~~~~~~~~~-~~~r~~p~~~~~~~~~  140 (330)
+T 3e9m_A           66 --ETIDIIYIPTYNQGHYSAAKLALSQGKPVLL--EKPFTLNAAEAEELFAIAQEQGVFLMEA-QKSVFLPITQKVKATI  140 (330)
+T ss_dssp             --TTCSEEEECCCGGGHHHHHHHHHHTTCCEEE--CSSCCSSHHHHHHHHHHHHHTTCCEEEC-CSGGGCHHHHHHHHHH
+T ss_pred             --CCCCEEEEeCCcHHHHHHHHHHHHCCCeEEe--cCCCCCCHHHHHHHHHHHHHcCCEEEEE-hHHhhChHHHHHHHHH
+Confidence              1235678899888888888999999999876  3444555666677777777666665433 3345578888999988
+
+
+Q gi|556503834|r  624 NAG  626 (820)
+Q Consensus       624 nag  626 (820)
+                      ..|
+T Consensus       141 ~~~  143 (330)
+T 3e9m_A          141 QEG  143 (330)
+T ss_dssp             HTT
+T ss_pred             hcC
+Confidence            765
+
+
+No 84
+>4had_A Probable oxidoreductase protein; structural genomics, protein structure initiative, nysgrc, PSI-biology; 2.00A {Rhizobium etli}
+Probab=94.20  E-value=0.0041  Score=55.49  Aligned_cols=141  Identities=11%  Similarity=0.178  Sum_probs=81.6  Template_Neff=10.400
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLV  541 (820)
+Q Consensus       463 dqvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlv  541 (820)
+                      +..+.|.|||.|.+|.. +...|++.      .  +.+|++|.....-       ..+.|.+++.-   +.-...+-.++
+T Consensus        21 ~~~~~i~iiG~G~~g~~~~~~~l~~~------~--~~~v~~i~d~~~~-------~~~~~~~~~~~---~~~~~~~~~~l   82 (350)
+T 4had_A           21 QSMLRFGIISTAKIGRDNVVPAIQDA------E--NCVVTAIASRDLT-------RAREMADRFSV---PHAFGSYEEML   82 (350)
+T ss_dssp             -CCEEEEEESCCHHHHHTHHHHHHHC------S--SEEEEEEECSSHH-------HHHHHHHHHTC---SEEESSHHHHH
+T ss_pred             CCcceEEEEcCcHHHHHHHHHHHhcC------C--CcEEEEEEeCCHH-------HHHHHHHHcCC---CcccCCHHHHh
+Confidence            45678999999999986 76666542      1  2455554432211       11223222211   00011122222
+
+
+Q gi|556503834|r  542 KEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQN  621 (820)
+Q Consensus       542 keyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqn  621 (820)
+                      ++  .--.+++.||.++.-.+...+.++.|.||+.  .|.-+.+.....+|...+++...+ ++......-.|.+..+++
+T Consensus        83 ~~--~~~d~v~i~tp~~~~~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~~~~~~~~-~~~~~~~r~~p~~~~~~~  157 (350)
+T 4had_A           83 AS--DVIDAVYIPLPTSQHIEWSIKAADAGKHVVC--EKPLALKAGDIDAVIAARDRNKVV-VTEAYMITYSPVWQKVRS  157 (350)
+T ss_dssp             HC--SSCSEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCCCSSGGGGHHHHHHHHHHTCC-EEECCGGGGSHHHHHHHH
+T ss_pred             cC--CCCCEEEEeCChHHHHHHHHHHHHCCCEEEE--eCCCCCCHHHHHHHHHHHHHcCCE-EEEeeeeeeCHHHHHHHH
+Confidence            21  1246788899999999999999999999987  233333333345565555544433 344444456789999999
+
+
+Q gi|556503834|r  622 LLNAG  626 (820)
+Q Consensus       622 llnag  626 (820)
+                      +++.|
+T Consensus       158 ~i~~g  162 (350)
+T 4had_A          158 LIDEG  162 (350)
+T ss_dssp             HHHTT
+T ss_pred             HHhcC
+Confidence            99876
+
+
+No 85
+>2y1e_A 1-deoxy-D-xylulose 5-phosphate reductoisomerase; oxidoreductase, DOXP/MEP pathway; 1.65A {Mycobacterium tuberculosis} PDB: 2jcv_A* 2jd2_A 2jd1_A 2y1d_A* 2y1c_A 2y1f_A* 2y1g_A* 3ras_A* 4a03_A* 4aic_A* 3zi0_A* 3zhy_A* 3zhz_A* 3zhx_A* 2jcx_A* 2jcy_A 2jd0_A* 2c82_A 4rcv_A* 4ooe_A* 4oof_A*
+Probab=93.78  E-value=0.0064  Score=59.28  Aligned_cols=152  Identities=22%  Similarity=0.261  Sum_probs=77.1  Template_Neff=8.100
+
+Q gi|556503834|r  453 RVTHQMLFNTDQVIEVFVIGV-GGVGGALLEQLKRQQSWLKNKHIDLRVCGVANS---KALLTNV-HGLNLENWQ---EE  524 (820)
+Q Consensus       453 rvthqmlfntdqvievfvigv-ggvggalleqlkrqqswlknkhidlrvcgvans---kalltnv-hglnlenwq---ee  524 (820)
+                      .+|.|+.+.....+.|.++|. |.+|...++.+++...       +++|.+|...   ...+... ..+....+.   ++
+T Consensus         9 ~~~~~~~~~~~~~~kI~IiGaTG~iG~~~l~~l~~~~~-------~~~vvav~~~~~~~~~~~~~a~~~~~~~~~~~~~~   81 (398)
+T 2y1e_A            9 HVTNSTDGRADGRLRVVVLGSTGSIGTQALQVIADNPD-------RFEVVGLAAGGAHLDTLLRQRAQTGVTNIAVADEH   81 (398)
+T ss_dssp             -----------CCEEEEEESTTSHHHHHHHHHHHHCTT-------TEEEEEEEECSSCHHHHHHHHHHHCCCCEEESCHH
+T ss_pred             cccCCCcccCCCeeEEEEECCCchHHHHHHHHHHhCCC-------CeEEEEEEeCCCCHHHHHHHHHHcCCCEEEEcchh
+Confidence            478889999999999999996 9999999998876432       4677777542   2222111 000000000   00
+
+
+Q gi|556503834|r  525 LAQA--KEPF-NLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRR  601 (820)
+Q Consensus       525 laqa--kepf-nlgrlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrr  601 (820)
+                      ..+.  ...+ ....+..++..  .---+++.||+...-.+.....++.|.||++-||.+-....   ..+.-.++  ..
+T Consensus        82 ~~~~~~~~~~~~~~~~~ell~~--~~vDvVv~a~~~~~~~~~~~~Al~~Gk~Vi~enke~lv~~g---~~l~~~a~--g~  154 (398)
+T 2y1e_A           82 AAQRVGDIPYHGSDAATRLVEQ--TEADVVLNALVGALGLRPTLAALKTGARLALANKESLVAGG---SLVLRAAR--PG  154 (398)
+T ss_dssp             HHHHHCCCSEESTTHHHHHHHH--SCCSEEEECCCSGGGHHHHHHHHHHTCEEEECCHHHHHHHT---HHHHHHCC--TT
+T ss_pred             hhhhccceeeeccchHHHHHhC--CCCCEEEEeCCchhHHHHHHHHHHCCCeEEEcchHHHHHHH---HHHHHHhc--CC
+Confidence            0000  0000 00112222211  11246788888887778888899999999999887643222   23333332  11
+
+
+Q gi|556503834|r  602 KFLYDTNVGAGLPVI---ENLQNLLNAGD  627 (820)
+Q Consensus       602 kflydtnvgaglpvi---enlqnllnagd  627 (820)
+                      ++         +|+.   ..+++++..|+
+T Consensus       155 ~i---------~p~~s~~~~l~~~l~~~~  174 (398)
+T 2y1e_A          155 QI---------VPVDSEHSALAQCLRGGT  174 (398)
+T ss_dssp             CE---------EECSHHHHHHHHHGGGSC
+T ss_pred             eE---------EecCHHHHHHHHHHhcCC
+Confidence            11         6666   77788887764
+
+
+No 86
+>4ew6_A D-galactose-1-dehydrogenase protein; nysgrc, PSI-biology, structural genomics, NEW YORK structura genomics research consortium, two domain; 2.30A {Rhizobium etli}
+Probab=93.76  E-value=0.0066  Score=54.92  Aligned_cols=142  Identities=15%  Similarity=0.247  Sum_probs=86.6  Template_Neff=9.800
+
+Q gi|556503834|r  456 HQMLFNTDQVIEVFVIGVGGVGG-ALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNL  534 (820)
+Q Consensus       456 hqmlfntdqvievfvigvggvgg-alleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnl  534 (820)
+                      |-+.+-....+.|.+||.|.+|. .++..+.+..        +..+++|.+...-.   .|.            +...++
+T Consensus        16 ~~~~~~~~~~~~v~iiG~G~~g~~~~~~~l~~~~--------~~~l~~v~~~~~~~---~~~------------~~~~~~   72 (330)
+T 4ew6_A           16 ENLYFQSMSPINLAIVGVGKIVRDQHLPSIAKNA--------NFKLVATASRHGTV---EGV------------NSYTTI   72 (330)
+T ss_dssp             ---CCCCCCCEEEEEECCSHHHHHTHHHHHHHCT--------TEEEEEEECSSCCC---TTS------------EEESSH
+T ss_pred             cccCCccCCceEEEEECccHHHHHHHHHHHhhCC--------CcEEEEEEeCCccc---CCC------------cccCCH
+Confidence            34445556678999999999998 7888886631        24455554322110   010            001111
+
+
+Q gi|556503834|r  535 GRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       535 grlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                      ..+   ++. +----+++.|++.....+.+..+++.|.||+.  .|..+.+.+...++.-++++...+ ++....-...|
+T Consensus        73 ~~~---~~~-~~~~d~Vvi~~p~~~h~~~~~~~l~~g~~v~~--eKP~~~~~~~~~~l~~~a~~~~~~-~~~~~~~r~~p  145 (330)
+T 4ew6_A           73 EAM---LDA-EPSIDAVSLCMPPQYRYEAAYKALVAGKHVFL--EKPPGATLSEVADLEALANKQGAS-LFASWHSRYAP  145 (330)
+T ss_dssp             HHH---HHH-CTTCCEEEECSCHHHHHHHHHHHHHTTCEEEE--CSSSCSSHHHHHHHHHHHHHHTCC-EEECCGGGGST
+T ss_pred             HHH---HhC-CCCCCEEEEcCCcHHHHHHHHHHHHCCCcEEE--cCCCCCCHHHHHHHHHHHHHcCCe-EEEeechhcCH
+Confidence            111   110 00123678899998889999999999999986  344455556667777777665443 55555556678
+
+
+Q gi|556503834|r  615 VIENLQNLLNAGD  627 (820)
+Q Consensus       615 vienlqnllnagd  627 (820)
+                      .+..+++++..|+
+T Consensus       146 ~~~~lk~~i~~g~  158 (330)
+T 4ew6_A          146 AVEAAKAFLASTT  158 (330)
+T ss_dssp             THHHHHHHHHSSC
+T ss_pred             HHHHHHHHHhcCC
+Confidence            8888999988763
+
+
+No 87
+>4gqa_A NAD binding oxidoreductase; structural genomics, PSI-biology, NEW YORK structural genomi research consortium, nysgrc; HET: MSE; 2.42A {Klebsiella pneumoniae}
+Probab=93.68  E-value=0.0071  Score=56.17  Aligned_cols=158  Identities=15%  Similarity=0.171  Sum_probs=86.3  Template_Neff=9.900
+
+Q gi|556503834|r  455 THQMLFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNL  534 (820)
+Q Consensus       455 thqmlfntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnl  534 (820)
+                      +.+.-+.....+.|.+||.|.+|...+..+++...+..+..-+.++.+|.+...-       ..+.+.+.+.. ...+  
+T Consensus        16 ~~~~~~~~~~~~~v~iiG~G~~g~~~~~~~~~~~~~~~~~~~~~~~v~v~d~~~~-------~~~~~~~~~~~-~~~~--   85 (412)
+T 4gqa_A           16 ENLYFQSMSARLNIGLIGSGFMGQAHADAYRRAAMFYPDLPKRPHLYALADQDQA-------MAERHAAKLGA-EKAY--   85 (412)
+T ss_dssp             ---------CEEEEEEECCSHHHHHHHHHHHHHHHHCTTSSSEEEEEEEECSSHH-------HHHHHHHHHTC-SEEE--
+T ss_pred             CcccccccccceeEEEEcCCHHHHHHHHHHHhccccccccCCCceEEEEECCCHH-------HHHHHHHHCCC-Cccc--
+Confidence            3445566677899999999999999888888765444432224555555443211       01112211110 0011  
+
+
+Q gi|556503834|r  535 GRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       535 grlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                      ..+-.++...  --.+++.||.+..-.+....+++.|.||+.-  |.-+.+.+-..+|.-+++++..++....+ -...|
+T Consensus        86 ~~~~~ll~~~--~~d~Vii~tp~~~h~~~~~~~l~~g~~v~~E--kP~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p  160 (412)
+T 4gqa_A           86 GDWRELVNDP--QVDVVDITSPNHLHYTMAMAAIAAGKHVYCE--KPLAVNEQQAQEMAQAARRAGVKTMVAFN-NIKTP  160 (412)
+T ss_dssp             SSHHHHHHCT--TCCEEEECSCGGGHHHHHHHHHHTTCEEEEE--SCSCSSHHHHHHHHHHHHHHTCCEEEECG-GGTSH
+T ss_pred             CCHHHHhcCC--CCCEEEEcCCcHHHHHHHHHHHHCCCcEEEc--CCCCCCHHHHHHHHHHHHHcCCeEEEEee-ccCCH
+Confidence            1111222211  1257889999988888889999999999973  32222333334555555555555554333 34457
+
+
+Q gi|556503834|r  615 VIENLQNLLNAGD  627 (820)
+Q Consensus       615 vienlqnllnagd  627 (820)
+                      .+..+++++..|.
+T Consensus       161 ~~~~~~~~i~~g~  173 (412)
+T 4gqa_A          161 AALLAKQIIARGD  173 (412)
+T ss_dssp             HHHHHHHHHHHTT
+T ss_pred             HHHHHHHHHhCCC
+Confidence            8888888887763
+
+
+No 88
+>3c1m_A Probable aspartokinase; allosteric inhibition, threonine-sensitive, ACT DOMA amino-acid biosynthesis, threonine biosynthesis; HET: ANP; 2.30A {Methanocaldococcus jannaschii} PDB: 3c1n_A 3c20_A 2hmf_A*
+Probab=93.56  E-value=0.008  Score=58.28  Aligned_cols=75  Identities=29%  Similarity=0.577  Sum_probs=64.1  Template_Neff=9.100
+
+Q gi|556503834|r  386 LLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLF  460 (820)
+Q Consensus       386 lleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvrvthqmlf  460 (820)
+                      ....+...+.+++|+++|.+|..-.++.++.|..|.+.+|++..|.|++++.++++++..++...-++.-|+.++
+T Consensus       308 ~v~~It~~~~valIsi~g~~~~~~~~~~~~i~~~L~~~~I~v~~i~~~~s~~sis~~v~~~~~~~~l~~l~~~l~  382 (473)
+T 3c1m_A          308 IVKAISTIKNVALINIFGAGMVGVSGTAARIFKALGEEEVNVILISQGSSETNISLVVSEEDVDKALKALKREFG  382 (473)
+T ss_dssp             SCCEEEEEEEEEEEEEEECSSSCHHHHHHHHHHHHHHTTCCEEEEEECCTTCCEEEEEEGGGHHHHHHHHHHHHC
+T ss_pred             cceEEEecCCEEEEEEEecCCCCcccHHHHHHHHHHHCCCcEEEEEcccccceEEEecCHHHHHHHHHHHHHHHH
+Confidence            345567788999999999999888899999999999999999999999999999999998886665666665443
+
+
+No 89
+>3s6g_A N-acetylglutamate kinase / N-acetylglutamate SYNT; synthase, transferase; HET: COA; 2.67A {Maricaulis maris} PDB: 4kzt_A* 3s7y_A 3s6h_A*
+Probab=93.40  E-value=0.0091  Score=58.49  Aligned_cols=68  Identities=19%  Similarity=0.234  Sum_probs=51.7  Template_Neff=8.600
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQ-EAME  256 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyq-eame  256 (820)
+                      +...++.+++++ +-++.|+..   +-.+|..|+.||..+.++-+-++||++|+|+.||+.      +..+++. |+-+
+T Consensus       187 l~~g~IPVv~~~-~~~~~g~~~---~v~aD~~A~~LA~~l~a~kli~ltdv~Gv~~~~~~~------i~~I~~~~e~~~  255 (460)
+T 3s6g_A          187 ARAGQAAILACL-GETPDGTLV---NINADVAVRALVHALQPYKVVFLTGTGGLLDEDGDI------LSSINLATDFGD  255 (460)
+T ss_dssp             HHTTCEEEEECE-EECTTCCEE---EECHHHHHHHHHHHHCCSEEEEECSSCSCBCTTSSB------CCEEEHHHHHHH
+T ss_pred             HHCCCeEEEcCc-eECCCCCEE---eeCHHHHHHHHHHhcCCCEEEEEeCCCceEcCCCce------EeEEcHHHHHHH
+Confidence            444566677777 456678743   347999999999999999999999999999999863      4566664 5533
+
+
+No 90
+>3ezy_A Dehydrogenase; structural genomics, unknown function, PSI-2, protein structure initiative; 2.04A {Thermotoga maritima}
+Probab=93.22  E-value=0.011  Score=52.37  Aligned_cols=75  Identities=12%  Similarity=0.143  Sum_probs=54.1  Template_Neff=10.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||+.....+.....++.|.||+.  .|.-+.+.+...+|...++++..++....+ ..-.|.+..++.+++.|
+T Consensus        66 D~v~i~~~~~~~~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~a~~~~~~~~~~~~-~r~~p~~~~~~~~i~~g  140 (344)
+T 3ezy_A           66 DAVLVCSSTNTHSELVIACAKAKKHVFC--EKPLSLNLADVDRMIEETKKADVILFTGFN-RRFDRNFKKLKEAVENG  140 (344)
+T ss_dssp             CEEEECSCGGGHHHHHHHHHHTTCEEEE--ESCSCSCHHHHHHHHHHHHHHTCCEEEECG-GGGCHHHHHHHHHHHTT
+T ss_pred             CEEEEeCCchhhHHHHHHHHhcCCeEEE--cCCCcCCHHHHHHHHHHHHhcCCEEEeccc-ccCCHHHHHHHHHHhcC
+Confidence            4677888888888888899999999998  333333455567888888777666544433 45568888888888875
+
+
+No 91
+>3ec7_A Putative dehydrogenase; alpha-beta, structural genomics, PSI-2, protein structure in midwest center for structural genomics, MCSG; HET: MSE NAD EPE; 2.15A {Salmonella typhimurium}
+Probab=93.19  E-value=0.011  Score=53.54  Aligned_cols=148  Identities=16%  Similarity=0.187  Sum_probs=84.4  Template_Neff=10.100
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLI  538 (820)
+Q Consensus       459 lfntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrli  538 (820)
+                      .+++...+.+.+||.|.+|...+..+++.       +-++++++|.+...-.       .+.+.+++.-....+  ..+-
+T Consensus        17 ~~~~~~~~~i~iiG~G~~g~~~~~~l~~~-------~~~~~~~~v~~~~~~~-------~~~~~~~~~~~~~~~--~~~~   80 (357)
+T 3ec7_A           17 LYFQGMTLKAGIVGIGMIGSDHLRRLANT-------VSGVEVVAVCDIVAGR-------AQAALDKYAIEAKDY--NDYH   80 (357)
+T ss_dssp             -----CCEEEEEECCSHHHHHHHHHHHHT-------CTTEEEEEEECSSTTH-------HHHHHHHHTCCCEEE--SSHH
+T ss_pred             ccccCCceEEEEECCCHHHHHHHHHHHhc-------CCCcEEEEEEcCCHHH-------HHHHHHHhCCCCccc--CCHH
+Confidence            45677789999999999999888877652       1245666666432111       122222221000000  1111
+
+
+Q gi|556503834|r  539 RLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIEN  618 (820)
+Q Consensus       539 rlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvien  618 (820)
+                      .++.+ .-. -+++.||....-.+.....++.|.||+. .|.. +.+.+-..++.-++++...++++-.......|.+..
+T Consensus        81 ~~l~~-~~~-D~v~i~~p~~~h~~~~~~~l~~g~~v~~-ekP~-~~~~~~~~~l~~~a~~~~~~~~~~~~~~r~~p~~~~  156 (357)
+T 3ec7_A           81 DLIND-KDV-EVVIITASNEAHADVAVAALNANKYVFC-EKPL-AVTAADCQRVIEAEQKNGKRMVQIGFMRRYDKGYVQ  156 (357)
+T ss_dssp             HHHHC-TTC-CEEEECSCGGGHHHHHHHHHHTTCEEEE-ESSS-CSSHHHHHHHHHHHHHHTSCCEEEECGGGGSHHHHH
+T ss_pred             HHhcC-CCC-CEEEEeCCHHHHHHHHHHHHHCCCcEEE-ecCc-ccCHHHHHHHHHHHHHhCCcEEEEecccccCHHHHH
+Confidence            22221 112 2556788888888888889999999998 3333 333455566666665544334544445566788999
+
+
+Q gi|556503834|r  619 LQNLLNAG  626 (820)
+Q Consensus       619 lqnllnag  626 (820)
+                      +..++..|
+T Consensus       157 ~~~~i~~~  164 (357)
+T 3ec7_A          157 LKNIIDSG  164 (357)
+T ss_dssp             HHHHHHHT
+T ss_pred             HHHHHhcC
+Confidence            99988765
+
+
+No 92
+>2nvw_A Galactose/lactose metabolism regulatory protein GAL80; transcription, galactose metabolism, repressor; 2.10A {Kluyveromyces lactis} SCOP: c.2.1.3 d.81.1.5 PDB: 3e1k_A
+Probab=92.73  E-value=0.015  Score=57.67  Aligned_cols=158  Identities=12%  Similarity=0.033  Sum_probs=92.7  Template_Neff=8.300
+
+Q gi|556503834|r  454 VTHQMLFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAK-EPF  532 (820)
+Q Consensus       454 vthqmlfntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqak-epf  532 (820)
+                      -..|+.+.+...+.|.+||.|.+|..+-....+   .++....++++++|.+...-.       .+.|.+++.-.+ ..|
+T Consensus        28 ~~~~~~~~~~~~~rV~iIG~G~~g~~~~~~h~~---~l~~~~~~~~lvav~d~~~~~-------~~~~~~~~~~~~~~~~   97 (479)
+T 2nvw_A           28 RSKLSTVPSSRPIRVGFVGLTSGKSWVAKTHFL---AIQQLSSQFQIVALYNPTLKS-------SLQTIEQLQLKHATGF   97 (479)
+T ss_dssp             TSGGGSSGGGCCEEEEEECCCSTTSHHHHTHHH---HHHHTTTTEEEEEEECSCHHH-------HHHHHHHTTCTTCEEE
+T ss_pred             CcccccCCcCCCcEEEEECcCCcchHHHHHHHH---HHHhcCCCeEEEEEEcCCHHH-------HHHHHHHcCCCCceee
+Confidence            345667788899999999999876332221111   111112356777776543211       111211110000 001
+
+
+Q gi|556503834|r  533 NLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREG------FHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYD  606 (820)
+Q Consensus       533 nlgrlirlvkeyhllnpvivdctssqavadqyadflreg------fhvvtpnkkantssmdyyhqlryaaeksrrkflyd  606 (820)
+                        ..+-.++.+  .--.+++.||.++.-.+.....++.|      .||+.  .|.-+.+.....+|..++++...++++-
+T Consensus        98 --~~~~~ll~~--~~~D~VvI~tp~~~h~~~~~~al~~g~~~~~~k~V~~--EKPla~~~~~~~~l~~~a~~~~~~~~~v  171 (479)
+T 2nvw_A           98 --DSLESFAQY--KDIDMIVVSVKVPEHYEVVKNILEHSSQNLNLRYLYV--EWALAASVQQAEELYSISQQRANLQTII  171 (479)
+T ss_dssp             --SCHHHHHHC--TTCSEEEECSCHHHHHHHHHHHHHHSSSCSSCCEEEE--ESSSSSSHHHHHHHHHHHHTCTTCEEEE
+T ss_pred             --CCHHHHhcC--CCCCEEEEcCCcHHHHHHHHHHHHcCCccccCcceEE--ecCCcCCHHHHHHHHHHHHhccCceEEE
+Confidence              111122221  12357888999999899989999999      59988  4566666777788887776622344444
+
+
+Q gi|556503834|r  607 TNVGAGLPVIENLQNLLNAGD  627 (820)
+Q Consensus       607 tnvgaglpvienlqnllnagd  627 (820)
+                      .......|.+..+++++..|.
+T Consensus       172 ~~~~r~~p~~~~lk~li~~g~  192 (479)
+T 2nvw_A          172 CLQGRKSPYIVRAKELISEGC  192 (479)
+T ss_dssp             ECGGGGCHHHHHHHHHHHTTT
+T ss_pred             EeccccCHHHHHHHHHHHcCC
+Confidence            444455888999999998763
+
+
+No 93
+>3evn_A Oxidoreductase, GFO/IDH/MOCA family; structural genomics; 2.00A {Streptococcus agalactiae serogroup V}
+Probab=92.61  E-value=0.017  Score=51.19  Aligned_cols=140  Identities=17%  Similarity=0.184  Sum_probs=79.9  Template_Neff=10.400
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKE  543 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvke  543 (820)
+                      ..+.|-+||.|.+|...+..+++..        +..+++|.....       -..+.|.+++.. ...+  ..+-.+++.
+T Consensus         4 ~~~~i~iiG~G~~~~~~~~~l~~~~--------~~~v~~v~~~~~-------~~~~~~~~~~~~-~~~~--~~~~~l~~~   65 (329)
+T 3evn_A            4 SKVRYGVVSTAKVAPRFIEGVRLAG--------NGEVVAVSSRTL-------ESAQAFANKYHL-PKAY--DKLEDMLAD   65 (329)
+T ss_dssp             -CEEEEEEBCCTTHHHHHHHHHHHC--------SEEEEEEECSCS-------STTCC---CCCC-SCEE--SCHHHHHTC
+T ss_pred             ccceEEEEeCCHHHHHHHHHHhcCC--------CcEEEEEEeCCH-------HHHHHHHHHcCC-Cccc--CCHHHHhcC
+Confidence            3467889999999998888776631        344454432211       011122221110 0011  111122221
+
+
+Q gi|556503834|r  544 YHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLL  623 (820)
+Q Consensus       544 yhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnll  623 (820)
+                        ----+++.||+.+...+...+.++.|.||+.  .|.-+.+.+...+|...+++...+|....+ -.-.|.+..+++++
+T Consensus        66 --~~~D~v~i~~~~~~~~~~~~~~l~~g~~v~~--EkP~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~~~~~i  140 (329)
+T 3evn_A           66 --ESIDVIYVATINQDHYKVAKAALLAGKHVLV--EKPFTLTYDQANELFALAESCNLFLMEAQK-SVFIPMTQVIKKLL  140 (329)
+T ss_dssp             --TTCCEEEECSCGGGHHHHHHHHHHTTCEEEE--ESSCCSSHHHHHHHHHHHHHTTCCEEEECS-SCSSHHHHHHHHHH
+T ss_pred             --CCCCEEEEcCCCHHHHHHHHHHHHCCCeEEE--eCCCCCCHHHHHHHHHHHHHcCCEEEEeec-cccCHHHHHHHHHH
+Confidence              1235778899888877777788999999887  333344455556677777776666544433 33358888899998
+
+
+Q gi|556503834|r  624 NAG  626 (820)
+Q Consensus       624 nag  626 (820)
+                      ..|
+T Consensus       141 ~~~  143 (329)
+T 3evn_A          141 ASG  143 (329)
+T ss_dssp             HTT
+T ss_pred             hcC
+Confidence            765
+
+
+No 94
+>4hkt_A Inositol 2-dehydrogenase; structural genomics, nysgrc, PSI-biology, NEW YORK structura genomics research consortium, oxidoreductase; HET: MSE; 2.00A {Sinorhizobium meliloti}
+Probab=92.12  E-value=0.022  Score=49.45  Aligned_cols=137  Identities=15%  Similarity=0.168  Sum_probs=81.2  Template_Neff=10.900
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPF-NLGRLIRLVKE  543 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepf-nlgrlirlvke  543 (820)
+                      .+.|.+||.|.+|...+..+++.        -+..++++.+...-.       .+.+.++..   -++ ++..   ++..
+T Consensus         3 ~~~i~iiG~G~~g~~~~~~l~~~--------~~~~~~~~~~~~~~~-------~~~~~~~~~---~~~~~~~~---~~~~   61 (331)
+T 4hkt_A            3 TVRFGLLGAGRIGKVHAKAVSGN--------ADARLVAVADAFPAA-------AEAIAGAYG---CEVRTIDA---IEAA   61 (331)
+T ss_dssp             CEEEEEECCSHHHHHHHHHHHHC--------TTEEEEEEECSSHHH-------HHHHHHHTT---CEECCHHH---HHHC
+T ss_pred             ccEEEEECCCHHHHHHHHHHhcC--------CCceEEEEEcCCHHH-------HHHHHHHhC---CCcccHHH---Hhcc
+Confidence            46788999999998777766542        245666665432111       011111100   000 1111   1111
+
+
+Q gi|556503834|r  544 YHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLL  623 (820)
+Q Consensus       544 yhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnll  623 (820)
+                       . ---+++.||......+.....++.|-||+.  .|.-+.+.+-..++..+++++..++ +-.....-.|.+..+++++
+T Consensus        62 -~-~~d~v~i~~~~~~h~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~a~~~~~~~-~v~~~~r~~p~~~~~k~~i  136 (331)
+T 4hkt_A           62 -A-DIDAVVICTPTDTHADLIERFARAGKAIFC--EKPIDLDAERVRACLKVVSDTKAKL-MVGFNRRFDPHFMAVRKAI  136 (331)
+T ss_dssp             -T-TCCEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCSCSSHHHHHHHHHHHHHTTCCE-EECCGGGGCHHHHHHHHHH
+T ss_pred             -C-CCCEEEEeCCcHHHHHHHHHHHHcCCeEEE--eCCCcCCHHHHHHHHHHHHHcCCeE-EecccccCCHHHHHHHHHH
+Confidence             0 123566788888888888889999999998  3444444455567777777765554 4444456678888888888
+
+
+Q gi|556503834|r  624 NAGD  627 (820)
+Q Consensus       624 nagd  627 (820)
+                      ..|.
+T Consensus       137 ~~g~  140 (331)
+T 4hkt_A          137 DDGR  140 (331)
+T ss_dssp             HTTT
+T ss_pred             hCCC
+Confidence            7653
+
+
+No 95
+>3mz0_A Inositol 2-dehydrogenase/D-chiro-inositol 3-dehyd; MYO-inositol dehydrogenase, bsidh, oxidoreductase; HET: MSE PGE; 1.54A {Bacillus subtilis} PDB: 3nt2_A* 3nt4_A* 3nt5_A* 3nto_A* 3ntq_A* 3ntr_A* 4l8v_A* 4l9r_A
+Probab=92.03  E-value=0.024  Score=50.14  Aligned_cols=140  Identities=10%  Similarity=0.082  Sum_probs=80.1  Template_Neff=10.600
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKA-LLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanska-lltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      +.|.+||.|.+|...+..++++.       -+.++++|..... .+.        .+.+++......|  ..+-.+++. 
+T Consensus         3 ~~v~iiG~G~~g~~~~~~~~~~~-------~~~~i~~v~~~~~~~~~--------~~~~~~~~~~~~~--~~~~~~~~~-   64 (344)
+T 3mz0_A            3 LRIGVIGTGAIGKEHINRITNKL-------SGAEIVAVTDVNQEAAQ--------KVVEQYQLNATVY--PNDDSLLAD-   64 (344)
+T ss_dssp             EEEEEECCSHHHHHHHHHHHHTC-------SSEEEEEEECSSHHHHH--------HHHHHTTCCCEEE--SSHHHHHHC-
+T ss_pred             cEEEEECCcHHHHHHHHHHHhhC-------CCceEEEEECCCHHHHH--------HHHHHhCCCCeee--cCHHHHhcC-
+Confidence            56789999999988887776532       2345555433221 111        1111110000001  112222221 
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLN  624 (820)
+Q Consensus       545 hllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnlln  624 (820)
+                      . --.+++.||....-.+.....++.|.||+.  .|.-..+.+-..+|...++++...+++-.......|.+..++++++
+T Consensus        65 ~-~~D~v~i~~~~~~h~~~~~~~~~~g~~v~~--eKP~~~~~~~~~~l~~~~~~~~~~~~~~~~~~r~~p~~~~~k~~i~  141 (344)
+T 3mz0_A           65 E-NVDAVLVTSWGPAHESSVLKAIKAQKYVFC--EKPLATTAEGCMRIVEEEIKVGKRLVQVGFMRRYDSGYVQLKEALD  141 (344)
+T ss_dssp             T-TCCEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCSCSSHHHHHHHHHHHHHHSSCCEEECCGGGGSHHHHHHHHHHH
+T ss_pred             C-CCCEEEEeCCchhHHHHHHHHHHcCCeEEE--eCCCcCCHHHHHHHHHHHHHhCCeEEEecccccCCHHHHHHHHHHh
+Confidence            1 113556688888888888889999999988  3444445666667777776654445544444455678888999888
+
+
+Q gi|556503834|r  625 AG  626 (820)
+Q Consensus       625 ag  626 (820)
+                      .|
+T Consensus       142 ~g  143 (344)
+T 3mz0_A          142 NH  143 (344)
+T ss_dssp             TT
+T ss_pred             cC
+Confidence            75
+
+
+No 96
+>3m2t_A Probable dehydrogenase; PSI, SGXNY, structural genomics, protein structure initiative; HET: NAD; 2.30A {Chromobacterium violaceum}
+Probab=91.60  E-value=0.03  Score=50.34  Aligned_cols=140  Identities=16%  Similarity=0.136  Sum_probs=81.0  Template_Neff=10.300
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGG-ALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVK  542 (820)
+Q Consensus       464 qvievfvigvggvgg-alleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvk  542 (820)
+                      ..+-|.+||.|.+|. +++..+++..        +.++++|.+...-.       .+.+.+++...+---++..++   +
+T Consensus         4 ~~~~i~iiG~G~~g~~~~~~~l~~~~--------~~~v~~v~~~~~~~-------~~~~~~~~~~~~~~~~~~~~~---~   65 (359)
+T 3m2t_A            4 SLIKVGLVGIGAQMQENLLPSLLQMQ--------DIRIVAACDSDLER-------ARRVHRFISDIPVLDNVPAML---N   65 (359)
+T ss_dssp             CCEEEEEECCSHHHHHTHHHHHHTCT--------TEEEEEEECSSHHH-------HGGGGGTSCSCCEESSHHHHH---H
+T ss_pred             CceEEEEEcCCHHHHHHHHHHHHhCC--------CceEEEEEcCCHHH-------HHHHHHhcCCCcccCCHHHHh---c
+Confidence            345678999999998 7888876521        24555544332100       111211111111111222221   1
+
+
+Q gi|556503834|r  543 EYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNL  622 (820)
+Q Consensus       543 eyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnl  622 (820)
+                      +.  --.+++.||.+..-.+.....++.|.||+.  .|..+.+.+-..++...++++..++....+ -...|.+..++.+
+T Consensus        66 ~~--~~D~v~i~tp~~~h~~~~~~~l~~g~~v~~--EkP~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~~~~~  140 (359)
+T 3m2t_A           66 QV--PLDAVVMAGPPQLHFEMGLLAMSKGVNVFV--EKPPCATLEELETLIDAARRSDVVSGVGMN-FKFARPVRQLREM  140 (359)
+T ss_dssp             HS--CCSEEEECSCHHHHHHHHHHHHHTTCEEEE--CSCSCSSHHHHHHHHHHHHHHTCCEEECCH-HHHCHHHHHHHHH
+T ss_pred             CC--CCCEEEEeCCHHHHHHHHHHHHHCCCeEEE--eCCCCCCHHHHHHHHHHHHHcCCeEEEEee-eeecHHHHHHHHH
+Confidence            11  135788999999888999999999999987  233344444455666666665555444433 4456888888888
+
+
+Q gi|556503834|r  623 LNAG  626 (820)
+Q Consensus       623 lnag  626 (820)
+                      +..|
+T Consensus       141 i~~g  144 (359)
+T 3m2t_A          141 TQVD  144 (359)
+T ss_dssp             HTSG
+T ss_pred             HhcC
+Confidence            8765
+
+
+No 97
+>3ohs_X Trans-1,2-dihydrobenzene-1,2-DIOL dehydrogenase; dimeric dihydrodiol dehydrogenase, MDD, oxidoreductase; 1.90A {Macaca fascicularis} PDB: 2o48_X 2poq_X* 2o4u_X
+Probab=91.58  E-value=0.03  Score=49.45  Aligned_cols=140  Identities=15%  Similarity=0.125  Sum_probs=81.2  Template_Neff=10.500
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEYH  545 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkeyh  545 (820)
+                      +.|-+||.|.+|...+..+++..    +  -+.++.+|.+...-       ..+.+.+++... ..|  ..+-.+++.  
+T Consensus         3 ~~v~iiG~G~~g~~~~~~l~~~~----~--~~~~i~~v~~~~~~-------~~~~~~~~~~~~-~~~--~~~~~~~~~--   64 (334)
+T 3ohs_X            3 LRWGIVSVGLISSDFTAVLQTLP----R--SEHQVVAVAARDLS-------RAKEFAQKHDIP-KAY--GSYEELAKD--   64 (334)
+T ss_dssp             EEEEEECCSHHHHHHHHHHTTSC----T--TTEEEEEEECSSHH-------HHHHHHHHHTCS-CEE--SSHHHHHHC--
+T ss_pred             eEEEEEcCCHHHHHHHHHHHhCC----C--cCceEEEEEeCCHH-------HHHHHHHHcCCC-ccc--CCHHHHhcC--
+Confidence            45789999999998888776532    1  13455555443210       111122211110 011  111122221  
+
+
+Q gi|556503834|r  546 LLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNA  625 (820)
+Q Consensus       546 llnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllna  625 (820)
+                      ---.+++.||....-.+....+++.|.||+.  .|.-..+.+-..+|...+++...++....+ ....|.+..++.++..
+T Consensus        65 ~~~D~v~i~~~~~~h~~~~~~~l~~g~~v~~--EKP~~~~~~~~~~l~~~a~~~~~~~~~~~~-~r~~p~~~~~~~~i~~  141 (334)
+T 3ohs_X           65 PNVEVAYVGTQHPQHKAAVMLCLAAGKAVLC--EKPMGVNAAEVREMVTEARSRGLFLMEAIW-TRFFPASEALRSVLAQ  141 (334)
+T ss_dssp             TTCCEEEECCCGGGHHHHHHHHHHTTCEEEE--ESSSSSSHHHHHHHHHHHHHTTCCEEEECG-GGGSHHHHHHHHHHHH
+T ss_pred             CCCCEEEEcCCChhHHHHHHHHHHCCCeEEE--eCCCCCCHHHHHHHHHHHHHcCCeEEEEeh-hccChHHHHHHHHHhc
+Confidence            1124677799988888888889999999988  344444556666776666665555554444 3567788888888876
+
+
+Q gi|556503834|r  626 G  626 (820)
+Q Consensus       626 g  626 (820)
+                      |
+T Consensus       142 ~  142 (334)
+T 3ohs_X          142 G  142 (334)
+T ss_dssp             T
+T ss_pred             C
+Confidence            5
+
+
+No 98
+>4nhe_A Oxidoreductase, GFO/IDH/MOCA family; structural genomics, PSI-biology; HET: NAP; 1.95A {Streptococcus pneumoniae} PDB: 4iq0_A* 2ho5_A
+Probab=91.44  E-value=0.032  Score=49.13  Aligned_cols=141  Identities=17%  Similarity=0.230  Sum_probs=81.8  Template_Neff=10.500
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      .+.|-+||.|.+|..++..|.+.      .  +.++.+|.+...-       ..+.+.++....+ .  ...+-.+++  
+T Consensus         4 ~~~i~iiG~G~~g~~~~~~l~~~------~--~~~i~~v~~~~~~-------~~~~~~~~~~~~~-~--~~~~~~l~~--   63 (328)
+T 4nhe_A            4 MLKLGVIGTGAISHHFIEAAHTS------G--EYQLVAIYSRKLE-------TAATFASRYQNIQ-L--FDQLEVFFK--   63 (328)
+T ss_dssp             CEEEEEECCSHHHHHHHHHHHHH------T--SEEEEEEECSSHH-------HHHHHHTTSSSCE-E--ESCHHHHHH--
+T ss_pred             ceEEEEEcCCHHHHHHHHHHhhC------C--CeEEEEEEeCCHH-------HHHHHHHHcCCCc-c--cCCHHHHhc--
+Confidence            35678999999999887777542      1  2344444332110       0011111110000 0  011111121  
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLN  624 (820)
+Q Consensus       545 hllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnlln  624 (820)
+                       .--.+++.||.+..-.+.....++.|-||+. .|... .+.+-..++...+++... +++....-...|.+..++.++.
+T Consensus        64 -~~~d~v~i~~~~~~h~~~~~~~l~~gk~v~~-EkP~~-~~~~~~~~l~~~a~~~~~-~~~~~~~~r~~p~~~~~k~~i~  139 (328)
+T 4nhe_A           64 -SSFDLVYIASPNSLHFAQAKAALSAGKHVIL-EKPAV-SQPQEWFDLIQTAEKNNC-FIFEAARNYHEKAFTTIKNFLA  139 (328)
+T ss_dssp             -SSCSEEEECSCGGGHHHHHHHHHHTTCEEEE-ESSCC-SSHHHHHHHHHHHHHTTC-CEEEECTTTTCHHHHHHHHHHH
+T ss_pred             -CCCCEEEECCChHHHHHHHHHHHHCCCeEEE-ccccc-CCHHHHHHHHHHHHHcCC-EEEEeehhccCHHHHHHHHHHh
+Confidence             1235788899988888888899999999997 44433 344555666666655544 4555555567899999999998
+
+
+Q gi|556503834|r  625 AGDEL  629 (820)
+Q Consensus       625 agdel  629 (820)
+                      .|+.+
+T Consensus       140 ~g~~i  144 (328)
+T 4nhe_A          140 DKQVL  144 (328)
+T ss_dssp             TSCEE
+T ss_pred             cCCee
+Confidence            76533
+
+
+No 99
+>3euw_A MYO-inositol dehydrogenase; protein structure initiative II (PSI II), NYSGXRC, MYO-inosi dehydrogenase, oxidoreductase, tetramer; 2.30A {Corynebacterium glutamicum}
+Probab=91.14  E-value=0.038  Score=48.88  Aligned_cols=140  Identities=11%  Similarity=0.091  Sum_probs=77.0  Template_Neff=10.600
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKE  543 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvke  543 (820)
+                      +.+-|.|||.|.+|.+.+..+.+.      .  +..+++|.+...-       ..+.+.++.. .+ .+  ..+..+++.
+T Consensus         3 ~~~~i~iiG~G~~g~~~~~~l~~~------~--~~~v~~v~~~~~~-------~~~~~~~~~~-~~-~~--~~~~~~~~~   63 (344)
+T 3euw_A            3 LTLRIALFGAGRIGHVHAANIAAN------P--DLELVVIADPFIE-------GAQRLAEANG-AE-AV--ASPDEVFAR   63 (344)
+T ss_dssp             CCEEEEEECCSHHHHHHHHHHHHC------T--TEEEEEEECSSHH-------HHHHHHHTTT-CE-EE--SSHHHHTTC
+T ss_pred             CceEEEEECCCHHHHHHHHHHHhC------C--CcEEEEEEcCCHH-------HHHHHHHHcC-Cc-cc--CCHHHHhcC
+Confidence            345688999999999888877653      1  2344444332110       0111111110 00 00  011122221
+
+
+Q gi|556503834|r  544 YHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLL  623 (820)
+Q Consensus       544 yhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnll  623 (820)
+                        .---+++.||++..-.+.....++.|.||+. .|. -+.+.+-..++.-++++...++... ......|.+..++.++
+T Consensus        64 --~~~d~v~i~~~~~~~~~~~~~~l~~g~~v~~-ekp-~~~~~~~~~~l~~~~~~~~~~~~~~-~~~r~~p~~~~~~~~i  138 (344)
+T 3euw_A           64 --DDIDGIVIGSPTSTHVDLITRAVERGIPALC-EKP-IDLDIEMVRACKEKIGDGASKVMLG-FNRRFDPSFAAINARV  138 (344)
+T ss_dssp             --SCCCEEEECSCGGGHHHHHHHHHHTTCCEEE-CSC-SCSCHHHHHHHHHHHGGGGGGEEEC-CGGGGCHHHHHHHHHH
+T ss_pred             --CCCCEEEEcCCcHHHHHHHHHHHHcCCCEEe-cCC-CcCCHHHHHHHHHHHHhCCCeEEec-cccccCHHHHHHHHHH
+Confidence              1124678899998888888889999999987 222 2222333445555555554444433 3344568888888888
+
+
+Q gi|556503834|r  624 NAGD  627 (820)
+Q Consensus       624 nagd  627 (820)
+                      ..|.
+T Consensus       139 ~~~~  142 (344)
+T 3euw_A          139 ANQE  142 (344)
+T ss_dssp             HTTT
+T ss_pred             hcCC
+Confidence            7653
+
+
+No 100
+>2dc1_A L-aspartate dehydrogenase; NAD, oxidoreductase; HET: CIT NAD; 1.90A {Archaeoglobus fulgidus}
+Probab=90.64  E-value=0.047  Score=46.42  Aligned_cols=117  Identities=23%  Similarity=0.342  Sum_probs=67.2  Template_Neff=10.200
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKRQQSWLKNKHIDL-RVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEYH  545 (820)
+Q Consensus       467 evfvigvggvggalleqlkrqqswlknkhidl-rvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkeyh  545 (820)
+                      .|.+||.|.+|..+++.|.+.       +.++ .+|....+++           .+.         -++..++.  +   
+T Consensus         2 ~i~iiG~G~~G~~~~~~l~~~-------~~~vv~v~~~~~~~~-----------~~~---------~~~~~~~~--~---   49 (236)
+T 2dc1_A            2 LVGLIGYGAIGKFLAEWLERN-------GFEIAAILDVRGEHE-----------KMV---------RGIDEFLQ--R---   49 (236)
+T ss_dssp             EEEEECCSHHHHHHHHHHHHT-------TCEEEEEECSSCCCT-----------TEE---------SSHHHHTT--S---
+T ss_pred             EEEEECCCHHHHHHHHHHHhC-------CcEEEEEEecChhhc-----------ccc---------CCHHHHhc--C---
+Confidence            467899999999999888642       2232 3333322222           000         01111110  1   
+
+
+Q gi|556503834|r  546 LLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIE  617 (820)
+Q Consensus       546 llnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvie  617 (820)
+                       -.-++++|++.+...+.....++.|.+++.-.....+ .-+...++..++++....++.+.++..|+..+.
+T Consensus        50 -~~DvVi~~~~~~~~~~~~~~~l~~g~~vv~~~~~~~~-~~~~~~~l~~~a~~~~~~~~~~~~~~g~~~~~~  119 (236)
+T 2dc1_A           50 -EMDVAVEAASQQAVKDYAEKILKAGIDLIVLSTGAFA-DRDFLSRVREVCRKTGRRVYIASGAIGGLDAIF  119 (236)
+T ss_dssp             -CCSEEEECSCHHHHHHHHHHHHHTTCEEEESCGGGGG-SHHHHHHHHHHHHHHCCCEEECCTTCSCHHHHH
+T ss_pred             -CCCEEEEcCChHHHHHHHHHHHHCCCcEEEECccccC-CHHHHHHHHHHHHHcCCEEEEeCCcccCHHHHH
+Confidence             1357889998888888777888999998875533222 112234555566666666666666655555443
+
+
+No 101
+>3moi_A Probable dehydrogenase; structural genomics, PSI2, MCSG, protein structure initiativ midwest center for structural genomics; 2.50A {Bordetella bronchiseptica}
+Probab=90.22  E-value=0.056  Score=49.64  Aligned_cols=76  Identities=18%  Similarity=0.274  Sum_probs=53.9  Template_Neff=10.000
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAGD  627 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnagd  627 (820)
+                      .+++.||......+.....++.|.||+.  .|.-+.+.+....+..++++...++.-.. .-.-.|.+..++.++..|.
+T Consensus        66 d~v~i~~~~~~~~~~~~~~l~~g~~v~~--ekp~~~~~~~~~~l~~~a~~~~~~~~~~~-~~r~~p~~~~~k~li~~g~  141 (387)
+T 3moi_A           66 DAVYIASPHQFHCEHVVQASEQGLHIIV--EKPLTLSRDEADRMIEAVERAGVHLVVGT-SRSHDPVVRTLRAIVQEGS  141 (387)
+T ss_dssp             SEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCCCSCHHHHHHHHHHHHHHTCCEEECC-CGGGSHHHHHHHHHHHHCT
+T ss_pred             cEEEEcCCHHHHHHHHHHHHHCCCceEe--cCCCcCCHHHHHHHHHHHHHcCCEEEEec-ccccCHHHHHHHHHHHCCC
+Confidence            4788899998888888889999999887  33333444555666666666666654443 3467788888888887654
+
+
+No 102
+>1h6d_A Precursor form of glucose-fructose oxidoreductase; protein translocation, periplasmic oxidoreductase, signal peptide, ligand binding,; HET: NDP; 2.05A {Zymomonas mobilis} SCOP: c.2.1.3 d.81.1.5 PDB: 1h6b_A* 1h6a_A* 1h6c_A* 1ryd_A* 1rye_A* 1ofg_A* 1evj_A*
+Probab=89.94  E-value=0.062  Score=51.08  Aligned_cols=144  Identities=13%  Similarity=0.116  Sum_probs=82.5  Template_Neff=9.400
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFN-LGRLIRL  540 (820)
+Q Consensus       463 dqvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfn-lgrlirl  540 (820)
+                      +..+.|.+||.|.+|.. .+..+.+.      +  ++++++|.+...       -..+.|.+++.....++. ...+-.+
+T Consensus        81 ~~~~~vgiIG~G~~g~~~~~~~l~~~------~--~~~~v~v~d~~~-------~~~~~~~~~~~~~~~~~~~~~~~~~~  145 (433)
+T 1h6d_A           81 DRRFGYAIVGLGKYALNQILPGFAGC------Q--HSRIEALVSGNA-------EKAKIVAAEYGVDPRKIYDYSNFDKI  145 (433)
+T ss_dssp             CCCEEEEEECCSHHHHHTHHHHTTTC------S--SEEEEEEECSCH-------HHHHHHHHHTTCCGGGEECSSSGGGG
+T ss_pred             CCceeEEEECCCHHHHHHHHHHhhcC------C--CcEEEEEEcCCH-------HHHHHHHHHhCCCcccccccCCHHHH
+Confidence            44588999999999984 66665442      1  234444433211       112233333321100000 0111122
+
+
+Q gi|556503834|r  541 VKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQ  620 (820)
+Q Consensus       541 vkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlq  620 (820)
+                      ++.  .--.+|+.||++..-.....++++.|.||+.  .|.-+.+.+-..+|+..+++....+ +......-.|.+..++
+T Consensus       146 ~~~--~~~DvVi~~t~~~~~~~~~~~~l~~g~~v~~--ekp~~~~~~~~~~l~~~a~~~~~~~-~~~~~~r~~p~~~~~~  220 (433)
+T 1h6d_A          146 AKD--PKIDAVYIILPNSLHAEFAIRAFKAGKHVMC--EKPMATSVADCQRMIDAAKAANKKL-MIGYRCHYDPMNRAAV  220 (433)
+T ss_dssp             GGC--TTCCEEEECSCGGGHHHHHHHHHHTTCEEEE--CSSCCSSHHHHHHHHHHHHHHTCCE-EECCGGGGCHHHHHHH
+T ss_pred             hcC--CCCCEEEEeCCcHHHHHHHHHHHHCCCeEEE--ecCCCCCHHHHHHHHHHHHHcCCeE-EEEeccccCHHHHHHH
+Confidence            221  1246888999987655555789999999987  3333444555678887777765554 4445566778888888
+
+
+Q gi|556503834|r  621 NLLNAG  626 (820)
+Q Consensus       621 nllnag  626 (820)
+                      .++..|
+T Consensus       221 ~~i~~g  226 (433)
+T 1h6d_A          221 KLIREN  226 (433)
+T ss_dssp             HHHHTT
+T ss_pred             HHHHcC
+Confidence            888765
+
+
+No 103
+>4fb5_A Probable oxidoreductase protein; PSI-biology, nysgrc, structural genomics, NEW YORK structura genomics research consortium, GFO/IDH/MOCA family; 2.61A {Rhizobium etli}
+Probab=89.43  E-value=0.074  Score=48.58  Aligned_cols=161  Identities=19%  Similarity=0.174  Sum_probs=81.0  Template_Neff=10.200
+
+Q gi|556503834|r  450 TGVRVTHQML-FNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQA  528 (820)
+Q Consensus       450 tgvrvthqml-fntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqa  528 (820)
+                      .||..+--++ .+....+.|.+||.|.+|...+..+++.+.-+.. +-+.++++|.+...-       ..+.+.++..- 
+T Consensus         9 ~~~~~~~~~~~~~~~~~~~i~iiG~G~~g~~~~~~l~~~~~~~~~-~~~~~v~~v~d~~~~-------~~~~~~~~~~~-   79 (393)
+T 4fb5_A            9 SGVDLGTENLYFQSMKPLGIGLIGTGYMGKCHALAWNAVKTVFGD-VERPRLVHLAEANAG-------LAEARAGEFGF-   79 (393)
+T ss_dssp             ---------------CCCEEEEECCSHHHHHHHHHHTTHHHHHCS-SCCCEEEEEECC--T-------THHHHHHHHTC-
+T ss_pred             cccccccchhccccCCceeEEEECCCHHHHHHHHHHHhCchhhcc-cccceEEEEecCCHH-------HHHHHHHHcCC-
+Confidence            3444443333 3456788999999999999888777653321111 123455555433210       01111111100 
+
+
+Q gi|556503834|r  529 KEPFNLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTN  608 (820)
+Q Consensus       529 kepfnlgrlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtn  608 (820)
+                      ...++  .+-.++...  ---+++.||....-.+.....++.|.||+.  .|.-+.+.+-..++..++++...+|... .
+T Consensus        80 ~~~~~--~~~~l~~~~--~~D~V~i~~~~~~h~~~~~~~~~~g~~v~~--ekP~~~~~~~~~~l~~~~~~~~~~~~~~-~  152 (393)
+T 4fb5_A           80 EKATA--DWRALIADP--EVDVVSVTTPNQFHAEMAIAALEAGKHVWC--EKPMAPAYADAERMLATAERSGKVAALG-Y  152 (393)
+T ss_dssp             SEEES--CHHHHHHCT--TCCEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCSCSSHHHHHHHHHHHHHSSSCEEEC-C
+T ss_pred             CcccC--CHHHHhcCC--CCCEEEEcCCchHHHHHHHHHHHcCCeEEE--ECCCCCCHHHHHHHHHHHHHcCCeEEEe-e
+Confidence            00011  111122110  124678899988888888888999999987  2332333334455555565555555433 3
+
+
+Q gi|556503834|r  609 VGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       609 vgaglpvienlqnllnag  626 (820)
+                      .-.-.|.+..++.++..|
+T Consensus       153 ~~r~~p~~~~~~~~i~~g  170 (393)
+T 4fb5_A          153 NYIQNPVMRHIRKLVGDG  170 (393)
+T ss_dssp             GGGGCHHHHHHHHHHHTT
+T ss_pred             cccCCHHHHHHHHHHHcC
+Confidence            345568888888888765
+
+
+No 104
+>3ip3_A Oxidoreductase, putative; structural genomics, PSI-2, protein structure initiative, NEW YORK SGX research center for structural genomics; 2.14A {Thermotoga maritima}
+Probab=89.32  E-value=0.077  Score=47.46  Aligned_cols=75  Identities=15%  Similarity=0.115  Sum_probs=52.6  Template_Neff=10.200
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEK--SRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaek--srrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||....-++....+++.|.||+.-  |.-+.+.+-..+|..++++  +...+....+ -.-.|.+..+++++..|
+T Consensus        69 D~vii~tp~~~h~~~~~~~l~~g~~v~~E--KP~~~~~~~~~~l~~~a~~~~~~~~~~v~~~-~r~~p~~~~~~~~i~~g  145 (337)
+T 3ip3_A           69 DILVINTVFSLNGKILLEALERKIHAFVE--KPIATTFEDLEKIRSVYQKVRNEVFFTAMFG-IRYRPHFLTAKKLVSEG  145 (337)
+T ss_dssp             SEEEECSSHHHHHHHHHHHHHTTCEEEEC--SSSCSSHHHHHHHHHHHHHHTTTCCEEECCG-GGGSHHHHHHHHHHHHT
+T ss_pred             CEEEEeCCchhhHHHHHHHHHCCCcEEEE--CCCCCCHHHHHHHHHHHHHhccCcEEEecch-hhcCHHHHHHHHHHHCC
+Confidence            36778999888889999999999999853  4444445556677777776  3344443333 45667788888888765
+
+
+No 105
+>4gmf_A Yersiniabactin biosynthetic protein YBTU; rossmann fold, NADPH dependent thiazoline reductase, oxidore; HET: EPE; 1.85A {Yersinia enterocolitica subsp} PDB: 4gmg_A*
+Probab=88.88  E-value=0.089  Score=48.05  Aligned_cols=138  Identities=18%  Similarity=0.204  Sum_probs=79.8  Template_Neff=10.000
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKE-PFNLGRLIRLVK  542 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqake-pfnlgrlirlvk  542 (820)
+                      ..+.+.+||.| +|..++..+++...       +..+++|.+...-           ..+++++... + ....+-.+++
+T Consensus         6 ~~~~i~iiG~G-~g~~~~~~l~~~~~-------~~~l~~v~d~~~~-----------~~~~~~~~~~~~-~~~~~~e~~~   65 (372)
+T 4gmf_A            6 PKQRVLIVGAK-FGEMYLNAFMQPPE-------GLELVGLLAQGSA-----------RSRELAHAFGIP-LYTSPEQITG   65 (372)
+T ss_dssp             -CEEEEEECST-TTHHHHHTTSSCCT-------TEEEEEEECCSSH-----------HHHHHHHHTTCC-EESSGGGCCS
+T ss_pred             CCCeEEEEcCC-HHHHHHHHHHhCCC-------CeEEEEEEcCCHH-----------HHHHHHHHcCCC-ccCCHHHHhc
+Confidence            34568899999 99988887765321       3456665543210           0111111000 0 0011111111
+
+
+Q gi|556503834|r  543 EYHLLNPVIVDCTS--SQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQ  620 (820)
+Q Consensus       543 eyhllnpvivdcts--sqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlq  620 (820)
+                      .  .---+++.||.  .....+....+++.|.||+.....+    .+-..+|..++++...++.    ++.-.|.+..++
+T Consensus        66 ~--~~~d~v~i~~~~~~~~h~~~~~~~l~~g~~V~~ekP~~----~~~~~~l~~~a~~~~~~~~----v~r~~p~~~~~k  135 (372)
+T 4gmf_A           66 M--PDIACIVVRSTVAGGAGTQLARHFLARGVHVIQEHPLH----PDDISSLQTLAQEQGCCYW----INTFYPHTRAGR  135 (372)
+T ss_dssp             C--CSEEEECCC--CTTSHHHHHHHHHHHTTCEEEEESCCC----HHHHHHHHHHHHHHTCCEE----EECSGGGSHHHH
+T ss_pred             C--CCCcEEEEeCCCCCccHHHHHHHHHhcCCcEEEcCCCC----HHHHHHHHHHHHHhCCEEE----EecCCHHHHHHH
+Confidence            1  01235677888  7788888888999999998743333    4455667667776666655    357889999999
+
+
+Q gi|556503834|r  621 NLLNAGDELMK  631 (820)
+Q Consensus       621 nllnagdelmk  631 (820)
+                      +++..|..+..
+T Consensus       136 ~~i~~g~~l~~  146 (372)
+T 4gmf_A          136 TWLRDAQQLRR  146 (372)
+T ss_dssp             HHHHHHHHHHH
+T ss_pred             HHHHHhHHHHh
+Confidence            99998775443
+
+
+No 106
+>4ab7_A Protein Arg5,6, mitochondrial; transferase, arginine biosynthesis, amino acid kinase domain GCN5-related acetyltransferase, GNAT; HET: NLG; 3.25A {Saccharomyces cerevisiae} PDB: 3zzi_A*
+Probab=88.19  E-value=0.11  Score=52.10  Aligned_cols=70  Identities=14%  Similarity=0.228  Sum_probs=53.3  Template_Neff=7.800
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQ-EAMEL  257 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyq-eamel  257 (820)
+                      +..++++++.++. .+.+|+...   -.+|..|+.+|..+.++.+-++||++|+|+.+|     ...+..+++. |+-++
+T Consensus       177 L~~g~IPVI~~~a-~~~~g~~~~---v~sD~vA~~lA~~L~a~klIiLtdvgGI~~~~~-----~~~i~~Inl~qE~~~l  247 (464)
+T 4ab7_A          177 IKAGALPILTSLA-ETASGQMLN---VNADVAAGELARVFEPLKIVYLNEKGGIINGST-----GEKISMINLDEEYDDL  247 (464)
+T ss_dssp             HHTTCEEEEESEE-ECTTCBEEE---CCHHHHHHHHHHHHCCSEEEEEESSCSEECTTT-----CCEECEEEHHHHHHHH
+T ss_pred             HhCCCcEEEcCce-ECCCCcEEE---ECHHHHHHHHhhhCCCCEEEEEeCCCCcccCCC-----CCEeeEEcHHHHHHHH
+Confidence            4556778888874 556676544   367899999999999999999999999999776     3456777774 55444
+
+
+No 107
+>3uuw_A Putative oxidoreductase with NAD(P)-binding rossm domain; structural genomics, center for structural genomics of infec diseases, csgid; HET: 1PE PGE; 1.63A {Clostridium difficile}
+Probab=88.08  E-value=0.11  Score=45.15  Aligned_cols=136  Identities=18%  Similarity=0.159  Sum_probs=77.4  Template_Neff=10.600
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSK-ALLTNVHGLNLENWQEELAQAKEPFNLGRLIR  539 (820)
+Q Consensus       462 tdqvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvansk-alltnvhglnlenwqeelaqakepfnlgrlir  539 (820)
+                      +...+-|.+||.|.+|.. ++..+++.        -+.++++|.+.. ....        .+.+++. .+ .+  ..+-.
+T Consensus         3 ~~~~~~i~iiG~g~~~~~~~~~~~~~~--------~~~~i~~v~~~~~~~~~--------~~~~~~~-~~-~~--~~~~~   62 (308)
+T 3uuw_A            3 AMKNIKMGMIGLGSIAQKAYLPILTKS--------ERFEFVGAFTPNKVKRE--------KICSDYR-IM-PF--DSIES   62 (308)
+T ss_dssp             --CCCEEEEECCSHHHHHHTHHHHTSC--------SSSEEEEEECSCHHHHH--------HHHHHHT-CC-BC--SCHHH
+T ss_pred             CCCCceEEEECCCHHHHHHHHHHHhcC--------CCcEEEEEECCCHHHHH--------HHHHHcC-CC-ee--CCHHH
+Confidence            455677889999999986 66666542        145566554321 1111        1111110 00 11  11111
+
+
+Q gi|556503834|r  540 LVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENL  619 (820)
+Q Consensus       540 lvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienl  619 (820)
+                      +++    --.+++.||.+..-.+....++..|.||+.  .|..+.+.+-..+|-.++++.. ..++....-...|.+..+
+T Consensus        63 ~~~----~~d~v~i~~~~~~h~~~~~~~l~~g~~v~~--eKP~~~~~~~~~~l~~~~~~~~-~~~~~~~~~r~~~~~~~~  135 (308)
+T 3uuw_A           63 LAK----KCDCIFLHSSTETHYEIIKILLNLGVHVYV--DKPLASTVSQGEELIELSTKKN-LNLMVGFNRRFCPMYKEI  135 (308)
+T ss_dssp             HHT----TCSEEEECCCGGGHHHHHHHHHHTTCEEEE--CSSSSSSHHHHHHHHHHHHHHT-CCEEECCGGGGCHHHHHH
+T ss_pred             HHh----hCCEEEEeCCchhHHHHHHHHHHcCCCEEE--eCCCCCCHHHHHHHHHHHHhcC-CeEEEccccccCHHHHHH
+Confidence            222    135788899998888888888999999887  3333444555566666666543 344444455567777788
+
+
+Q gi|556503834|r  620 QNLLN  624 (820)
+Q Consensus       620 qnlln  624 (820)
+                      ++++.
+T Consensus       136 k~~i~  140 (308)
+T 3uuw_A          136 KNNAT  140 (308)
+T ss_dssp             HHHCC
+T ss_pred             HHHhc
+Confidence            88775
+
+
+No 108
+>3c1a_A Putative oxidoreductase; ZP_00056571.1, oxidoreductase FAM binding rossmann fold, structural genomics; HET: MSE PG4 PGE; 1.85A {Magnetospirillum magnetotacticum}
+Probab=87.81  E-value=0.12  Score=45.43  Aligned_cols=142  Identities=13%  Similarity=0.071  Sum_probs=80.7  Template_Neff=10.400
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELA-QAKEPFNLGRLIRLVK  542 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeela-qakepfnlgrlirlvk  542 (820)
+                      ..+-|-+||.|.+|...+..+.+.+        ++++++|.+...-..       +    +++ ..+..-++..+   +.
+T Consensus         9 ~~~~i~iiG~G~~g~~~~~~l~~~~--------~~~~~~v~~~~~~~~-------~----~~~~~~~~~~~~~~~---~~   66 (315)
+T 3c1a_A            9 SPVRLALIGAGRWGKNYIRTIAGLP--------GAALVRLASSNPDNL-------A----LVPPGCVIESDWRSV---VS   66 (315)
+T ss_dssp             CCEEEEEEECTTTTTTHHHHHHHCT--------TEEEEEEEESCHHHH-------T----TCCTTCEEESSTHHH---HT
+T ss_pred             CceeEEEECCCHHHHHHHHHHHhCC--------CcEEEEEEcCCHHHH-------H----hhccCCcccCCHHHH---hc
+Confidence            4567889999999998887765421        456676665321100       0    010 00000111111   11
+
+
+Q gi|556503834|r  543 EYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNL  622 (820)
+Q Consensus       543 eyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnl  622 (820)
+                      +  .---+++.||..+...+....+++.|.||+.-  |.-+.+.+...+|.-.+++...++. ..-.....|.+..++.+
+T Consensus        67 ~--~~~d~V~i~~~~~~~~~~~~~~l~~g~~v~~e--kp~~~~~~~~~~l~~~~~~~g~~~~-~~~~~~~~p~~~~~~~~  141 (315)
+T 3c1a_A           67 A--PEVEAVIIATPPATHAEITLAAIASGKAVLVE--KPLTLDLAEAEAVAAAAKATGVMVW-VEHTQLFNPAWEALKAD  141 (315)
+T ss_dssp             C--TTCCEEEEESCGGGHHHHHHHHHHTTCEEEEE--SSSCSCHHHHHHHHHHHHHHCCCEE-EECGGGGCHHHHHHHHT
+T ss_pred             C--CCCCEEEEeCChHHHHHHHHHHHHCCCeEEEe--cCCcCCHHHHHHHHHHHHHhCCEEE-EeehHHcCHHHHHHHHH
+Confidence            1  01236778999888888888899999999873  3333344445556555555555444 33334556778888887
+
+
+Q gi|556503834|r  623 LNAGDELMKF  632 (820)
+Q Consensus       623 lnagdelmkf  632 (820)
+                      ++.-.++..+
+T Consensus       142 i~~~G~i~~~  151 (315)
+T 3c1a_A          142 LTSIGPILAV  151 (315)
+T ss_dssp             HHHHCSEEEE
+T ss_pred             HHhcCCeEEE
+Confidence            7644444433
+
+
+No 109
+>3fhl_A Putative oxidoreductase; NAD-binding domain, PSI-2, NYSGXRC, structur genomics, protein structure initiative; 1.93A {Bacteroides fragilis nctc 9343}
+Probab=87.66  E-value=0.13  Score=46.72  Aligned_cols=137  Identities=17%  Similarity=0.101  Sum_probs=79.5  Template_Neff=10.100
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGG-ALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVK  542 (820)
+Q Consensus       464 qvievfvigvggvgg-alleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvk  542 (820)
+                      +.+.|.|||.|.+|. +.+..+++..        +.++++|.....-..          ++.....+---++..   +++
+T Consensus         4 ~~~~i~iiG~G~~g~~~~~~~l~~~~--------~~~l~~v~d~~~~~~----------~~~~~~~~~~~~~~e---~l~   62 (362)
+T 3fhl_A            4 EIIKTGLAAFGMSGQVFHAPFISTNP--------HFELYKIVERSKELS----------KERYPQASIVRSFKE---LTE   62 (362)
+T ss_dssp             CCEEEEESCCSHHHHHTTHHHHHHCT--------TEEEEEEECSSCCGG----------GTTCTTSEEESCSHH---HHT
+T ss_pred             CceEEEEEccCHHHHHHHHHHHhcCC--------CceEEEEEcCCHHHH----------HHhcCCCCccCCHHH---Hhc
+Confidence            456788999999997 6887776532        356666654321100          000000000011111   111
+
+
+Q gi|556503834|r  543 EYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNL  622 (820)
+Q Consensus       543 eyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnl  622 (820)
+                      +  .---+++.||......+....+++.|.||+.  .|..+.+.+...++...+++...++....+ -.-.|.+..+.++
+T Consensus        63 ~--~~~d~vii~~~~~~h~~~~~~~l~~g~~v~~--EkP~~~~~~~~~~l~~~~~~~~~~~~v~~~-~r~~p~~~~~~~~  137 (362)
+T 3fhl_A           63 D--PEIDLIVVNTPDNTHYEYAGMALEAGKNVVV--EKPFTSTTKQGEELIALAKKKGLMLSVYQN-RRWDADFLTVRDI  137 (362)
+T ss_dssp             C--TTCCEEEECSCGGGHHHHHHHHHHTTCEEEE--ESSCCSSHHHHHHHHHHHHHHTCCEEEECG-GGGSHHHHHHHHH
+T ss_pred             C--CCCCEEEEeCChHHHHHHHHHHHHcCCCEEE--eCCCCCCHHHHHHHHHHHHHcCCEEEEeec-cccCHHHHHHHHH
+Confidence            1  1234677888888888888888999999886  344444445556676666666555543333 3346778888888
+
+
+Q gi|556503834|r  623 LNAG  626 (820)
+Q Consensus       623 lnag  626 (820)
+                      +..|
+T Consensus       138 i~~g  141 (362)
+T 3fhl_A          138 LAKS  141 (362)
+T ss_dssp             HHTT
+T ss_pred             HhCC
+Confidence            8766
+
+
+No 110
+>3s6k_A Acetylglutamate kinase; synthase, transferase; 2.80A {Xanthomonas campestris PV}
+Probab=86.97  E-value=0.15  Score=50.11  Aligned_cols=64  Identities=16%  Similarity=0.326  Sum_probs=48.3  Template_Neff=8.600
+
+Q gi|556503834|r  179 IPADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQ  252 (820)
+Q Consensus       179 ipadhmvlmagftagnekgelvvlgrngsdysaavlaaclradcceiwtdvdgvytcdprqvpdarllksmsyq  252 (820)
+                      +...+++++.|+. -+..|+...+   .+|..|+.+|..+.+|.+-+.||++|+|+.||+      .+..++++
+T Consensus       190 L~~g~IPVv~~~~-~~~~g~~~~v---~~D~ia~~lA~~l~a~klI~ltdv~GI~~~~~~------~i~~In~~  253 (467)
+T 3s6k_A          190 LQAGSIPVITSLG-ETPSGQILNV---NADFAANELVQELQPYKIIFLTGTGGLLDAEGK------LIDSINLS  253 (467)
+T ss_dssp             HHHTCBCCCCSCC-CCSSSCCCBC---CHHHHHHHHHHHHCCSSCCCCCSSCSCCCSSCC------CCCCCCTT
+T ss_pred             HHCCCEEEECCce-ECCCCcEEEE---CHHHHHHHHHhhcCCCEEEEEeCCCCeeCCCCc------eeeEEcHH
+Confidence            4456677777754 4556664433   678999999999999999999999999999864      35556664
+
+
+No 111
+>1zh8_A Oxidoreductase; TM0312, structural genomics, JO center for structural genomics, JCSG, protein structure INI PSI; HET: MSE NAP; 2.50A {Thermotoga maritima} SCOP: c.2.1.3 d.81.1.5
+Probab=86.74  E-value=0.16  Score=45.34  Aligned_cols=146  Identities=16%  Similarity=0.186  Sum_probs=78.7  Template_Neff=10.300
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRL  537 (820)
+Q Consensus       459 lfntdqvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrl  537 (820)
+                      -..++..+.|-+||.|.+|.. .+..|++.       ..+.++++|.....-.       .+.+.++...   +--...+
+T Consensus        12 ~~~~~~~~~v~iiG~G~~~~~~~~~~l~~~-------~~~~~v~~v~d~~~~~-------~~~~~~~~~~---~~~~~~~   74 (340)
+T 1zh8_A           12 HMKPLRKIRLGIVGCGIAARELHLPALKNL-------SHLFEITAVTSRTRSH-------AEEFAKMVGN---PAVFDSY   74 (340)
+T ss_dssp             ----CCCEEEEEECCSHHHHHTHHHHHHTT-------TTTEEEEEEECSSHHH-------HHHHHHHHSS---CEEESCH
+T ss_pred             hccccCCceEEEEcccHHHHHHHHHHHHhC-------cCceEEEEEecCCHHH-------HHHHHHHcCC---CcccCCH
+Confidence            346778899999999999985 66666542       1235666665432111       0111111100   0000111
+
+
+Q gi|556503834|r  538 IRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIE  617 (820)
+Q Consensus       538 irlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvie  617 (820)
+                      -.++.+  .---+++-||....-++.....++.|-||+.. |.. +.+.+-..+|..++++....+....+ -.-.|.+.
+T Consensus        75 ~~~~~~--~~~D~v~i~~~~~~h~~~~~~~l~~g~~v~~E-KP~-~~~~~~~~~l~~~a~~~~~~~~v~~~-~r~~p~~~  149 (340)
+T 1zh8_A           75 EELLES--GLVDAVDLTLPVELNLPFIEKALRKGVHVICE-KPI-STDVETGKKVVELSEKSEKTVYIAEN-FRHVPAFW  149 (340)
+T ss_dssp             HHHHHS--SCCSEEEECCCGGGHHHHHHHHHHTTCEEEEE-SSS-SSSHHHHHHHHHHHHHCSSCEEEECG-GGGCHHHH
+T ss_pred             HHHhcC--CCCCEEEEeCCchhhHHHHHHHHHCCCeEEEc-CCC-CCCHHHHHHHHHHHHHhCCEEEEeec-cccChHHH
+Confidence            111111  01124567888777777777889999998873 332 33344556676666665555444333 33457788
+
+
+Q gi|556503834|r  618 NLQNLLNAG  626 (820)
+Q Consensus       618 nlqnllnag  626 (820)
+                      .+++++..|
+T Consensus       150 ~l~~~i~~g  158 (340)
+T 1zh8_A          150 KAKELVESG  158 (340)
+T ss_dssp             HHHHHHHTT
+T ss_pred             HHHHHHHcC
+Confidence            888888765
+
+
+No 112
+>3kux_A Putative oxidoreductase; oxidoreductase family, csgid, structural genomics, center FO structural genomics of infectious diseases; HET: MSE; 2.75A {Yersinia pestis}
+Probab=86.69  E-value=0.16  Score=45.36  Aligned_cols=137  Identities=20%  Similarity=0.137  Sum_probs=79.5  Template_Neff=10.400
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVK  542 (820)
+Q Consensus       464 qvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvk  542 (820)
+                      ..+.|.+||.|.+|.. .+..+.+        +-+++++||.+...          +..+.+....+.   ...+-.++.
+T Consensus         6 ~~~~i~iiG~G~~g~~~~~~~l~~--------~~~~~i~~v~~~~~----------~~~~~~~~~~~~---~~~~~~~~~   64 (352)
+T 3kux_A            6 DKIKVGLLGYGYASKTFHAPLIMG--------TPGLELAGVSSSDA----------SKVHADWPAIPV---VSDPQMLFN   64 (352)
+T ss_dssp             CCEEEEEECCSHHHHHTHHHHHHT--------STTEEEEEEECSCH----------HHHHTTCSSCCE---ESCHHHHHH
+T ss_pred             CceEEEEECCCHHHHHHHHHHHhh--------CCCcEEEEEcCCCH----------HHHHHhcCCCcc---cCCHHHHhc
+Confidence            4567899999999974 5555542        12456666654321          110000000000   011111111
+
+
+Q gi|556503834|r  543 EYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNL  622 (820)
+Q Consensus       543 eyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnl  622 (820)
+                      +  .---+++.||....-.+.....++.|.||+.  .|.-+.+.+-..++.-+++++..++....+ .--.|.+..++++
+T Consensus        65 ~--~~~d~V~i~~p~~~h~~~~~~~~~~g~~v~~--ekP~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~~~~~  139 (352)
+T 3kux_A           65 D--PSIDLIVIPTPNDTHFPLAQSALAAGKHVVV--DKPFTVTLSQANALKEHADDAGLLLSVFHN-RRWDSDFLTLKTL  139 (352)
+T ss_dssp             C--SSCCEEEECSCTTTHHHHHHHHHHTTCEEEE--CSSCCSCHHHHHHHHHHHHHTTCCEEECCG-GGGCHHHHHHHHH
+T ss_pred             C--CCCCEEEEeCCcHHHHHHHHHHHhCCCCEEE--eCCCCCCHHHHHHHHHHHHHhCCEEEEEee-eecCHHHHHHHHH
+Confidence            1  1124678899998888888889999999987  333334445556777777776666654433 3356888888888
+
+
+Q gi|556503834|r  623 LNAG  626 (820)
+Q Consensus       623 lnag  626 (820)
+                      +..|
+T Consensus       140 i~~g  143 (352)
+T 3kux_A          140 LAEG  143 (352)
+T ss_dssp             HHHT
+T ss_pred             HhcC
+Confidence            8765
+
+
+No 113
+>2ixa_A Alpha-N-acetylgalactosaminidase; NAD, A-ECO conversion, hydrolase; HET: NAD; 2.3A {Flavobacterium meningosepticum} PDB: 2ixb_A*
+Probab=86.63  E-value=0.16  Score=48.69  Aligned_cols=145  Identities=11%  Similarity=0.129  Sum_probs=84.9  Template_Neff=9.200
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKAL-LTNVHGLNLENWQEELAQAKEPF---NLGRLIR  539 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskal-ltnvhglnlenwqeelaqakepf---nlgrlir  539 (820)
+                      ..+.|.|||.|.+|...+..+++..        ++++.+|.+...- +.     ..+++.+++.....++   ....+-.
+T Consensus        19 ~~~~v~viG~G~~g~~~~~~l~~~~--------~~~lv~v~d~~~~~~~-----~a~~~~~~~~~~~~~~~~~~~~~~~e   85 (444)
+T 2ixa_A           19 KKVRIAFIAVGLRGQTHVENMARRD--------DVEIVAFADPDPYMVG-----RAQEILKKNGKKPAKVFGNGNDDYKN   85 (444)
+T ss_dssp             CCEEEEEECCSHHHHHHHHHHHTCT--------TEEEEEEECSCHHHHH-----HHHHHHHHTTCCCCEEECSSTTTHHH
+T ss_pred             CceEEEEEcccHHHHHHHHHHHhCC--------CCEEEEEEeCCHHHHH-----HHHHHHHHcCCCcccccccCcCCHHH
+Confidence            5678999999999999888886532        2344444332210 00     0011111111000000   0111112
+
+
+Q gi|556503834|r  540 LVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENL  619 (820)
+Q Consensus       540 lvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienl  619 (820)
+                      +++.  ----+++.||....-++.....++.|-||+..  |.-+.+.+-..++..+++++..+++...+.. ..|.+..+
+T Consensus        86 ll~~--~~~D~Vii~t~~~~h~~~~~~al~~g~~v~~E--kP~a~~~~~~~~i~~~a~~~~~~~~v~~~~r-~~p~~~~l  160 (444)
+T 2ixa_A           86 MLKD--KNIDAVFVSSPWEWHHEHGVAAMKAGKIVGME--VSGAITLEECWDYVKVSEQTGVPLMALENVC-YRRDVMAI  160 (444)
+T ss_dssp             HTTC--TTCCEEEECCCGGGHHHHHHHHHHTTCEEEEC--CCCCSSHHHHHHHHHHHHHHCCCEEECCGGG-GCHHHHHH
+T ss_pred             HHhc--CCCCEEEECCChHHHHHHHHHHHHCCCCEEEe--cCccCCHHHHHHHHHHHHHcCCEEEEeecee-ecHHHHHH
+Confidence            2221  11346788999998899999999999999963  4444455666788888887777776655444 45777788
+
+
+Q gi|556503834|r  620 QNLLNAG  626 (820)
+Q Consensus       620 qnllnag  626 (820)
+                      .+++..|
+T Consensus       161 ~~~i~~g  167 (444)
+T 2ixa_A          161 LNMVRKG  167 (444)
+T ss_dssp             HHHHHTT
+T ss_pred             HHHHhcC
+Confidence            8888765
+
+
+No 114
+>4mkx_A Inositol dehydrogenase; NAD, sugar alcohol dehydrogenases, rossmann fold, dehydrogen scyllo-inositol, dehydrogenate, oxidoreductase; 1.60A {Lactobacillus casei} PDB: 4mkz_A* 4n54_A*
+Probab=86.51  E-value=0.17  Score=45.63  Aligned_cols=138  Identities=12%  Similarity=0.120  Sum_probs=76.3  Template_Neff=10.200
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLG----RLI  538 (820)
+Q Consensus       463 dqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlg----rli  538 (820)
+                      ...+.|.|||.|.+|...+..++..       +-+.++.+|.....       -..+.+.++       +++.    .+-
+T Consensus        15 ~~~~~v~iiG~G~~~~~~~~~l~~~-------~~~~~i~~v~~~~~-------~~~~~~~~~-------~~~~~~~~~~~   73 (355)
+T 4mkx_A           15 QKTIKIGIVGLGRLGKIHATNIATK-------IQHAKLQAATSVVP-------AELDWAKKE-------LGVEEVFEDFD   73 (355)
+T ss_dssp             SCCEEEEEECCSHHHHHHHHHHHHT-------CTTEEEEEEECSSH-------HHHHHHHHH-------HCCSEEESSHH
+T ss_pred             CCCceEEEEcccHHHHHHHHHHHhh-------CCCceEEEEEcCCH-------HHHHHHHHH-------cCCCcccCCHH
+Confidence            3557788999999998877766542       11234333322110       001122211       2221    122
+
+
+Q gi|556503834|r  539 RLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYA-AEKSRRKFLYDTNVGAGLPVIE  617 (820)
+Q Consensus       539 rlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlrya-aeksrrkflydtnvgaglpvie  617 (820)
+                      .+++.  ----+++.||.+..-.+.....++.|.||++  .|.-..+.+-..+|..+ +++ ...+++-....-..|.+.
+T Consensus        74 ~l~~~--~~~d~v~i~~p~~~h~~~~~~~l~~g~~v~~--ekP~a~~~~~~~~l~~~~~~~-~~~~~~v~~~~r~~p~~~  148 (355)
+T 4mkx_A           74 DMVQH--ADIDAVFIVSPSGFHLQQIESALNAGKHVFS--EKPIGLDIEAIEHTQQVIAQH-ANLKFQLGFMRRFDDSYR  148 (355)
+T ss_dssp             HHHHH--SSCSEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCSCSCHHHHHHHHHHHHTT-TTSCEEECCGGGGCHHHH
+T ss_pred             HHhcC--CCCCEEEEeCCchHHHHHHHHHHHCCCeEEE--cCCCCCCHHHHHHHHHHHHhh-cCCEEEEeehhhcCHHHH
+Confidence            22221  1223567788877777777789999999998  33333334444455553 443 344555555566678888
+
+
+Q gi|556503834|r  618 NLQNLLNAG  626 (820)
+Q Consensus       618 nlqnllnag  626 (820)
+                      .++.++..|
+T Consensus       149 ~~~~~i~~g  157 (355)
+T 4mkx_A          149 YAKQLVDQG  157 (355)
+T ss_dssp             HHHHHHHTT
+T ss_pred             HHHHHHhcC
+Confidence            888888765
+
+
+No 115
+>3rc1_A Sugar 3-ketoreductase; sugar biosynthesis, TDP binding, NADP binding binding protein; HET: TLO NAP; 1.71A {Actinomadura kijaniata} PDB: 3rbv_A* 3rc2_A* 3rcb_A* 3rc7_A* 3rc9_A*
+Probab=85.87  E-value=0.19  Score=45.14  Aligned_cols=147  Identities=18%  Similarity=0.138  Sum_probs=78.9  Template_Neff=10.200
+
+Q gi|556503834|r  456 HQMLFNTDQVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNL  534 (820)
+Q Consensus       456 hqmlfntdqvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnl  534 (820)
+                      |.+-......+.|.+||.|.+|.. ++..+++..        ..++++|.+...       -+.+.|++++. .+ .  .
+T Consensus        18 ~~~~~~~~~~~~v~iiG~G~~g~~~~~~~~~~~~--------~~~v~~v~d~~~-------~~~~~~~~~~~-~~-~--~   78 (350)
+T 3rc1_A           18 HMENPANANPIRVGVIGCADIAWRRALPALEAEP--------LTEVTAIASRRW-------DRAKRFTERFG-GE-P--V   78 (350)
+T ss_dssp             --------CCEEEEEESCCHHHHHTHHHHHHHCT--------TEEEEEEEESSH-------HHHHHHHHHHC-SE-E--E
+T ss_pred             eecccCCCCcceEEEEcChHHHHHHHHHHHhhCC--------CcEEEEEEeCCH-------HHHHHHHHHcC-CC-C--c
+Confidence            334455677889999999999986 666665421        345555543211       01122222211 11 1  1
+
+
+Q gi|556503834|r  535 GRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       535 grlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                      ..+-.++++.  ---+++.||..+.-.+....+++.|.||+..  |.-+.+.+-..++...++++..+|....+ -.-.|
+T Consensus        79 ~~~~~~~~~~--~~D~v~i~~p~~~h~~~~~~~l~~g~~v~~e--kp~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p  153 (350)
+T 3rc1_A           79 EGYPALLERD--DVDAVYVPLPAVLHAEWIDRALRAGKHVLAE--KPLTTDRPQAERLFAVARERGLLLMENFM-FLHHP  153 (350)
+T ss_dssp             ESHHHHHTCT--TCSEEEECCCGGGHHHHHHHHHHTTCEEEEE--SSSCSSHHHHHHHHHHHHHTTCCEEEECG-GGGCT
+T ss_pred             CCHHHHhcCC--CCCEEEEcCCchhhHHHHHHHHHCCCeEEEc--CCCCCCHHHHHHHHHHHHHcCCEEEEeee-cccCH
+Confidence            1222233221  1136778888887777778889999999874  33233334445666666666655553333 33457
+
+
+Q gi|556503834|r  615 VIENLQNLLNAG  626 (820)
+Q Consensus       615 vienlqnllnag  626 (820)
+                      .+..+++++..|
+T Consensus       154 ~~~~~~~~i~~~  165 (350)
+T 3rc1_A          154 QHRQVADMLDEG  165 (350)
+T ss_dssp             HHHHHHHHHHTT
+T ss_pred             HHHHHHHHHhcC
+Confidence            788888888765
+
+
+No 116
+>5ees_A HTPA reductase, 4-hydroxy-tetrahydrodipicolinate reductase; oxidoreductase; HET: NAP; 2.15A {Corynebacterium glutamicum} PDB: 5eer_A*
+Probab=85.37  E-value=0.21  Score=45.09  Aligned_cols=113  Identities=22%  Similarity=0.225  Sum_probs=73.8  Template_Neff=8.600
+
+Q gi|556503834|r  466 IEVFVIG-VGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       466 ievfvig-vggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      +.|.|+| .|.+|..+.+.|....        ++.+.++...+.-           +.+                +..  
+T Consensus         2 ~kV~I~Ga~G~~G~~i~~~l~~~~--------~~~v~~v~~~~~~-----------~~~----------------~~~--   44 (247)
+T 5ees_A            2 IKVGVLGAKGRVGQTIVAAVNESD--------DLELVAEIGVDDD-----------LSL----------------LVD--   44 (247)
+T ss_dssp             CEEEEETTTSHHHHHHHHHHHHCS--------SCEEEEEECTTSC-----------THH----------------HHH--
+T ss_pred             CEEEEECCCCHHHHHHHHHHHhCC--------CCEEEEEECCCCC-----------HHH----------------Hhc--
+Confidence            3578999 8999999999986531        2344443322210           000                000  
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAE-KSRRKFLYDTNVGAGLPVIENL  619 (820)
+Q Consensus       545 hllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaae-ksrrkflydtnvgaglpvienl  619 (820)
+                       --..+++|||+.....+.....++.|..+|.-.....   ...+..|+.+++ ....+++|-+|.+.|...+..+
+T Consensus        45 -~~~dvvid~t~~~~~~~~~~~~l~~g~~~Vi~ttg~~---~~~~~~l~~aa~~~~~~~~~~~sn~s~g~~~~~~~  116 (247)
+T 5ees_A           45 -NGAEVVVDFTTPNAVMGNLEFCINNGISAVVGTTGFD---DARLEQVRDWLEGKDNVGVLIAPNFAISAVLTMVF  116 (247)
+T ss_dssp             -TTCSEEEECSCHHHHHHHHHHHHHTTCEEEECCCCCC---HHHHHHHHHHHTTCTTCEEEECSCCCHHHHHHHHH
+T ss_pred             -cCCcEEEEcCChHHHHHHHHHHHHcCCCEEEecCCCC---HHHHHHHHHHHHhcCCccEEEECCCchHHHHHHHH
+Confidence             0135789999988877777778888988887665442   345777888775 3356899999999888765544
+
+
+No 117
+>5a04_A Aldose-aldose oxidoreductase; HET: NDP BGC; 1.70A {Caulobacter crescentus CB15} PDB: 5a02_A* 5a03_A* 5a05_A* 5a06_A*
+Probab=85.00  E-value=0.23  Score=44.11  Aligned_cols=75  Identities=16%  Similarity=0.111  Sum_probs=52.5  Template_Neff=10.400
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||......+.....++.|.||+.  .|.-+.+.+-..+|...+++....+.-.. .-.-.|.+..++.++..|
+T Consensus        75 d~v~i~tp~~~h~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~~~~~~~~~~~~~-~~r~~p~~~~l~~~i~~g  149 (339)
+T 5a04_A           75 DIVYVITPNSLHRPFTERAARAGKHVMC--EKPMANTVADCEAMIAACKKAGRKLMIGY-RSRFQAHNIEAIKLVRDG  149 (339)
+T ss_dssp             CEEEECSCGGGHHHHHHHHHHTTCEEEE--CSSCCSSHHHHHHHHHHHHHHTCCEEECC-GGGGSHHHHHHHHHHHTT
+T ss_pred             CEEEEeCChHHHHHHHHHHHHCCCeEEe--cCCCCCCHHHHHHHHHHHHHcCCEEEEee-cccCCHHHHHHHHHHHcC
+Confidence            4677899998888888999999999998  34444455556777777766554443322 334457788888877765
+
+
+No 118
+>3q2i_A Dehydrogenase; rossmann fold, UDP-sugar binding, NAD binding oxidoreductase; HET: NAI HP7; 1.50A {Chromobacterium violaceum} PDB: 3q2k_A*
+Probab=84.88  E-value=0.24  Score=44.65  Aligned_cols=143  Identities=17%  Similarity=0.226  Sum_probs=78.9  Template_Neff=10.200
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLV  541 (820)
+Q Consensus       462 tdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlv  541 (820)
+                      ....+.|-+||.|.+|...+..+++..       -+.++++|.+...       -..+.|.++.. .+ .+  ..+-.++
+T Consensus        10 ~~~~~~v~iiG~G~~g~~~~~~~~~~~-------~~~~v~~v~d~~~-------~~~~~~~~~~~-~~-~~--~~~~~~~   71 (354)
+T 3q2i_A           10 TDRKIRFALVGCGRIANNHFGALEKHA-------DRAELIDVCDIDP-------AALKAAVERTG-AR-GH--ASLTDML   71 (354)
+T ss_dssp             CSSCEEEEEECCSTTHHHHHHHHHHTT-------TTEEEEEEECSSH-------HHHHHHHHHHC-CE-EE--SCHHHHH
+T ss_pred             cCCcceEEEEeCcHHHHHHHHHHHhcC-------CCceEEEEECCCH-------HHHHHHHHHcC-CC-Cc--CCHHHHh
+Confidence            345678899999999998777665431       1344444432110       00111211110 00 01  0111111
+
+
+Q gi|556503834|r  542 KEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQN  621 (820)
+Q Consensus       542 keyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqn  621 (820)
+                      ..  ----+++.||.++.-.+.....++.|.||+.. | .-+.+.+-..+|.-+++++...+....+.. -.|.+..+++
+T Consensus        72 ~~--~~~d~v~i~~p~~~h~~~~~~~l~~g~~v~~e-k-P~~~~~~~~~~l~~~a~~~~~~~~~~~~~r-~~~~~~~~~~  146 (354)
+T 3q2i_A           72 AQ--TDADIVILTTPSGLHPTQSIECSEAGFHVMTE-K-PMATRWEDGLEMVKAADKAKKHLFVVKQNR-RNATLQLLKR  146 (354)
+T ss_dssp             HH--CCCSEEEECSCGGGHHHHHHHHHHTTCEEEEC-S-SSCSSHHHHHHHHHHHHHHTCCEEECCGGG-GSHHHHHHHH
+T ss_pred             cC--CCCCEEEEcCChHHHHHHHHHHHHcCCeEEEe-C-CCCCCHHHHHHHHHHHHHhCCeEEEEeccc-CCHHHHHHHH
+Confidence            11  01236778998888777778888999998863 2 223333444566666666665555444433 4677888888
+
+
+Q gi|556503834|r  622 LLNAGD  627 (820)
+Q Consensus       622 llnagd  627 (820)
+                      +++.|+
+T Consensus       147 ~i~~~~  152 (354)
+T 3q2i_A          147 AMQEKR  152 (354)
+T ss_dssp             HHHTTT
+T ss_pred             HHhcCC
+Confidence            888764
+
+
+No 119
+>3v5n_A Oxidoreductase; structural genomics, PSI-biology, protein structure initiati nysgrc, NEW YORK structural genomics research consortium; 2.80A {Sinorhizobium meliloti}
+Probab=84.02  E-value=0.28  Score=46.13  Aligned_cols=75  Identities=24%  Similarity=0.425  Sum_probs=55.7  Template_Neff=9.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||....-.+.....++.|.||+.  .|.-+.+.+...+|..++++...++....+ -.-.|.+..++.++..|
+T Consensus       112 D~Vii~tp~~~h~~~~~~al~~g~~vl~--EKP~~~~~~~~~~l~~~a~~~~~~~~v~~~-~r~~p~~~~~~~~i~~g  186 (417)
+T 3v5n_A          112 EAVAIVTPNHVHYAAAKEFLKRGIHVIC--DKPLTSTLADAKKLKKAADESDALFVLTHN-YTGYPMVRQAREMIENG  186 (417)
+T ss_dssp             SEEEECSCTTSHHHHHHHHHTTTCEEEE--ESSSCSSHHHHHHHHHHHHHCSSCEEEECG-GGGSHHHHHHHHHHHTT
+T ss_pred             CEEEEeCCcHHHHHHHHHHHHcCCeEEE--eCCCCCCHHHHHHHHHHHHHcCCEEEEeec-ccCCHHHHHHHHHHhcC
+Confidence            4678899998888888899999999997  344455566677777777766655544433 44568889999998876
+
+
+No 120
+>2dt9_A Aspartokinase; protein-ligand complex, regulatory subunit, transferase; 2.15A {Thermus thermophilus} PDB: 2zho_A
+Probab=83.89  E-value=0.28  Score=40.56  Aligned_cols=58  Identities=33%  Similarity=0.437  Sum_probs=44.3  Template_Neff=9.500
+
+Q gi|556503834|r  388 EPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGS-----SERSISVVVNNDD  447 (820)
+Q Consensus       388 eplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgs-----sersisvvvnndd  447 (820)
+                      .-.+..+.++.+++.+  +....+..++.|..|+++++|+..+.++.     ++..+++++..++
+T Consensus         8 ~~I~~~~~~~~i~i~~--~~~~~~~~~~~~~~l~~~~i~i~~i~~~~~~~~~~~~~i~~~v~~~~   70 (167)
+T 2dt9_A            8 TGVALDLDHAQIGLIG--IPDQPGIAAKVFQALAERGIAVDMIIQGVPGHDPSRQQMAFTVKKDF   70 (167)
+T ss_dssp             EEEEEECSEEEEEEEE--EECSTTHHHHHHHHHHHHTCCCSCEEBCCCCSCTTEEEEEEEEEGGG
+T ss_pred             eEEEEeCCEEEEEEcC--CCCCcCHHHHHHHHHHHCCCcEEEEEcCCCCCCCCcceEEEEEeHHH
+Confidence            3455667777777764  55555788999999999999999999885     4677888887544
+
+
+No 121
+>3a06_A 1-deoxy-D-xylulose 5-phosphate reductoisomerase; MEP pathway, isoprene biosynthesis, metal- NADP, oxidoreductase; HET: NDP; 2.00A {Thermotoga maritima} PDB: 3a14_A*
+Probab=83.76  E-value=0.29  Score=46.93  Aligned_cols=128  Identities=13%  Similarity=0.182  Sum_probs=71.5  Template_Neff=8.500
+
+Q gi|556503834|r  465 VIEVFVIGV-GGVGGALLEQLKRQQSWLKNKHIDLRVCGVAN-S-KALLTNV-HGLNLE--NWQEEL--AQAKEP-F-NL  534 (820)
+Q Consensus       465 vievfvigv-ggvggalleqlkrqqswlknkhidlrvcgvan-s-kalltnv-hglnle--nwqeel--aqakep-f-nl  534 (820)
+                      .+.|.++|. |.+|...++.+++.        -+++|++|+. + ...+... ..++..  .|.+.-  ...+.. + +.
+T Consensus         3 ~~kI~IiGatG~iG~~~l~~l~~~--------~~~~vvav~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   74 (376)
+T 3a06_A            3 ERTLVILGATGSIGTQTLDVLKKV--------KGIRLIGISFHSNLELAFKIVKEFNVKNVAITGDVEFEDSSINVWKGS   74 (376)
+T ss_dssp             CEEEEEETTTSHHHHHHHHHHHHS--------CSEEEEEEEESSCHHHHHHHHHHHTCCEEEECSSCCCCCSSSEEEEST
+T ss_pred             ceEEEEECCCCHHHHHHHHHHHcC--------CCeEEEEEEeCCCHHHHHHHHHHcCCCEEEecchhhhhhcccceecCc
+Confidence            356789995 99999999988754        1467777764 3 2211110 000000  000000  000000 0 00
+
+
+Q gi|556503834|r  535 GRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLY  605 (820)
+Q Consensus       535 grlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkfly  605 (820)
+                      ..+..+++.  .-..++++||+...-.+.....++.|.||++.||..+   .....++..+++++..+++.
+T Consensus        75 ~~~~ell~~--~~~DvVi~at~~~~~~~~~~~al~~Gk~V~~ekp~~~---~~~~~~l~~~a~~~g~~i~p  140 (376)
+T 3a06_A           75 HSIEEMLEA--LKPDITMVAVSGFSGLRAVLASLEHSKRVCLANKESL---VCGGFLVKKKLKEKGTELIP  140 (376)
+T ss_dssp             THHHHHHHH--HCCSEEEECCCSTTHHHHHHHHHHHCSEEEECCSHHH---HHHHHHHHHHHHHHCCEEEE
+T ss_pred             hHHHHHHhC--CCCCEEEECCCChhhHHHHHHHHHCCCeEEecCcccc---HHHHHHHHHHHHhcCCEEEE
+Confidence            112222221  1246889999999888999999999999999988632   34456666666666655553
+
+
+No 122
+>3e18_A Oxidoreductase; dehydrogenase, NAD-binding, structural genom protein structure initiative, PSI, NEW YORK structural GENO research consortium; HET: NAD; 1.95A {Listeria innocua}
+Probab=83.53  E-value=0.3  Score=44.20  Aligned_cols=136  Identities=16%  Similarity=0.184  Sum_probs=77.7  Template_Neff=10.100
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKA-LLTNVHGLNLENWQEELAQAKE-PFNLGRLIRLV  541 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanska-lltnvhglnlenwqeelaqake-pfnlgrlirlv  541 (820)
+                      ..+.|.|||.|.+|...+..+++.      .  ...+++|.+... .+..            .++..- .+  ..+-.++
+T Consensus         4 ~~~~v~iiG~G~ig~~~~~~l~~~------~--~~~i~~v~d~~~~~~~~------------~~~~~~~~~--~~~~~~~   61 (359)
+T 3e18_A            4 KKYQLVIVGYGGMGSYHVTLASAA------D--NLEVHGVFDILAEKREA------------AAQKGLKIY--ESYEAVL   61 (359)
+T ss_dssp             CCEEEEEECCSHHHHHHHHHHHTS------T--TEEEEEEECSSHHHHHH------------HHTTTCCBC--SCHHHHH
+T ss_pred             CCceEEEECCCHHHHHHHHHHhhC------C--CceEEEEEcCCHHHHHH------------HHhcCCcee--CCHHHHh
+Confidence            346688999999999877766442      1  244555543221 1110            000000 01  0111111
+
+
+Q gi|556503834|r  542 KEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQN  621 (820)
+Q Consensus       542 keyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqn  621 (820)
+                      ..  .--.++++||..+...+...++++.|.||+.  .|.-+.+.+...+|..+++++...+....+ ..-.|.+..++.
+T Consensus        62 ~~--~~~D~v~i~~p~~~~~~~~~~~l~~g~~v~~--ekp~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~~~~  136 (359)
+T 3e18_A           62 AD--EKVDAVLIATPNDSHKELAISALEAGKHVVC--EKPVTMTSEDLLAIMDVAKRVNKHFMVHQN-RRWDEDFLIIKE  136 (359)
+T ss_dssp             HC--TTCCEEEECSCGGGHHHHHHHHHHTTCEEEE--ESSCCSSHHHHHHHHHHHHHHTCCEEEECG-GGGCHHHHHHHH
+T ss_pred             cc--CCCCEEEEeCCHHHHHHHHHHHHHCCCCeEE--ecCCcCCHHHHHHHHHHHHhcCCeEEEeec-cccCHHHHHHHH
+Confidence            11  1235788899999888888899999999886  222223334456677777666655555443 344577888888
+
+
+Q gi|556503834|r  622 LLNAG  626 (820)
+Q Consensus       622 llnag  626 (820)
+                      +++.|
+T Consensus       137 ~i~~~  141 (359)
+T 3e18_A          137 MFEQK  141 (359)
+T ss_dssp             HHHHT
+T ss_pred             HHhcC
+Confidence            77765
+
+
+No 123
+>3e82_A Putative oxidoreductase; NAD, GFO/IDH/MOCA family, PSI-2, NYSGXRC, 11136F, structural genomics, protein structure initiative; 2.04A {Klebsiella pneumoniae subsp}
+Probab=83.36  E-value=0.31  Score=44.04  Aligned_cols=138  Identities=19%  Similarity=0.112  Sum_probs=80.9  Template_Neff=10.200
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGA-LLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLV  541 (820)
+Q Consensus       463 dqvievfvigvggvgga-lleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlv  541 (820)
+                      +..+-|.+||.|.+|.. .+..|++.        -+.+|++|.+...--       .+.+.+.   .+..   ..+-.++
+T Consensus         5 ~~~~~i~iiG~G~~g~~~~~~~l~~~--------~~~~v~~v~d~~~~~-------~~~~~~~---~~~~---~~~~~~l   63 (364)
+T 3e82_A            5 NNTINIALIGYGFVGKTFHAPLIRSV--------PGLNLAFVASRDEEK-------VKRDLPD---VTVI---ASPEAAV   63 (364)
+T ss_dssp             --CEEEEEECCSHHHHHTHHHHHHTS--------TTEEEEEEECSCHHH-------HHHHCTT---SEEE---SCHHHHH
+T ss_pred             CCceeEEEECCCHHHHHHHHHHHhcC--------CCeEEEEEECCCHHH-------HHhhcCC---Ccee---CCHHHHh
+Confidence            34677899999999986 55545432        135666665443110       0001000   0000   1111111
+
+
+Q gi|556503834|r  542 KEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQN  621 (820)
+Q Consensus       542 keyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqn  621 (820)
+                      .+  .-.-+++.||....-.+.....++.|.||++  .|.-+.+.+-...|..++++....+....+ -.-.|.+..+.+
+T Consensus        64 ~~--~~~D~v~i~~~~~~h~~~~~~~l~~g~~v~~--ekP~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~l~~  138 (364)
+T 3e82_A           64 QH--PDVDLVVIASPNATHAPLARLALNAGKHVVV--DKPFTLDMQEARELIALAEEKQRLLSVFHN-RRWDSDYLGIRQ  138 (364)
+T ss_dssp             TC--TTCSEEEECSCGGGHHHHHHHHHHTTCEEEE--CSCSCSSHHHHHHHHHHHHHTTCCEEECCC-CTTCHHHHHHHH
+T ss_pred             cC--CCCCEEEEcCCHHHHHHHHHHHHHCCCCEEe--ecCCCCCHHHHHHHHHHHHHhCCEEEEEeh-hhcCHHHHHHHH
+Confidence            11  1234778899888888888889999999997  444455566667777777776665554433 334677778888
+
+
+Q gi|556503834|r  622 LLNAG  626 (820)
+Q Consensus       622 llnag  626 (820)
+                      ++..|
+T Consensus       139 ~i~~g  143 (364)
+T 3e82_A          139 VIEQG  143 (364)
+T ss_dssp             HHHHT
+T ss_pred             HHHcC
+Confidence            88754
+
+
+No 124
+>1lc0_A Biliverdin reductase A; oxidoreductase, tetrapyrrole, bIle pigment, heme, bilirubin, NADH; 1.20A {Rattus norvegicus} SCOP: c.2.1.3 d.81.1.4 PDB: 1lc3_A* 1gcu_A 2h63_A*
+Probab=83.17  E-value=0.32  Score=42.80  Aligned_cols=138  Identities=25%  Similarity=0.275  Sum_probs=78.2  Template_Neff=10.100
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKE  543 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvke  543 (820)
+                      ..+.|.+||.|.+|...+..+++.+.-     -+++|.+|.+...-.. ..+....+                +-.++++
+T Consensus         6 ~~~~i~iiG~G~~g~~~~~~l~~~~~~-----~~~~v~~i~~~~~~~~-~~~~~~~~----------------~~~~~~~   63 (294)
+T 1lc0_A            6 GKFGVVVVGVGRAGSVRLRDLKDPRSA-----AFLNLIGFVSRRELGS-LDEVRQIS----------------LEDALRS   63 (294)
+T ss_dssp             CSEEEEEECCSHHHHHHHHHHTSHHHH-----TTEEEEEEECSSCCCE-ETTEEBCC----------------HHHHHHC
+T ss_pred             CcCcEEEEcCcHHHHHHHHHHhhCCcc-----ceEEEEEEeCChhhhh-hcCccccC----------------HHHHhcC
+Confidence            346788999999999888877553310     1355556554321100 01111111                1122221
+
+
+Q gi|556503834|r  544 YHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLL  623 (820)
+Q Consensus       544 yhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnll  623 (820)
+                      .  ---+++.||......+.....++.|.||+.-  |.-..+.+-..++.-++++.... ++......-.|.++.+++++
+T Consensus        64 ~--~~d~v~i~~~~~~~~~~~~~~~~~g~~v~~e--KP~~~~~~~~~~l~~~a~~~~~~-~~~~~~~r~~~~~~~~~~~i  138 (294)
+T 1lc0_A           64 Q--EIDVAYICSESSSHEDYIRQFLQAGKHVLVE--YPMTLSFAAAQELWELAAQKGRV-LHEEHVELLMEEFEFLRREV  138 (294)
+T ss_dssp             S--SEEEEEECSCGGGHHHHHHHHHHTTCEEEEE--SCSCSCHHHHHHHHHHHHHTTCC-EEEECGGGGSHHHHHHHHHH
+T ss_pred             C--CCCEEEEcCCChHHHHHHHHHHHCCCeEEEe--CCCCCCHHHHHHHHHHHHhhCCE-EEEeEhHhccHHHHHHHHHh
+Confidence            1  1236778888888888888899999998852  22222333344555555554443 35555556677888887777
+
+
+Q gi|556503834|r  624 NAGDEL  629 (820)
+Q Consensus       624 nagdel  629 (820)
+                      . |+.+
+T Consensus       139 ~-g~~~  143 (294)
+T 1lc0_A          139 L-GKEL  143 (294)
+T ss_dssp             T-TCCE
+T ss_pred             c-CCce
+Confidence            4 5443
+
+
+No 125
+>4lrt_B Acetaldehyde dehydrogenase; rosmmann fold, TIM barrel, aldolase, lyase- oxidoreductase complex; HET: COA; 1.50A {Thermomonospora curvata} PDB: 4lrs_B* 4jn6_B
+Probab=82.93  E-value=0.33  Score=44.77  Aligned_cols=95  Identities=20%  Similarity=0.316  Sum_probs=52.9  Template_Neff=9.100
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDL-RVCGVANSKALLT--NVHGLNLENWQEELAQAKEPFNLGRLI  538 (820)
+Q Consensus       462 tdqvievfvigvggvggalleqlkrqqswlknkhidl-rvcgvanskallt--nvhglnlenwqeelaqakepfnlgrli  538 (820)
+                      ....+.|.+||.|.+|..++..|++.      ..+++ .+++..+.+....  ...|..  .+         .-++..++
+T Consensus        20 ~~~~~rV~IiG~G~iG~~~~~~l~~~------~~~~v~~~v~~~~~~~~~~~~~~~g~~--~~---------~~~~~~ll   82 (323)
+T 4lrt_B           20 HMGKAVAAIVGPGNIGTDLLIKLQRS------EHIEVRYMVGVDPASEGLARARKLGVE--AS---------AEGVDWLL   82 (323)
+T ss_dssp             CCSCEEEEEECCSHHHHHHHHHHHHC------SSEEEEEEECSCTTCHHHHHHHHTTCE--EE---------SSHHHHHT
+T ss_pred             cCCccEEEEECCCHHHHHHHHHHHhC------CCcEEEEEEecCcHHHHHHHHHHcCCc--ee---------cCCHHHHH
+Confidence            34568899999999999998877653      23333 2222222221110  011110  00         00111111
+
+
+Q gi|556503834|r  539 RLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTP  577 (820)
+Q Consensus       539 rlvkeyhllnpvivdctssqavadqyadflregfhvvtp  577 (820)
+                         ..- ----++++||++....+....+++.|.+|+.-
+T Consensus        83 ---~~~-~~~DvV~iat~~~~~~~~~~~~l~~G~~Vi~~  117 (323)
+T 4lrt_B           83 ---EQD-ELPDLVFEATSAKAHLANAPRYAEAGITAIDL  117 (323)
+T ss_dssp             ---TSS-SCCSEEEECSCHHHHHHHHHHHHHHTCEEEEC
+T ss_pred             ---hCC-CCCCEEEECCChHHHHHHHHHHHHCCCEEEEC
+Confidence               100 01247899999988888888899999998874
+
+
+No 126
+>1dih_A Dihydrodipicolinate reductase; oxidoreductase; HET: NDP; 2.20A {Escherichia coli} SCOP: c.2.1.3 d.81.1.3 PDB: 1arz_A* 1dru_A* 1drv_A* 1drw_A*
+Probab=81.60  E-value=0.41  Score=42.13  Aligned_cols=132  Identities=17%  Similarity=0.174  Sum_probs=72.1  Template_Neff=9.800
+
+Q gi|556503834|r  464 QVIEVFVIG-VGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSK-ALLTNVHGLNLENWQEELAQAKEPF-NLGRLIRL  540 (820)
+Q Consensus       464 qvievfvig-vggvggalleqlkrqqswlknkhidlrvcgvansk-alltnvhglnlenwqeelaqakepf-nlgrlirl  540 (820)
+                      ..+.|.+|| .|.+|..+++.+.++.        ++.+.++.... ...   .+   +.+.+++....... ....+..+
+T Consensus         4 ~~~~i~iiG~~G~~G~~~~~~l~~~~--------~~~lv~v~~~~~~~~---~~---~~~~~~~~~~~~~~~~~~~~~~~   69 (273)
+T 1dih_A            4 ANIRVAIAGAGGRMGRQLIQAALALE--------GVQLGAALEREGSSL---LG---SDAGELAGAGKTGVTVQSSLDAV   69 (273)
+T ss_dssp             CBEEEEETTTTSHHHHHHHHHHHHST--------TEECCCEECCTTCTT---CS---CCTTCSSSSSCCSCCEESCSTTT
+T ss_pred             CCCEEEEECCCCHHHHHHHHHHHhCC--------CcEEEEEEecCCccc---cc---cchhhhcccccCCcccccCHHHh
+Confidence            346788999 9999999998886532        24454443321 100   01   11111110000000 00111111
+
+
+Q gi|556503834|r  541 VKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIEN  618 (820)
+Q Consensus       541 vkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvien  618 (820)
+                      ++    -..+++|||......+.....++.|.|+|.-.. ..  +.+-..+|..+++  +...++..|.+.|...+..
+T Consensus        70 ~~----~~DvVi~~t~~~~~~~~~~~al~~g~~vv~~t~-g~--~~~~~~~l~~~a~--~~~v~~~~n~s~g~~~~~~  138 (273)
+T 1dih_A           70 KD----DFDVFIDFTRPEGTLNHLAFCRQHGKGMVIGTT-GF--DEAGKQAIRDAAA--DIAIVFAANFSVGVNVMLK  138 (273)
+T ss_dssp             TT----SCSEEEECSCHHHHHHHHHHHHHTTCEEEECCC-CC--CHHHHHHHHHHTT--TSCEEECSCCCHHHHHHHH
+T ss_pred             hc----CCCEEEEcCCHHHHHHHHHHHHHcCCcEEecCC-CC--CHHHHHHHHHHhC--CCCEEEEecccchHHHHHH
+Confidence            11    236899999999888888888999999998653 11  2223344554443  4566777887777665543
+
+
+No 127
+>2j0w_A Lysine-sensitive aspartokinase 3; feedback inhibition, allosteric regulation, ACT domain, transferase, amino acid biosynthesis; HET: ADP; 2.5A {Escherichia coli} SCOP: c.73.1.3 d.58.18.10 d.58.18.10 PDB: 2j0x_A*
+Probab=81.51  E-value=0.42  Score=46.77  Aligned_cols=59  Identities=27%  Similarity=0.412  Sum_probs=49.1  Template_Neff=8.600
+
+Q gi|556503834|r  388 EPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDA  448 (820)
+Q Consensus       388 eplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnndda  448 (820)
+                      .-+...+.+++|++.+.+|....|+.++.|..|++++|||..|.|  ++.+++++++.++.
+T Consensus       300 ~~It~~~~iali~v~~~~~~~~~~~~~~i~~~la~~~I~i~~I~~--s~~~is~~i~~~~~  358 (449)
+T 2j0w_A          300 RALALRRNQTLLTLHSLNMLHSRGFLAEVFGILARHNISVDLITT--SEVSVALTLDTTGS  358 (449)
+T ss_dssp             EEEEEEEEEEEEEECCCSCSCHHHHHHHHTTTTTTTTCCCSEEEE--ETTEEEEEECCCCC
+T ss_pred             cceEecCCeEEEEEEEccccchhhHHHHHHHHHHHCCCcEEEEEc--CCCceEEEEechhh
+Confidence            345666788999999999988889999999999999999999999  56777777765543
+
+
+No 128
+>3wgq_A MESO-diaminopimelate dehydrogenase; mutation, domain motion, oxidoreductase; HET: API; 2.00A {Clostridium tetani} PDB: 3wgo_A* 3wgy_A 3wgz_A
+Probab=81.35  E-value=0.43  Score=42.79  Aligned_cols=131  Identities=18%  Similarity=0.286  Sum_probs=72.9  Template_Neff=10.000
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLR-VCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKE  543 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlr-vcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvke  543 (820)
+                      .+.|.|||.|.+|..+++.|.+..      .+.+. +|+....++  .  ..++...           +... ....+.+
+T Consensus         4 ~~~i~iiG~G~vG~~~~~~l~~~~------~~~v~~v~~r~~~~~--~--~~~~~~~-----------~~~~-~~~~l~~   61 (326)
+T 3wgq_A            4 KIRIGIVGYGNIGKGVEKAIKQND------DMELEAIFTRRDINK--V--DSNNSKL-----------VHIS-RLELYKD   61 (326)
+T ss_dssp             CEEEEEECCSHHHHHHHHHHTTCT------TEEEEEEEECSCSSS--C--SSCCTTE-----------EEGG-GGGGGTT
+T ss_pred             ccEEEEEeehHHHHHHHHHHhcCC------CcEEEEEEeCCHHHH--H--HhcCCCE-----------EECC-HHHHhhC
+Confidence            356889999999999999887532      34553 555544443  1  1111100           0000 0001111
+
+
+Q gi|556503834|r  544 YHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSM-DYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNL  622 (820)
+Q Consensus       544 yhllnpvivdctssqavadqyadflregfhvvtpnkkantssm-dyyhqlryaaeksrrkflydtnvgaglpvienlqnl  622 (820)
+                         ---++++|+......+.....++.|.|++..  +..+..+ +...++...+++....++...  | -.|.+.++..+
+T Consensus        62 ---~~DvVi~~~~~~~~~~~~~~al~~g~~~vd~--~~~~~~~~~~~~~l~~~a~~~g~~~~~~~--g-~~pgl~~l~~~  133 (326)
+T 3wgq_A           62 ---TVDVMILCGGSATDLVEQGPMIASQFNTVDS--FDNHGRIPQHFERMDEISKKAGNISLIST--G-WDPGLFSLNRL  133 (326)
+T ss_dssp             ---TCSEEEECCTTSHHHHHHHHHHHTTSCEECC--CCCGGGHHHHHHHHHHHHHHHTCEEECSC--S-BTTBHHHHHHH
+T ss_pred             ---CCCEEEECCCchhhHHHHHHHHHcCCeEEEe--cCccCcHHHHHHHHHHHHHHcCCEEEEeC--C-cCHHHHHHHHH
+Confidence               2346789998877777777888999999974  2223333 444555555666666665543  2 34555555555
+
+
+Q gi|556503834|r  623 LNA  625 (820)
+Q Consensus       623 lna  625 (820)
+                      +..
+T Consensus       134 ~~~  136 (326)
+T 3wgq_A          134 LGE  136 (326)
+T ss_dssp             HHH
+T ss_pred             Hhc
+Confidence            443
+
+
+No 129
+>4miy_A Inositol 2-dehydrogenase/D-chiro-inositol 3-dehyd; NAD, sugar alcohol dehydrogenases, rossmann fold, dehydrogen binding; HET: NAD INS; 1.42A {Lactobacillus casei} PDB: 4mio_A* 4min_A* 4mie_A* 4mjl_A*
+Probab=80.87  E-value=0.46  Score=41.90  Aligned_cols=140  Identities=15%  Similarity=0.139  Sum_probs=75.2  Template_Neff=10.600
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEYH  545 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlirlvkeyh  545 (820)
+                      +.|.+||.|.+|...+..++..       +-++++.+|.+...-       ..+.+.+++.-....+  ..+-.+++. .
+T Consensus         3 ~~i~iiG~G~~~~~~~~~~~~~-------~~~~~i~~~~~~~~~-------~~~~~~~~~~~~~~~~--~~~~~~l~~-~   65 (339)
+T 4miy_A            3 VKVGVIGTGAMGRAHIDRLTNV-------LTGAEVVAVTDIDHE-------AAEAAVRDFHLNAKVY--PDDTSLLQD-P   65 (339)
+T ss_dssp             EEEEEECCSHHHHHHHHHHHHT-------SSSEEEEEEECSSHH-------HHHHHHHHTTCCCEEC--SSHHHHTTC-T
+T ss_pred             cEEEEECCcHHHHHHHHHHHhc-------CCCcEEEEEECCCHH-------HHHHHHHHhCCCceEE--CCHHHHhcC-C
+Confidence            5678999999998777666542       224556665543210       1111211111000001  111122221 1
+
+
+Q gi|556503834|r  546 LLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAA-EKSRRKFLYDTNVGAGLPVIENLQNLLN  624 (820)
+Q Consensus       546 llnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaa-eksrrkflydtnvgaglpvienlqnlln  624 (820)
+                      - --+++-||.+..-.+....++..|.||+.-.  .-+.+.+-..+|.-.+ +++.+++.-.. .-.-.|.+..+++++.
+T Consensus        66 ~-~d~v~i~t~~~~h~~~~~~~l~~g~~v~~EK--P~a~~~~~~~~l~~~a~~~~~~~~~v~~-~~r~~p~~~~~k~~i~  141 (339)
+T 4miy_A           66 D-IDAVFVVSFGGAHEATVLKALDTDKFIFTEK--PLATTLEGAKRIVDKELTKSKKVIQVGF-MRRYDQGIRALKEKLD  141 (339)
+T ss_dssp             T-CCEEEECSCGGGHHHHHHHHTTSSCEEEECS--CSCSSHHHHHHHHHHHTTSSSCCEEECC-GGGGCHHHHHHHHHHH
+T ss_pred             C-CCEEEEeCCchhHHHHHHHHHhCCCcEEeeC--CCCCCHHHHHHHHHHHHHhcCCEEEecc-chhcCHHHHHHHHHHh
+Confidence            1 1245567887777777788999999998743  3333334445555555 55555544333 3455677888888887
+
+
+Q gi|556503834|r  625 AG  626 (820)
+Q Consensus       625 ag  626 (820)
+                      .|
+T Consensus       142 ~g  143 (339)
+T 4miy_A          142 TG  143 (339)
+T ss_dssp             TT
+T ss_pred             cC
+Confidence            65
+
+
+No 130
+>1xea_A Oxidoreductase, GFO/IDH/MOCA family; structural genomics, protein structure initiative, NYSGXRC, VCA1048, GFO/IDH/MOCA family oxidoreductase; 2.65A {Vibrio cholerae} SCOP: c.2.1.3 d.81.1.5
+Probab=80.68  E-value=0.47  Score=41.69  Aligned_cols=75  Identities=17%  Similarity=0.109  Sum_probs=51.2  Template_Neff=10.500
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      .+++.||.+..-.+.....++.|-||+..  |.-+.+.+-..++..++++...++....+.... |.+..++.+++.|
+T Consensus        65 d~v~i~~~~~~h~~~~~~~l~~g~~v~~e--kp~~~~~~~~~~l~~~a~~~~~~~~~~~~~r~~-~~~~~~~~~i~~g  139 (323)
+T 1xea_A           65 DAVMIHAATDVHSTLAAFFLHLGIPTFVD--KPLAASAQECENLYELAEKHHQPLYVGFNRRHI-PLYNQHLSELAQQ  139 (323)
+T ss_dssp             SEEEECSCGGGHHHHHHHHHHTTCCEEEE--SCSCSSHHHHHHHHHHHHHTTCCEEEECGGGCC-HHHHHHCHHHHHT
+T ss_pred             CEEEEeCCchhHHHHHHHHHHCCCcEEEe--CCCcCCHHHHHHHHHHHHHCCCEEEEecccccC-HHHHHHHHHHhcc
+Confidence            56777888887777777888899888752  332334444556666676666666666554433 8888888888876
+
+
+No 131
+>1tlt_A Putative oxidoreductase (virulence factor MVIM HO; structural genomics, NYSGXRC, PSI, protein structure initiative; 2.70A {Escherichia coli} SCOP: c.2.1.3 d.81.1.5
+Probab=80.26  E-value=0.5  Score=41.30  Aligned_cols=76  Identities=14%  Similarity=0.162  Sum_probs=46.7  Template_Neff=10.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAGD  627 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnagd  627 (820)
+                      -+++.|++...-.+...++++.|.||+...  .-+.+.+--.++...+++...+++.. ..-.-.|.+..++.+++.|.
+T Consensus        67 D~vii~~~~~~~~~~~~~~~~~g~~v~~ek--p~~~~~~~~~~l~~~~~~~~~~~~~~-~~~r~~~~~~~~k~~i~~g~  142 (319)
+T 1tlt_A           67 DAVFVHSSTASHFDVVSTLLNAGVHVCVDK--PLAENLRDAERLVELAARKKLTLMVG-FNRRFAPLYGELKTQLATAA  142 (319)
+T ss_dssp             SEEEECSCTTHHHHHHHHHHHTTCEEEEES--SSCSSHHHHHHHHHHHHHTTCCEEEE-CGGGGCHHHHHHTTTGGGCC
+T ss_pred             CEEEEeCCchhHHHHHHHHHHCCCcEEEeC--CCCCCHHHHHHHHHHHHHcCCeEEEe-ecccCCHHHHHHHHHhcCCC
+Confidence            467778887777777788888999887532  11112222234444444444444433 33556778888999988875
+
+
+No 132
+>3gdo_A Uncharacterized oxidoreductase YVAA; structural genomics, putative oxidoreductase YVAA, oxidoredu PSI-2, protein structure initiative; 2.03A {Bacillus subtilis subsp} PDB: 3gfg_A
+Probab=78.49  E-value=0.63  Score=41.66  Aligned_cols=75  Identities=19%  Similarity=0.176  Sum_probs=50.5  Template_Neff=10.400
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||......+.....++.|-||+. .|.. +.+.+-..+|.-+++++..++.-..+ -.-.|.+..++.+++.|
+T Consensus        67 D~V~i~~p~~~h~~~~~~al~~g~~v~~-EKP~-~~~~~~~~~l~~~a~~~~~~~~~~~~-~r~~p~~~~~~~~i~~g  141 (358)
+T 3gdo_A           67 ELVIVTTPSGLHYEHTMACIQAGKHVVM-EKPM-TATAEEGETLKRAADEKGVLLSVYHN-RRWDNDFLTIKKLISEG  141 (358)
+T ss_dssp             CEEEECSCTTTHHHHHHHHHHTTCEEEE-ESSC-CSSHHHHHHHHHHHHHHTCCEEEECG-GGGSHHHHHHHHHHHTT
+T ss_pred             CEEEEeCCcHHHHHHHHHHHHCCCcEEE-eCCC-CCCHHHHHHHHHHHHHcCCEEEEeee-eccCHHHHHHHHHHhhC
+Confidence            3677888888888888889999999987 3433 33445557777777766665543322 23456677777777654
+
+
+No 133
+>3f4l_A Putative oxidoreductase YHHX; structural genomics, PSI-2, protein structure initiative, northeast structural genomics consortium, NESG; 2.00A {Escherichia coli k-12}
+Probab=77.65  E-value=0.7  Score=41.17  Aligned_cols=74  Identities=15%  Similarity=0.099  Sum_probs=49.6  Template_Neff=10.400
+
+Q gi|556503834|r  550 VIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       550 vivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      +++.||....-++.....++.|.||+. .|...++. +-..++.-++++....+.-..| -.-.|.+..++.++..|
+T Consensus        68 ~v~i~~~~~~h~~~~~~~l~~g~~v~~-ekP~~~~~-~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~lk~li~~g  141 (345)
+T 3f4l_A           68 LVVVCTHADSHFEYAKRALEAGKNVLV-EKPFTPTL-AQAKELFALAKSKGLTVTPYQN-RRFDSCFLTAKKAIESG  141 (345)
+T ss_dssp             EEEECSCGGGHHHHHHHHHHTTCEEEE-CSSSCSSH-HHHHHHHHHHHHHTCCEEECCG-GGGCHHHHHHHHHHHHS
+T ss_pred             EEEEeCCchhHHHHHHHHHHcCCcEEE-eCCCCCCH-HHHHHHHHHHHhcCCeEEEEee-eccCHHHHHHHHHHhcC
+Confidence            567788888888888899999999988 34333333 3445666666666555543333 34457777788777654
+
+
+No 134
+>4koa_A 1,5-anhydro-D-fructose reductase; GFO/IDH/MOCA family, dehydrogenase, sugar binding, oxidoredu; HET: NDP; 1.93A {Sinorhizobium meliloti} PDB: 2glx_A*
+Probab=77.34  E-value=0.72  Score=40.55  Aligned_cols=75  Identities=12%  Similarity=0.114  Sum_probs=48.8  Template_Neff=10.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||....-.+.-...+..|.||+.-..-  +.+.+-..++...+++...++....+. --.|.+..+++++..|
+T Consensus        65 d~v~i~~~~~~h~~~~~~~l~~g~~v~~ekP~--~~~~~~~~~l~~~a~~~~~~~~~~~~~-r~~p~~~~~~~~i~~g  139 (333)
+T 4koa_A           65 DAVYISTTNELHHGQALAAIRAGKHVLCEKPL--AMNLNDGCEMVLKACEAGVVLGTNHHL-RNAATHRAMREAIAAG  139 (333)
+T ss_dssp             CEEEECSCGGGHHHHHHHHHHTTCEEEECSCS--CSSHHHHHHHHHHHHHHTCCEEECCCG-GGSHHHHHHHHHHHTT
+T ss_pred             CEEEEeCChhhhHHHHHHHHHcCCeEEeeCCC--cCCHHHHHHHHHHHHHcCCeEEeCccc-cCCHHHHHHHHHHHcC
+Confidence            45777888877777777788999999875332  334555667776666666565544332 2236677777777654
+
+
+No 135
+>3wb9_A Diaminopimelate dehydrogenase; domain motion, thermo-stable, D-amino acid dehydrogenase, oxidoreductase; 1.93A {Symbiobacterium thermophilum} PDB: 3wbb_A* 3wbf_A*
+Probab=77.11  E-value=0.74  Score=41.88  Aligned_cols=122  Identities=20%  Similarity=0.306  Sum_probs=69.6  Template_Neff=9.300
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLE-NWQEELAQAKEPFNLGRLIRLVK  542 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnle-nwqeelaqakepfnlgrlirlvk  542 (820)
+                      +-+.+.++|.|.+|..+++.|++.      .  ++.++++..+..-. .     +. ++. .+    ..++  .+-.+++
+T Consensus         8 ~~~~~~i~G~G~iG~~~~~~l~~~------~--~~~l~~v~~~~~~~-~-----~a~~~~-~v----~~~~--~~~~~~~   66 (305)
+T 3wb9_A            8 DKLRVAVVGYGNVGRYALEAVQAA------P--DMELVGVVRRKVLA-A-----TPPELT-GV----RVVT--DISQLEG   66 (305)
+T ss_dssp             -CEEEEEESCSHHHHHHHHHHHHC------T--TEEEEEEECSCCCS-S-----CCGGGT-TS----CEES--SGGGSTT
+T ss_pred             CCccEEEECcHHHHHHHHHHHhhC------C--CcEEEEEEecchhh-h-----hhcccc-Cc----eeeC--CHHHHhC
+Confidence            346788999999999999888743      1  24445444433110 0     11 000 00    0011  1222222
+
+
+Q gi|556503834|r  543 EYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNK-KANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGL  613 (820)
+Q Consensus       543 eyhllnpvivdctssqavadqyadflregfhvvtpnk-kantssmdyyhqlryaaeksrrkflydtnvgagl  613 (820)
+                           --+++.|+......+.....++.|.|++.... .+  .+.+...++..++++.....++..+...|+
+T Consensus        67 -----~D~Vi~~~~~~~~~~~~~~al~~g~~~id~~~p~~--~~~~~~~~l~~~a~~~~~~~v~~~g~~pg~  131 (305)
+T 3wb9_A           67 -----VQGALLCVPTRSVPEYAEAMLRRGIHTVDSYDIHG--DLADLRRRLDPVAREHGAAAVISAGWDPGT  131 (305)
+T ss_dssp             -----CCEEEECSCGGGHHHHHHHHHTTTCEEECCCCCTT--THHHHHHHHHHHHHHTTCEEECSCBBTTBH
+T ss_pred             -----CCEEEEeCCCccCHHHHHHHHHcCCCEEEccCccc--cCHHHHHHHHHHHHHcCCEEEEeCCcChhH
+Confidence                 34678898887766667778889999998752 32  334445566667777777756655555444
+
+
+No 136
+>3i23_A Oxidoreductase, GFO/IDH/MOCA family; structural genomics, PSI-2, protein structure initiative, northeast structural genomics consortium; 2.30A {Enterococcus faecalis} PDB: 3fd8_A* 3hnp_A
+Probab=76.90  E-value=0.76  Score=40.84  Aligned_cols=75  Identities=13%  Similarity=0.097  Sum_probs=51.0  Template_Neff=10.500
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      .+++.|+++..-.+....+++.|.||+.. | .-+.+.+...+|.-.+++...++....|. .-.|.+..++.++..|
+T Consensus        67 D~v~i~~p~~~h~~~~~~~~~~g~~v~~e-k-P~~~~~~~~~~l~~~~~~~~~~~~~~~~~-r~~~~~~~~~~~i~~~  141 (349)
+T 3i23_A           67 ELITICTPAHTHYDLAKQAILAGKSVIVE-K-PFCDTLEHAEELFALGQEKGVVVMPYQNR-RFDGDYLAMKQVVEQG  141 (349)
+T ss_dssp             CEEEECSCGGGHHHHHHHHHHTTCEEEEC-S-CSCSSHHHHHHHHHHHHHTTCCEEECCGG-GGCHHHHHHHHHHHHT
+T ss_pred             CEEEEcCChHHHHHHHHHHHHCCCcEEEe-C-CCCCCHHHHHHHHHHHHHcCCEEEEEeee-ccCHHHHHHHHHHhcC
+Confidence            45677888888888888889999998872 2 22333344466666677766677666654 3456777777777654
+
+
+No 137
+>2cdq_A Aspartokinase; aspartate kinase, amino acid metabolism, ACT domain, alloste S-adenosylmethionine, lysine, allosteric effector, plant; HET: TAR SAM LYS; 2.85A {Arabidopsis thaliana} SCOP: c.73.1.3 d.58.18.10 d.58.18.10
+Probab=76.32  E-value=0.81  Score=45.98  Aligned_cols=60  Identities=22%  Similarity=0.366  Sum_probs=51.6  Template_Neff=8.200
+
+Q gi|556503834|r  387 LEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDA  448 (820)
+Q Consensus       387 leplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnndda  448 (820)
+                      ..-+...+.+++|++.+.+|....++.++.|..|++++||+..|.|  ++.+|+++++.++.
+T Consensus       332 i~~It~~~~ialI~v~~~~~~~~~~~~~~if~~La~~gI~v~~Is~--s~~~is~~v~~~~~  391 (510)
+T 2cdq_A          332 LTSIVLKRNVTMLDIASTRMLGQVGFLAKVFSIFEELGISVDVVAT--SEVSISLTLDPSKL  391 (510)
+T ss_dssp             EEEEEEEEEEEEEEEECGGGTTCTTHHHHHHHHHHHTTCCEEEEEE--ETTEEEEEECCGGG
+T ss_pred             ceeccccCCeeEEEEEecCcCCchhHHHHHHHHHHhcCceEEEEEc--CCceEEEEEehhhh
+Confidence            4456677889999999999998899999999999999999999987  57888888876653
+
+
+No 138
+>1ydw_A AX110P-like protein; structural genomics, protein structure initiative, center for eukaryotic structural genomics, CESG, AT4G09670; 2.49A {Arabidopsis thaliana} SCOP: c.2.1.3 d.81.1.5 PDB: 2q4e_A
+Probab=76.31  E-value=0.81  Score=40.72  Aligned_cols=73  Identities=12%  Similarity=0.094  Sum_probs=47.0  Template_Neff=10.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLN  624 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnlln  624 (820)
+                      -+++.||....-.+.....++.|.||+..  |.-+.+.....+|..+++++..++..+.+ -.-.|.+..++.++.
+T Consensus        73 d~V~i~~~~~~h~~~~~~~~~~g~~v~~E--kP~~~~~~~~~~l~~~~~~~~~~~~~~~~-~r~~p~~~~~~~~i~  145 (362)
+T 1ydw_A           73 DALYVPLPTSLHVEWAIKAAEKGKHILLE--KPVAMNVTEFDKIVDACEANGVQIMDGTM-WVHNPRTALLKEFLS  145 (362)
+T ss_dssp             CEEEECCCGGGHHHHHHHHHTTTCEEEEC--SSCSSSHHHHHHHHHHHHTTTCCEEECCC-GGGSGGGTTTTTGGG
+T ss_pred             CEEEECCChHHhHHHHHHHHHCCCeEEEe--CCCcCCHHHHHHHHHHHHHhCCEEEEeee-eecChHHHHHHHHHh
+Confidence            35556998888888888899999999973  33333334455666666655555443332 234577777777774
+
+
+No 139
+>2czc_A Glyceraldehyde-3-phosphate dehydrogenase; glycolysis, NAD, oxidoreductase, structural genomics; HET: NAD; 2.00A {Pyrococcus horikoshii} SCOP: c.2.1.3 d.81.1.1
+Probab=72.35  E-value=1.2  Score=40.88  Aligned_cols=97  Identities=21%  Similarity=0.315  Sum_probs=52.0  Template_Neff=9.400
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKA----LLTNVHGLNLE-NW---QEELAQAKEPFNL-GR  536 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanska----lltnvhglnle-nw---qeelaqakepfnl-gr  536 (820)
+                      +.|.+||.|.+|..+++.+.++        -++.+.+|.....    .+..-+|.... .|   .+++...  .+.. +.
+T Consensus         3 ~kV~IiG~G~iG~~~~~~l~~~--------~~~~l~~v~~~~~~~~~~~~~~~g~~~~~~~~~~~~~~~~~--~~~v~~~   72 (334)
+T 2czc_A            3 VKVGVNGYGTIGKRVAYAVTKQ--------DDMELIGITKTKPDFEAYRAKELGIPVYAASEEFIPRFEKE--GFEVAGT   72 (334)
+T ss_dssp             EEEEEECCSHHHHHHHHHHHTC--------TTEEEEEEEESSCSHHHHHHHHTTCCEEESSGGGHHHHHHH--TCCCSCB
+T ss_pred             eEEEEECCcHHHHHHHHHHHhC--------CCCEEEEEEcCChhHHHHHHHHcCCceeccccchhhhhhcC--CeEecCC
+Confidence            5678999999999999888753        2355666643211    11112332210 01   0111000  0000 01
+
+
+Q gi|556503834|r  537 LIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVT  576 (820)
+Q Consensus       537 lirlvkeyhllnpvivdctssqavadqyadflregfhvvt  576 (820)
+                      +-.+++    ---++++||......+....+++.|.+++.
+T Consensus        73 ~~~~~~----~~DiVv~atp~~~~~~~~~~~l~~G~~vi~  108 (334)
+T 2czc_A           73 LNDLLE----KVDIIVDATPGGIGAKNKPLYEKAGVKAIF  108 (334)
+T ss_dssp             HHHHHT----TCSEEEECCSTTHHHHHHHHHHHHTCEEEE
+T ss_pred             HHHHhh----CCCEEEECCCCcchHHHHHHHHhcCCeEEE
+Confidence            111111    246899999988776666678888999875
+
+
+No 140
+>3tvi_A Aspartokinase; structural genomics, ACT domains, regulatory domains, kinase transferase, PSI-2, protein structure initiative; HET: LYS; 3.00A {Clostridium acetobutylicum}
+Probab=69.87  E-value=1.5  Score=43.22  Aligned_cols=61  Identities=13%  Similarity=0.231  Sum_probs=50.9  Template_Neff=8.300
+
+Q gi|556503834|r  386 LLEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDA  448 (820)
+Q Consensus       386 lleplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnndda  448 (820)
+                      ........+.++.|++.+.+|....|+.++.|..|++++|||..|.+  ++.+|+++++.++.
+T Consensus       288 ~v~~It~~~ni~li~i~~~~~~~~~g~~~~if~~La~~gI~V~~Is~--s~~~is~~i~~~~~  348 (446)
+T 3tvi_A          288 TITGIAGKKNFTVIAIEKALLNSEVGFCRKILSILEMYGVSFEHMPS--GVDSVSLVIEDCKL  348 (446)
+T ss_dssp             CCCEEEEEEEEEEEEEECTTGGGSTTHHHHHHHHHHTTTCCEEEBCE--ETTEEEEEEEHHHH
+T ss_pred             cceeeeecCCceeEEEeccCCCCcccHHHHHHHHHHHcCceEEeecc--CcccEEEEEehhhh
+Confidence            34556677889999999998888889999999999999999999965  57788888876653
+
+
+No 141
+>3dty_A Oxidoreductase, GFO/IDH/MOCA family; MGCL2, tetramer, PSI-2, 11131, NYSGXRC, structural genomics, protein structure initiative; 2.04A {Pseudomonas syringae PV}
+Probab=67.59  E-value=1.8  Score=39.99  Aligned_cols=75  Identities=23%  Similarity=0.217  Sum_probs=51.1  Template_Neff=9.900
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++.||....-.+.....+..|.||+.  .|.-+.+.+-..++..++++....+.... .-.-.|.+..+++++..|
+T Consensus        87 d~V~i~tp~~~h~~~~~~~l~~g~~vl~--eKP~~~~~~~~~~l~~~a~~~~~~~~v~~-~~r~~p~~~~l~~~i~~g  161 (398)
+T 3dty_A           87 QAVSIATPNGTHYSITKAALEAGLHVVC--EKPLCFTVEQAENLRELSHKHNRIVGVTY-GYAGHQLIEQAREMIAAG  161 (398)
+T ss_dssp             SEEEEESCGGGHHHHHHHHHHTTCEEEE--CSCSCSCHHHHHHHHHHHHHTTCCEEECC-GGGGSHHHHHHHHHHHTT
+T ss_pred             CEEEEeCCCHHHHHHHHHHHHCCCeEEE--eCCCCCCHHHHHHHHHHHHHcCCeEEEee-cCcCCHHHHHHHHHHhcC
+Confidence            3677889888888888899999999884  34433444555667667766655444332 233467788888888766
+
+
+No 142
+>3p96_A Phosphoserine phosphatase SERB; ssgcid, structural genomics, structural genomics center for infectious disease, hydrolas; 2.05A {Mycobacterium avium}
+Probab=66.96  E-value=1.9  Score=40.07  Aligned_cols=116  Identities=17%  Similarity=0.230  Sum_probs=68.9  Template_Neff=9.900
+
+Q gi|556503834|r  311 NLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEY----SISFCVPQSDCV--RAERAMQ---EEFYLE  381 (820)
+Q Consensus       311 nlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqsssey----sisfcvpqsdcv--raeramq---eefyle  381 (820)
+                      +..+...+++.||.-.|   ..++++.++....+.+.-++|+...-    .+.|.+|..++.  ..+.+..   +++-..
+T Consensus         8 ~~~~~~~itv~g~d~pG---iva~v~~~l~~~~~ni~~~~~~~~~~~~~~~~~~~~~~~~~~~~~l~~~l~~~~~~~~~~   84 (415)
+T 3p96_A            8 PPKVSVLITVTGVDQPG---VTATLFEVLSRHGVELLNVEQVVIRHRLTLGVLVCCPADVADGPALRHDVEAAIRKVGLD   84 (415)
+T ss_dssp             -CCEEEEEEEEEECCTT---HHHHHHHHHTTTTCEEEEEEEEEETTEEEEEEEEEECHHHHTSHHHHHHHHHHHHHTTCE
+T ss_pred             CCcceEEEEEEcCCCCC---HHHHHHHHHHhCCCCEEEeeeheecCeeEEEEEEEeccccccHHHHHHHHHHHHHHhCCe
+Confidence            44556778888877655   55788888999999999998876542    455666654321  2222222   122222
+
+
+Q gi|556503834|r  382 LKEGLL--EPLAVTERLAIISVVGDGMR-TLRGISAKFFAALARANINIVAIAQ  432 (820)
+Q Consensus       382 lkegll--eplavterlaiisvvgdgmr-tlrgisakffaalaraninivaiaq  432 (820)
+                      +...-.  +|.........+++.|   | .-.|+-++.+..|+..++||..+..
+T Consensus        85 ~~~~~~~~~~~~~~~~~~~v~l~~---~~~~~G~l~~i~~~L~~~~inI~~i~~  135 (415)
+T 3p96_A           85 VSIERSDDVPIIREPSTHTIFVLG---RPITAAAFGAVAREVAALGVNIDLIRG  135 (415)
+T ss_dssp             EEEEECSSSCSSCCCCSEEEEEEE---SSCCHHHHHHHHHHHHHTTCEEEEEEE
+T ss_pred             eEEecccccccccCCCceEEEEEC---CCCCHHHHHHHHHHHHHCCCCchheee
+Confidence            211111  1112222334556666   3 2347889999999999999988755
+
+
+No 143
+>3ijp_A DHPR, dihydrodipicolinate reductase; ssgcid, SBRI, decode biostructures, niaid, amino-acid biosynthesis, cytoplasm; HET: NAP; 2.30A {Bartonella henselae}
+Probab=66.42  E-value=2  Score=39.02  Aligned_cols=124  Identities=16%  Similarity=0.166  Sum_probs=65.7  Template_Neff=9.100
+
+Q gi|556503834|r  463 DQVIEVFVIG-VGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKA------LLTNVHGLNLENWQEELAQAKEPFNLG  535 (820)
+Q Consensus       463 dqvievfvig-vggvggalleqlkrqqswlknkhidlrvcgvanska------lltnvhglnlenwqeelaqakepfnlg  535 (820)
+                      ...+.|.||| .|.+|..+++.|.+..        ++.+.++..+..      .+....|...       ...+.   ..
+T Consensus        19 ~~~~kV~IiGa~G~~G~~i~~~l~~~~--------~~~vv~v~~~~~~~~~~~~~~~~~g~~~-------~~~~~---~~   80 (288)
+T 3ijp_A           19 PGSMRLTVVGANGRMGRELITAIQRRK--------DVELCAVLVRKGSSFVDKDASILIGSDF-------LGVRI---TD   80 (288)
+T ss_dssp             --CEEEEESSTTSHHHHHHHHHHHTCS--------SEEEEEEBCCTTCTTTTSBGGGGTTCSC-------CSCBC---BS
+T ss_pred             CCCCEEEEECCCCHHHHHHHHHHHhCC--------CcEEEEEEccCCcccccccchhhccccc-------cCccc---cc
+Confidence            4567899999 8999999998876532        345555443221      1111111100       00000   00
+
+
+Q gi|556503834|r  536 RLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGL  613 (820)
+Q Consensus       536 rlirlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgagl  613 (820)
+                      .+-.++.    ---+++|||......+.....++.|.++|.-+..   .+.+.+.+|..+++  ..+.++-.|.+.+.
+T Consensus        81 ~~~~~l~----~~DvVi~~t~~~~~~~~~~~al~~g~~vv~~tt~---~~~~~~~~l~~~a~--~~~v~~~~n~s~~~  149 (288)
+T 3ijp_A           81 DPESAFS----NTEGILDFSQPQASVLYANYAAQKSLIHIIGTTG---FSKTEEAQIADFAK--YTTIVKSGNMSLGV  149 (288)
+T ss_dssp             CHHHHTT----SCSEEEECSCHHHHHHHHHHHHHHTCEEEECCCC---CCHHHHHHHHHHHT--TSEEEECSCCCHHH
+T ss_pred             CHHHhcc----CCCEEEECCChHHHHHHHHHHHHcCCceEecCCC---CCHHHHHHHHHHhc--CCCEEEEcCCchHH
+Confidence            1111111    1348899998777777677778889999984321   12233556666653  23566666655443
+
+
+No 144
+>2axq_A Saccharopine dehydrogenase; rossmann fold variant, saccharopine reductase fold (domain II), alpha/beta protein; 1.70A {Saccharomyces cerevisiae}
+Probab=65.96  E-value=2.1  Score=41.79  Aligned_cols=132  Identities=14%  Similarity=0.172  Sum_probs=65.2  Template_Neff=8.900
+
+Q gi|556503834|r  460 FNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALL-TNVHGLNLENWQEELAQAKEPFNLGRLI  538 (820)
+Q Consensus       460 fntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskall-tnvhglnlenwqeelaqakepfnlgrli  538 (820)
+                      ........|.|+|.|++|..+...|.++..      ..+.+++-...++-- ....+  .+-.+   .....+-   .+.
+T Consensus        18 ~~~~~~~~ilIiGaG~vG~~ia~~L~~~~~------~~v~v~dr~~~~~~~l~~~~~--~~~~~---~D~~d~~---~l~   83 (467)
+T 2axq_A           18 EGRHMGKNVLLLGSGFVAQPVIDTLAANDD------INVTVACRTLANAQALAKPSG--SKAIS---LDVTDDS---ALD   83 (467)
+T ss_dssp             -----CEEEEEECCSTTHHHHHHHHHTSTT------EEEEEEESSHHHHHHHHGGGT--CEEEE---CCTTCHH---HHH
+T ss_pred             cccCCCCEEEEECChHHHHHHHHHHHcCCC------CeEEEEECCHHHHHHHHhhcC--ceEEE---ecCCCHH---HHH
+Confidence            344556678999999999999999987531      234455443332210 00000  00000   0011111   122
+
+
+Q gi|556503834|r  539 RLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       539 rlvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                      .+++.    --+++.|++.+....-....++.|.|++..+..     .+...++...+++....++.+.+...|+.
+T Consensus        84 ~~l~~----~DvVI~~~p~~~~~~v~~~al~~g~~~idls~~-----~~~~~~l~~~a~~~g~~~v~g~G~~pG~s  150 (467)
+T 2axq_A           84 KVLAD----NDVVISLIPYTFHPNVVKSAIRTKTDVVTSSYI-----SPALRELEPEIVKAGITVMNEIGLDPGID  150 (467)
+T ss_dssp             HHHHT----SSEEEECSCGGGHHHHHHHHHHHTCEEEECSCC-----CHHHHHHHHHHHHHTCEEECSCBBTTBHH
+T ss_pred             HHHhc----CCEEEECCCchhhHHHHHHHHHhCCceEEeccC-----cHHHHHHHHHHHhcCcEEEEccCCCcchH
+Confidence            22232    246788887554433334467889998884421     12223344445555666777666655543
+
+
+No 145
+>4ina_A Saccharopine dehydrogenase; structural genomics, PSI-biology, northeast structural genom consortium, NESG, oxidoreductas; 2.49A {Wolinella succinogenes}
+Probab=64.69  E-value=2.3  Score=39.44  Aligned_cols=67  Identities=7%  Similarity=0.076  Sum_probs=37.6  Template_Neff=9.900
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYA-DFLREGFHVVTPNKKANT----SSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVI  616 (820)
+Q Consensus       549 pvivdctssqavadqya-dflregfhvvtpnkkant----ssmdyyhqlryaaeksrrkflydtnvgaglpvi  616 (820)
+                      -++++|+.... ..+++ ..++.|.|++....+...    ..-+.+.++...+++....++....+..|++-+
+T Consensus        78 dvVi~~~~p~~-~~~v~~~a~~~g~~~vd~~~~~~~~~~~~~~~~~~~l~~~a~~~g~~~i~~~g~~pGl~~~  149 (405)
+T 4ina_A           78 QIVLNIALPYQ-DLTIMEACLRTGVPYLDTANYEHPDLAKFEYKEQWAFHDRYKEKGVMALLGSGFDPGVTNV  149 (405)
+T ss_dssp             SEEEECSCGGG-HHHHHHHHHHHTCCEEESSCCBCTTCSCBCSHHHHTTHHHHHHHTCEEEECCBTTTBHHHH
+T ss_pred             CEEEECCCccc-CHHHHHHHHHhCCCEEECCCCCCccccchhHHHHHHHHHHHHHCCCEEEECCCCCccHHHH
+Confidence            35678876553 23333 345678888844433311    001122344445667778888888777777543
+
+
+No 146
+>1zvp_A Hypothetical protein VC0802; structural genomics, PSI, protein structure initiative, midwest center for structural genomics, MCSG, U function; 2.20A {Vibrio cholerae} SCOP: d.58.18.9 d.58.18.9
+Probab=63.62  E-value=2.5  Score=36.22  Aligned_cols=65  Identities=15%  Similarity=0.194  Sum_probs=51.4  Template_Neff=7.400
+
+Q gi|556503834|r  309 ISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQE  376 (820)
+Q Consensus       309 isnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqe  376 (820)
+                      +..-....++.+.||..-.++|+.+.+-..++.+.|++..++.....|   +.||..|..+|.+++++
+T Consensus        65 l~~~~~w~~i~i~~~~~~~~~G~la~is~~LA~~gI~i~~ist~~tD~---ilV~~~~~~~A~~~L~~  129 (133)
+T 1zvp_A           65 LESSALFSLITLTVHSSLEAVGLTAAFATKLAEHGISANVIAGYYHDH---IFVQKEKAQQALQALGE  129 (133)
+T ss_dssp             CCCCSCEEEEEEECCC--CCSCHHHHHHHHHHHTTCCCEEEECSSCEE---EEEEGGGHHHHHHHHTT
+T ss_pred             CCccCCeEEEEEecCcchhHHHHHHHHHHHHHHCCCCEEEEeeecccE---EEEeHHHHHHHHHHHHH
+Confidence            445567889999999888899999999999999999999887766665   45698888888776653
+
+
+No 147
+>3l07_A Bifunctional protein fold; structural genomics, IDP01849, methylenetetrahydrofolate dehydrogenase; 1.88A {Francisella tularensis}
+Probab=63.61  E-value=2.5  Score=38.99  Aligned_cols=21  Identities=24%  Similarity=0.349  Sum_probs=18.3  Template_Neff=8.600
+
+Q gi|556503834|r  466 IEVFVIGVGG-VGGALLEQLKR  486 (820)
+Q Consensus       466 ievfvigvgg-vggalleqlkr  486 (820)
+                      -.|.|||.|+ +|.++...|++
+T Consensus       162 ~~v~IiG~G~~vg~~ia~~l~~  183 (285)
+T 3l07_A          162 AYAVVVGASNVVGKPVSQLLLN  183 (285)
+T ss_dssp             CEEEEECCCTTTHHHHHHHHHH
+T ss_pred             CEEEEECCCcchHHHHHHHHHH
+Confidence            4688999999 99999988865
+
+
+No 148
+>3s1t_A Aspartokinase; ACT domain, threonine binding, regulatory domain of aspartok transferase; 1.63A {Mycobacterium tuberculosis}
+Probab=62.97  E-value=2.6  Score=35.78  Aligned_cols=56  Identities=30%  Similarity=0.447  Sum_probs=41.8  Template_Neff=9.100
+
+Q gi|556503834|r  390 LAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSE-----RSISVVVNNDD  447 (820)
+Q Consensus       390 lavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgsse-----rsisvvvnndd  447 (820)
+                      ++..+.++++.+.+  +....+..++.|..|+++++++..+.++.+.     .++++++..++
+T Consensus        10 It~~~~~~li~l~~--~~~~~~~~~~l~~~l~~~~i~v~~i~~~~~~~~~~~~~i~~~i~~~~   70 (181)
+T 3s1t_A           10 VAHDRSEAKVTIVG--LPDIPGYAAKVFRAVADADVNIDMVLQNVSKVEDGKTDITFTCSRDV   70 (181)
+T ss_dssp             EEEECSEEEEEEEE--EESSTTHHHHHHHHHHHTTCCCCCEEECCCCTTTCEEEEEEEEETTT
+T ss_pred             EEecCCEEEEEEcc--CCCCcCHHHHHHHHHHHCCCEEEEEEcCCcCCCCCcccEEEEEEHHH
+Confidence            34456677777764  5555678889999999999999999998764     57777776443
+
+
+No 149
+>4f3y_A DHPR, dihydrodipicolinate reductase; structural genomics, niaid, national institute of allergy AN infectious diseases; 2.10A {Burkholderia thailandensis}
+Probab=62.78  E-value=2.6  Score=36.21  Aligned_cols=59  Identities=22%  Similarity=0.274  Sum_probs=32.0  Template_Neff=10.400
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAG  612 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgag  612 (820)
+                      .++++|++.....+.....++.|.+++.-|...   +.+.+.++..++.  ..+++|-.+.+.+
+T Consensus        75 d~Vi~~a~~~~~~~~~~~~~~~~~~~~~~~~~~---~~~~~~~l~~~~~--~~~~v~~s~~~~~  133 (272)
+T 4f3y_A           75 DYLIDFTLPEGTLVHLDAALRHDVKLVIGTTGF---SEPQKAQLRAAGE--KIALVFSANMSVG  133 (272)
+T ss_dssp             SEEEECSCHHHHHHHHHHHHHHTCEEEECCCCC---CHHHHHHHHHHTT--TSEEEECSCCCHH
+T ss_pred             CEEEECCCcHHHHHHHHHHHHcCCCEEEECCCC---CHHHHHHHHHHHh--cCCEEEEccchHH
+Confidence            367888876544444444556788877655321   2222334443443  3456666665544
+
+
+No 150
+>1p9l_A Dihydrodipicolinate reductase; oxidoreductase, lysine biosynthesis, NADH binding specificity, TB structural genomics consortium; HET: NAI PDC PG4; 2.30A {Mycobacterium tuberculosis} SCOP: c.2.1.3 d.81.1.3 PDB: 1c3v_A* 1yl5_A 1yl7_A* 1yl6_A*
+Probab=62.53  E-value=2.7  Score=38.19  Aligned_cols=68  Identities=16%  Similarity=0.234  Sum_probs=44.9  Template_Neff=8.400
+
+Q gi|556503834|r  548 NPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEK-SRRKFLYDTNVGAGLPVIEN  618 (820)
+Q Consensus       548 npvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaek-srrkflydtnvgaglpvien  618 (820)
+                      ..+++|+|+..++.+-+..++..|..+|.-....+   -+-+..++.++.+ ..-+.+|-+|.+.|..+...
+T Consensus        46 ~dvviD~s~~~~~~~~~~~~~~~g~~~Vi~ttG~~---~~~~~~l~a~a~~~~~v~~~~~snfs~g~~~~~~  114 (245)
+T 1p9l_A           46 TEVVIDFTHPDVVMGNLEFLIDNGIHAVVGTTGFT---AERFQQVESWLVAKPNTSVLIAPNFAIGAVLSMH  114 (245)
+T ss_dssp             CCEEEECSCTTTHHHHHHHHHHTTCEEEECCCCCC---HHHHHHHHHHHHTSTTCEEEECSCCCHHHHHHHH
+T ss_pred             CeEEEEcCCHHHHHHHHHHHhhcCCCEEEEcCCCC---HHHHHHHHHHHHhcCCccEEEeCCccHHHHHHHH
+Confidence            36789999988887777666667777554322222   2235667764543 45588999999988765443
+
+
+No 151
+>2f06_A Conserved hypothetical protein; structural genomics hypothetical protein, PSI, protein struc initiative; HET: MSE HIS; 2.10A {Bacteroides thetaiotaomicron} SCOP: d.58.18.11 d.58.18.11
+Probab=62.40  E-value=2.7  Score=31.99  Aligned_cols=67  Identities=13%  Similarity=0.143  Sum_probs=49.4  Template_Neff=10.900
+
+Q gi|556503834|r  317 MFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELK  383 (820)
+Q Consensus       317 mfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefylelk  383 (820)
+                      ..++-|..++...|..++++..++...+.+..+.+..+..++++.++.++..++.+.+.+.+|.-..
+T Consensus        71 ~~~~v~~~~~~~~g~l~~i~~~L~~~~i~i~~~~~~~~~~~~~~~v~~~~~~~~~~~L~~~~~~~~~  137 (144)
+T 2f06_A           71 ITDVVGISCPNVPGALAKVLGFLSAEGVFIEYMYSFANNNVANVVIRPSNMDKCIEVLKEKKVDLLA  137 (144)
+T ss_dssp             EEEEEEEEEESSTTHHHHHHHHHHHTTCCEEEEEEEEETTEEEEEEEESCHHHHHHHHHHTTCEEEC
+T ss_pred             eeEEEEEEecCCCchHHHHHHHHHHCCCCEEEEEEEccCCeEEEEEEeCCHHHHHHHHHHCCcEEeC
+Confidence            3344455556667888899999999999988888877767888888888877776666666655443
+
+
+No 152
+>1iuk_A Hypothetical protein TT1466; structural genomics, riken structural genomics/proteomics in RSGI, unknown function; 1.70A {Thermus thermophilus} SCOP: c.2.1.8 PDB: 1iul_A
+Probab=62.32  E-value=2.7  Score=34.01  Aligned_cols=106  Identities=15%  Similarity=0.080  Sum_probs=57.5  Template_Neff=9.300
+
+Q gi|556503834|r  464 QVIEVFVIGVGG----VGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNLGRLIR  539 (820)
+Q Consensus       464 qvievfvigvgg----vggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnlgrlir  539 (820)
+                      +-..+.|||.|.    +|..+++.|++. .        ..||++..++.. ...+|..            ..-++.   .
+T Consensus        12 ~~~~i~IiG~g~~~~~~g~~~~~~l~~~-~--------~~v~~~~~~~~~-~~~~g~~------------~~~~~~---~   66 (140)
+T 1iuk_A           12 QAKTIAVLGAHKDPSRPAHYVPRYLREQ-G--------YRVLPVNPRFQG-EELFGEE------------AVASLL---D   66 (140)
+T ss_dssp             HCCEEEEETCCSSTTSHHHHHHHHHHHT-T--------CEEEEECGGGTT-SEETTEE------------CBSSGG---G
+T ss_pred             CCCEEEEEcccCCCCchHHHHHHHHHHC-C--------CEEEEECCCCCc-ceeCCcc------------ccCCHH---H
+Confidence            345688999998    999999888752 1        137766554421 0111110            000111   1
+
+
+Q gi|556503834|r  540 LVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFL  604 (820)
+Q Consensus       540 lvkeyhllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkfl  604 (820)
+                      +..    ---+++.|+..+...+-...++..|-+++.....+.+      .++..++++.--+|+
+T Consensus        67 ~~~----~~d~vii~~~~~~~~~~~~~~~~~g~~vi~~~~~~~~------~~l~~~a~~~~~~~~  121 (140)
+T 1iuk_A           67 LKE----PVDILDVFRPPSALMDHLPEVLALRPGLVWLQSGIRH------PEFEKALKEAGIPVV  121 (140)
+T ss_dssp             CCS----CCSEEEECSCHHHHTTTHHHHHHHCCSCEEECTTCCC------HHHHHHHHHTTCCEE
+T ss_pred             CCC----CCCEEEEEeCHHHHHHHHHHHHHcCCCEEEECCCCCh------HHHHHHHHHcCCEEE
+Confidence            111    1236777888776666555566667777766554431      345555555444443
+
+
+No 153
+>1zhv_A Hypothetical protein ATU0741; NESG, ATR8, structural genomics, PSI, protein struc initiative; 1.50A {Agrobacterium tumefaciens str} SCOP: d.58.18.8 d.58.18.8
+Probab=60.72  E-value=3  Score=36.13  Aligned_cols=68  Identities=13%  Similarity=0.193  Sum_probs=54.5  Template_Neff=7.000
+
+Q gi|556503834|r  309 ISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFY  379 (820)
+Q Consensus       309 isnlnnmamfsvsgpgmkgmvgmaarvfaamsrarisvvlitqssseysisfcvpqsdcvraeramqeefy  379 (820)
+                      +..-....++.+.||..-.++|+.+.+-..++.+.|++..++...+.|-+   ||..+-.+|.+.+++..+
+T Consensus        56 ~~~~~~w~~i~i~~~~~~~~~G~la~ls~~LA~~gI~i~~iSt~~tD~il---V~e~~l~~A~~~L~~~g~  123 (134)
+T 1zhv_A           56 VRVDPGWSCFKFQGPFAFDETGIVLSVISPLSTNGIGIFVVSTFDGDHLL---VRSNDLEKTADLLANAGH  123 (134)
+T ss_dssp             SEEEEEEEEEEECSCCCCSSCCHHHHHHHHHHTTTCCCEEEECSSCEEEE---EEGGGHHHHHHHHHHTTC
+T ss_pred             CCCCCCeEEEEEecCCcccchhhHHHhhhhHHHcCCCEEEEEeccCcEEE---ecHHHHHHHHHHHHHcCh
+Confidence            34456778889999977789999999999999999999988777766644   899998888887766544
+
+
+No 154
+>3oqb_A Oxidoreductase; structural genomics, protein structure INI NEW YORK structural genomix research consortium, NYSGXRC, PSI-2; 2.60A {Bradyrhizobium japonicum}
+Probab=60.48  E-value=3.1  Score=38.28  Aligned_cols=74  Identities=18%  Similarity=0.161  Sum_probs=49.1  Template_Neff=9.900
+
+Q gi|556503834|r  550 VIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       550 vivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      +++.||....-.+.....++.|.||+.-  |.-..+.+-..+|..++++...++.-..|.- -.|.+..++.++..|
+T Consensus        86 ~vii~~~~~~h~~~~~~~l~~g~~v~~E--KP~a~~~~e~~~l~~~a~~~~~~~~v~~~~r-~~p~~~~~~~~i~~g  159 (383)
+T 3oqb_A           86 MFFDAATTQARPGLLTQAINAGKHVYCE--KPIATNFEEALEVVKLANSKGVKHGTVQDKL-FLPGLKKIAFLRDSG  159 (383)
+T ss_dssp             EEEECSCSSSSHHHHHHHHTTTCEEEEC--SCSCSSHHHHHHHHHHHHHTTCCEEECCGGG-GSHHHHHHHHHHHTT
+T ss_pred             EEEEeCChhhhHHHHHHHHHcCCeEEEC--CCCcCCHHHHHHHHHHHHHcCCeEEEEeccc-CCHHHHHHHHHHHcC
+Confidence            5667888777788888899999999883  3333344555666666776655555444432 347777777777654
+
+
+No 155
+>3o9z_A Lipopolysaccaride biosynthesis protein WBPB; oxidoreductase, sugar biosynthesis, dehydrogenase; HET: NAD AKG; 1.45A {Thermus thermophilus} PDB: 3oa0_A*
+Probab=58.82  E-value=3.4  Score=36.75  Aligned_cols=76  Identities=13%  Similarity=0.033  Sum_probs=52.5  Template_Neff=10.000
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAGD  627 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnagd  627 (820)
+                      -+++-||+...-.+.....++.|.||+.- |.. ..+.+-+.++..++++...++... ..---.|.+..+++++..|.
+T Consensus        74 D~Viiatp~~~h~~~~~~~l~~gk~v~~E-KP~-~~~~~~~~~l~~~a~~~~~~~~v~-~~~r~~p~~~~l~~~i~~~~  149 (312)
+T 3o9z_A           74 DYLSIASPNHLHYPQIRMALRLGANALSE-KPL-VLWPEEIARLKELEARTGRRVYTV-LQLRVHPSLLALKERLGQEK  149 (312)
+T ss_dssp             SEEEECSCGGGHHHHHHHHHHTTCEEEEC-SSS-CSCHHHHHHHHHHHHHHCCCEEEC-CGGGGCHHHHHHHHHHHTCC
+T ss_pred             CEEEEcCChHHHHHHHHHHHHCCCCEEEe-CCC-CCCHHHHHHHHHHHHHhCCEEEEe-ehhhcCHHHHHHHHHHhcCC
+Confidence            36778999988888888899999999875 222 223444556666666665554333 33446788888888888775
+
+
+No 156
+>3mah_A Aspartokinase; aspartate kinase, structural genomics, MCSG, transferase, PSI-2; 2.31A {Porphyromonas gingivalis}
+Probab=56.49  E-value=4  Score=33.10  Aligned_cols=55  Identities=18%  Similarity=0.257  Sum_probs=42.3  Template_Neff=9.700
+
+Q gi|556503834|r  390 LAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNND  446 (820)
+Q Consensus       390 lavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnd  446 (820)
+                      ++..+.++.+++.+..+....++..+.|+.|+++++++..+.++  +.++++++..+
+T Consensus        12 it~~~~~~~i~i~~~~~~~~~~~~~~i~~~l~~~~i~v~~~~~~--~~~~~~~v~~~   66 (157)
+T 3mah_A           12 VAAKDGITVIKVKSSNKLLSWHFMRKLFEIFEFYQEPVDMVATS--EVGVSLTIDND   66 (157)
+T ss_dssp             EEEEEEEEEEEEEECTTSCHHHHHHHHHHHHHHTTCCCSCEECC--SSEEEEEESCC
+T ss_pred             EEecCCEEEEEEEeCCccCcccHHHHHHHHHHHcCCcEEEEEcC--CCeEEEEEcch
+Confidence            44456778888888766655678889999999999999999984  55677776544
+
+
+No 157
+>1edz_A 5,10-methylenetetrahydrofolate dehydrogenase; nucleotide-binding domain, monofunctional, oxidoreductase; 2.80A {Saccharomyces cerevisiae} SCOP: c.2.1.7 c.58.1.2 PDB: 1ee9_A*
+Probab=55.26  E-value=4.3  Score=37.74  Aligned_cols=22  Identities=27%  Similarity=0.317  Sum_probs=19.0  Template_Neff=8.800
+
+Q gi|556503834|r  466 IEVFVIGVGG-VGGALLEQLKRQ  487 (820)
+Q Consensus       466 ievfvigvgg-vggalleqlkrq  487 (820)
+                      -.|.|+|.|| +|.++...|.+.
+T Consensus       178 k~vlViGaGg~vgr~ia~~L~~~  200 (320)
+T 1edz_A          178 KKCIVINRSEIVGRPLAALLAND  200 (320)
+T ss_dssp             CEEEEECCCTTTHHHHHHHHHTT
+T ss_pred             CEEEEECCcHHHHHHHHHHHHhC
+Confidence            5689999999 999999888763
+
+
+No 158
+>3abi_A Putative uncharacterized protein PH1688; L-lysine dehydrogenase, oxidoreductase; HET: NAD; 2.44A {Pyrococcus horikoshii}
+Probab=54.97  E-value=4.4  Score=37.26  Aligned_cols=35  Identities=29%  Similarity=0.556  Sum_probs=25.6  Template_Neff=9.700
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSK  507 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvansk  507 (820)
+                      ...+.|+|.|.+|..+...|.++       . ++.+++....+
+T Consensus        16 ~~~i~iiG~G~iG~~~~~~L~~~-------~-~v~i~~r~~~~   50 (365)
+T 3abi_A           16 HMKVLILGAGNIGRAIAWDLKDE-------F-DVYIGDVNNEN   50 (365)
+T ss_dssp             CCEEEEECCSHHHHHHHHHHTTT-------S-EEEEEESCHHH
+T ss_pred             CCEEEEECCCHHHHHHHHHHhcC-------C-cEEEEECCHHH
+Confidence            35688999999999999988764       1 46666665443
+
+
+No 159
+>1nvm_B Acetaldehyde dehydrogenase (acylating), 4-hydroxy-2-oxovalerate aldolase; sequestered tunnel, substrate channeling; HET: NAD; 1.70A {Pseudomonas SP} SCOP: c.2.1.3 d.81.1.1
+Probab=53.50  E-value=4.8  Score=37.97  Aligned_cols=34  Identities=18%  Similarity=0.236  Sum_probs=24.4  Template_Neff=8.200
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQ--YADFLREGFHVVTPNKKANT  583 (820)
+Q Consensus       549 pvivdctssqavadq--yadflregfhvvtpnkkant  583 (820)
+                      -++++||+.....+.  ....++.|.||+. .|.+..
+T Consensus        73 DiV~iat~~~~h~~~~~~~~al~~Gk~VI~-ekP~a~  108 (312)
+T 1nvm_B           73 DFVFDATSASAHVQNEALLRQAKPGIRLID-LTPAAI  108 (312)
+T ss_dssp             EEEEECSCHHHHHHHHHHHHHHCTTCEEEE-CSTTCS
+T ss_pred             CEEEECCCHHHHHHHHHHHHHHhCCCEEEE-CCCccc
+Confidence            477899999887776  4466788999886 444433
+
+
+No 160
+>1gr0_A Inositol-3-phosphate synthase; isomerase, oxidoreductase, PSI, protein structure initiative, TB structural genomics consortium, TB; HET: NAD; 1.95A {Mycobacterium tuberculosis} SCOP: c.2.1.3 d.81.1.3
+Probab=53.17  E-value=4.9  Score=39.93  Aligned_cols=74  Identities=14%  Similarity=0.013  Sum_probs=42.7  Template_Neff=7.000
+
+Q gi|556503834|r  549 PVIVDCTSSQAV--ADQYA-DFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVG--AGLPVIENLQNLL  623 (820)
+Q Consensus       549 pvivdctssqav--adqya-dflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvg--aglpvienlqnll  623 (820)
+                      -|++.||.+...  ...|+ ..|+.|.|||.-.+-.-    .-...+.-.+++....+..|--..  ...|+...|.+++
+T Consensus       140 DVvi~~~P~~sh~~~~~~a~~al~aG~~vvn~~P~~~----a~~~el~~~a~~~gv~l~g~g~~~q~G~~~l~r~L~~~l  215 (367)
+T 1gr0_A          140 DVLVSYLPVGSEEADKFYAQCAIDAGVAFVNALPVFI----ASDPVWAKKFTDARVPIVGDDIKSQVGATITHRVLAKLF  215 (367)
+T ss_dssp             SEEEECCCTTCHHHHHHHHHHHHHHTCEEEECSSCCS----TTSHHHHHHHHHHTCEEEESSBCCSSCHHHHHHHHHHHH
+T ss_pred             CEEEEeCCCccccchHHHHHHHHHhCCCEEECCcchH----HHHHHHHHHHHHcCCeEEEecccccccccHHHHHHHHHH
+Confidence            477888865532  33443 46778999997655431    112235555566555555443333  4567777777766
+
+
+Q gi|556503834|r  624 NAG  626 (820)
+Q Consensus       624 nag  626 (820)
+                      ..+
+T Consensus       216 ~~~  218 (367)
+T 1gr0_A          216 EDR  218 (367)
+T ss_dssp             HHT
+T ss_pred             Hhc
+Confidence            543
+
+
+No 161
+>3k92_A NAD-GDH, NAD-specific glutamate dehydrogenase; ROCG, oxidoreductase; 2.30A {Bacillus subtilis} PDB: 3k8z_A
+Probab=53.07  E-value=5  Score=40.54  Aligned_cols=51  Identities=22%  Similarity=0.405  Sum_probs=41.3  Template_Neff=7.100
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE  523 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqe  523 (820)
+                      .-..|.|.|.|.||..+.+.|.+.         ..+|+||+.++.-+.|-.|++++...+
+T Consensus       220 ~~~~vaIqGfG~VG~~~a~~L~~~---------GakvvaVsD~~g~i~~~~Gld~~~L~~  270 (424)
+T 3k92_A          220 QNARIIIQGFGNAGSFLAKFMHDA---------GAKVIGISDANGGLYNPDGLDIPYLLD  270 (424)
+T ss_dssp             GGCEEEEECCSHHHHHHHHHHHHH---------TCEEEEEECSSCEEECTTCCCHHHHHH
+T ss_pred             hccccceeccCcccchHHHHHHhC---------CCEEEEEEecCCeEECCCCCCHHHHHH
+Confidence            346688999999999999888753         458999999999988889998765544
+
+
+No 162
+>4h3v_A Oxidoreductase domain protein; structural genomics, PSI-biology, midwest center for structu genomics, MCSG, unknown function; HET: MSE; 1.68A {Kribbella flavida}
+Probab=51.12  E-value=5.6  Score=36.40  Aligned_cols=74  Identities=19%  Similarity=0.238  Sum_probs=46.8  Template_Neff=10.100
+
+Q gi|556503834|r  550 VIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEK---SRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       550 vivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaek---srrkflydtnvgaglpvienlqnllnag  626 (820)
+                      +++-||....-.+.....+..|.||..-.  .-+.+.+=..+|.-.+++   +..++...-+-- -.|...-++++++.|
+T Consensus        78 ~V~I~tp~~~H~~~~~~al~~gk~V~~EK--Pla~~~~e~~~L~~~a~~~~~~~~~~~v~~~~R-~~p~~~~lk~~i~~g  154 (390)
+T 4h3v_A           78 LVDVCTPGDSHAEIAIAALEAGKHVLCEK--PLANTVAEAEAMAAAAAKAAAGGIRSMVGFTYR-RVPAIALARKLVADG  154 (390)
+T ss_dssp             EEEECSCGGGHHHHHHHHHHTTCEEEEES--SSCSSHHHHHHHHHHHHHHHHTTCCEEEECGGG-GSHHHHHHHHHHHTT
+T ss_pred             EEEEcCCcHHHHHHHHHHHHCCCeEEEcC--CCCCCHHHHHHHHHHHHhhhccCceEEEEeecc-CCHHHHHHHHHHhcC
+Confidence            45567777777788888899999988743  333444555666665654   244444433332 257777778777754
+
+
+No 163
+>2ph5_A Homospermidine synthase; alpha-beta protein, structural genomics, PSI-2, protein STRU initiative; HET: NAD; 2.50A {Legionella pneumophila subsp}
+Probab=50.97  E-value=5.7  Score=40.18  Aligned_cols=100  Identities=15%  Similarity=0.225  Sum_probs=48.9  Template_Neff=7.700
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKEPFNL-GRLIRLVKEY  544 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqakepfnl-grlirlvkey  544 (820)
+                      ..|.|||.|.||.+++..|.+...-   .-..+.+++-...++-+..-.|.+...  ..+    .+.|. ..|.+++++ 
+T Consensus        14 ~kIlIiG~G~vG~~ia~~L~~~~~~---~~~~v~v~dr~~~~~~~a~~~g~~~~~--~~~----~~~~~~~~L~~~l~~-   83 (480)
+T 2ph5_A           14 NRFVILGFGCVGQALMPLIFEKFDI---KPSQVTIIAAEGTKVDVAQQYGVSFKL--QQI----TPQNYLEVIGSTLEE-   83 (480)
+T ss_dssp             SCEEEECCSHHHHHHHHHHHHHBCC---CGGGEEEEESSCCSCCHHHHHTCEEEE--CCC----CTTTHHHHTGGGCCT-
+T ss_pred             CcEEEEcCcHHHHHHHHHHHhCCCC---ceEEEEEEeCCHHHHHHHHHcCCCeeE--EEe----ecCCHHHHHHHhcCC-
+Confidence            4578999999999999998765310   012333444333332111111211000  000    01121 112222222 
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQAVADQYADFLREGFHVVTPN  578 (820)
+Q Consensus       545 hllnpvivdctssqavadqyadflregfhvvtpn  578 (820)
+                         --++++|+......+-....++.|.|++...
+T Consensus        84 ---~DvVIn~~~~~~~~~ii~~c~e~G~~yvD~s  114 (480)
+T 2ph5_A           84 ---NDFLIDVSIGISSLALIILCNQKGALYINAA  114 (480)
+T ss_dssp             ---TCEEEECCSSSCHHHHHHHHHHHTCEEEESS
+T ss_pred             ---CCEEEECCCchhhHHHHHHHHHCCCCEEecc
+Confidence               2578888775554344444566789988544
+
+
+No 164
+>3oa2_A WBPB; oxidoreductase, sugar biosynthesis, dehydrogenase; HET: NAD; 1.50A {Pseudomonas aeruginosa}
+Probab=50.45  E-value=5.8  Score=35.50  Aligned_cols=75  Identities=15%  Similarity=0.153  Sum_probs=49.8  Template_Neff=9.900
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAG  626 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnllnag  626 (820)
+                      -+++-||....-++....+++.|.||+.- | .-+.+++-..+|..++++...++....+. --.|.+..+++++..|
+T Consensus        75 D~V~ia~p~~~h~~~~~~~l~~g~~v~~E-K-P~a~~~~~~~~l~~~~~~~~~~~~v~~~~-r~~p~~~~~~~~i~~g  149 (318)
+T 3oa2_A           75 DYVSICSPNYLHYPHIAAGLRLGCDVICE-K-PLVPTPEMLDQLAVIERETDKRLYNILQL-RHHQAIIALKDKVARE  149 (318)
+T ss_dssp             CEEEECSCGGGHHHHHHHHHHTTCEEEEC-S-SCCSCHHHHHHHHHHHHHHTCCEEECCGG-GGCHHHHHHHHHHHHS
+T ss_pred             CEEEEcCCchhhHHHHHHHHHcCCCeEEE-C-CCcCCHHHHHHHHHHHHHhCCcEEEEeeh-hcCHHHHHHHHHHHhc
+Confidence            35677888888888888899999998854 3 23334444556666666665555433332 2347888888888765
+
+
+No 165
+>2tmg_A Protein (glutamate dehydrogenase); metabolic role, mutant, oxidoreductase; 2.90A {Thermotoga maritima} SCOP: c.2.1.7 c.58.1.1 PDB: 1b26_A 1b3b_A
+Probab=50.12  E-value=6  Score=39.78  Aligned_cols=53  Identities=23%  Similarity=0.340  Sum_probs=41.8  Template_Neff=7.200
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE  523 (820)
+Q Consensus       463 dqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqe  523 (820)
+                      -.-..|.+.|.|.||..+.+.|.++        ...+|.+|+.++..+.|-.|++++...+
+T Consensus       207 ~~~~~vaiqGfG~VG~~~a~~L~~~--------~GakvVaVsD~~G~i~~~~Gld~~~l~~  259 (415)
+T 2tmg_A          207 PKKATVAVQGFGNVGQFAALLISQE--------LGSKVVAVSDSRGGIYNPEGFDVEELIR  259 (415)
+T ss_dssp             TTTCEEEEECCSHHHHHHHHHHHHT--------TCCEEEEEECSSCEEECTTCCCHHHHHH
+T ss_pred             hhhceEEEecCCCcchHHHHHHHHc--------CCCEEEEEEcCCceEEcCCCCCHHHHHH
+Confidence            3456788999999999998888432        2458999999999999999998765444
+
+
+No 166
+>2dtj_A Aspartokinase; protein-ligand complex, regulatory subunit, transferase; HET: CIT; 1.58A {Corynebacterium glutamicum} PDB: 3aaw_B* 3ab2_B 3ab4_B*
+Probab=50.04  E-value=6  Score=33.21  Aligned_cols=56  Identities=34%  Similarity=0.432  Sum_probs=41.3  Template_Neff=9.300
+
+Q gi|556503834|r  390 LAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSE-----RSISVVVNNDD  447 (820)
+Q Consensus       390 lavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgsse-----rsisvvvnndd  447 (820)
+                      ++..+.+++|++.+  +...-+..++.|..|++.++++..+.+..++     .++++++..++
+T Consensus         9 It~~~~i~~i~i~~--~~~~~~~~~~i~~~l~~~~i~v~~i~~~~~~~~~~~~~i~~~i~~~~   69 (178)
+T 2dtj_A            9 VATDKSEAKVTVLG--ISDKPGEAAKVFRALADAEINIDMVLQNVSSVEDGTTDITFTCPRSD   69 (178)
+T ss_dssp             EEEECSEEEEEEEE--EECSTTHHHHHHHHHHHTTCCCCEEEECCCCTTTCEEEEEEEEEHHH
+T ss_pred             EEecCCEEEEEEec--CCCCCcHHHHHHHHHHHcCCeEEEEEeCCccCCCCcceEEEEEeHHH
+Confidence            44456677777764  5555578889999999999999999988654     66777765443
+
+
+No 167
+>4xgi_A Glutamate dehydrogenase; ssgcid, structural genomics, seattle structural genomics center for infectious disease, oxidoreductase; HET: NAD AKG; 2.00A {Burkholderia thailandensis}
+Probab=50.03  E-value=6  Score=40.27  Aligned_cols=50  Identities=18%  Similarity=0.328  Sum_probs=40.5  Template_Neff=6.900
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE  523 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqe  523 (820)
+                      -..|.|.|.|.||..+.+.|.+.         ..+|.+|+.++.-+.|-.|++.+...+
+T Consensus       231 ~~~vaIqGfGnVG~~~a~~L~~~---------GakVvaVsD~~G~i~~~~GlD~~~l~~  280 (436)
+T 4xgi_A          231 GARIAVQGFGNVGGIAAKLFQEA---------GAKVIAVQDHTGTIHQPAGVDTAKLLD  280 (436)
+T ss_dssp             TCEEEEECCSHHHHHHHHHHHHT---------TCEEEEEEETTEEEECTTCCCHHHHHH
+T ss_pred             cCeeEEEeecCcccHHHHHHHHC---------CCEEEEEEccCCeEEcCCCCCHHHHHH
+Confidence            35678999999999999988643         458999999999888889998665444
+
+
+No 168
+>3ab4_A Aspartokinase; aspartate kinase, concerted inhibition, alternative initiati amino-acid biosynthesis, ATP-binding; HET: LYS; 2.47A {Corynebacterium glutamicum} PDB: 3aaw_A* 3ab2_A
+Probab=49.94  E-value=6  Score=37.82  Aligned_cols=66  Identities=27%  Similarity=0.370  Sum_probs=46.0  Template_Neff=9.100
+
+Q gi|556503834|r  388 EPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGS-----SERSISVVVNNDDATTGVRVT  455 (820)
+Q Consensus       388 eplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgs-----sersisvvvnnddattgvrvt  455 (820)
+                      .-.+..+.++.+++.+  +...-|..++.|..|++.+|||..|.|+.     ++.++++.+..++...-..+-
+T Consensus       256 ~~i~~~~~i~~i~i~~--~~~~~g~l~~i~~~l~~~~I~v~~i~~s~~~~~~~~~~~~~~~~~~~~~~~~~~L  326 (421)
+T 3ab4_A          256 TGVATDKSEAKVTVLG--ISDKPGEAAKVFRALADAEINIDMVLQNVFSVEDGTTDITFTCPRSDGRRAMEIL  326 (421)
+T ss_dssp             CEEEEECSEEEEEEEE--EESSTTHHHHHHHHHHHTTCCCEEEEECCCC--CCEEEEEEEEETTTHHHHHHHH
+T ss_pred             eEEEecCceEEEEEec--CCCCccHHHHHHHHHHHcCCcEEEEEeccccccCCcceEEEEeeHHHHHHHHHHH
+Confidence            3344555566676665  66667889999999999999999999975     456677766655543333333
+
+
+No 169
+>3obb_A Probable 3-hydroxyisobutyrate dehydrogenase; structural genomics, PSI-2, protein structure initiative, MI center for structural genomics; HET: EPE; 2.20A {Pseudomonas aeruginosa} PDB: 3q3c_A*
+Probab=48.76  E-value=6.5  Score=34.01  Aligned_cols=22  Identities=23%  Similarity=0.539  Sum_probs=18.4  Template_Neff=10.600
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       465 vievfvigvggvggalleqlkr  486 (820)
+                      ...|.|||.|.+|.++...|.+
+T Consensus         3 ~~~i~iiG~G~~G~~la~~l~~   24 (300)
+T 3obb_A            3 MKQIAFIGLGHMGAPMATNLLK   24 (300)
+T ss_dssp             CCEEEEECCSTTHHHHHHHHHH
+T ss_pred             CCEEEEECCCHHHHHHHHHHHH
+Confidence            3467899999999999988864
+
+
+No 170
+>3ngx_A Bifunctional protein fold; methylenetetrahydrofolate dehydrogenase/cyclohydrolase; 2.30A {Thermoplasma acidophilum} PDB: 3ngl_A
+Probab=48.50  E-value=6.6  Score=36.02  Aligned_cols=22  Identities=23%  Similarity=0.157  Sum_probs=18.9  Template_Neff=8.600
+
+Q gi|556503834|r  465 VIEVFVIGVGG-VGGALLEQLKR  486 (820)
+Q Consensus       465 vievfvigvgg-vggalleqlkr  486 (820)
+                      --.|.|||.|+ +|.++...|++
+T Consensus       150 ~~~v~ViG~G~~~g~~ia~~L~~  172 (276)
+T 3ngx_A          150 ENTVTIVNRSPVVGRPLSMMLLN  172 (276)
+T ss_dssp             SCEEEEECCCTTTHHHHHHHHHH
+T ss_pred             CCEEEEEeCCcHHHHHHHHHHHH
+Confidence            35689999999 99999988866
+
+
+No 171
+>3btv_A Galactose/lactose metabolism regulatory protein GAL80; eukaryotic transcription repressor, acetylation, carbohydrate metabolism; 2.10A {Saccharomyces cerevisiae} PDB: 3bts_A 3v2u_A* 3btu_A
+Probab=48.05  E-value=6.7  Score=37.91  Aligned_cols=76  Identities=17%  Similarity=0.087  Sum_probs=53.4  Template_Neff=8.900
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREG------FHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNL  622 (820)
+Q Consensus       549 pvivdctssqavadqyadflreg------fhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpvienlqnl  622 (820)
+                      -+++-||....-.+.....|+.|      .||+.  .|.-..+.+...+|.-++++...++ +..-...-.|.+..++.+
+T Consensus        91 D~v~i~~~~~~h~~~~~~al~~g~~~~~~~~V~~--ekP~a~~~~~~~~l~~~a~~~~~~~-~v~~~~r~~p~~~~~k~~  167 (438)
+T 3btv_A           91 DMIVIAIQVASHYEVVMPLLEFSKNNPNLKYLFV--EWALACSLDQAESIYKAAAERGVQT-IISLQGRKSPYILRAKEL  167 (438)
+T ss_dssp             SEEEECSCHHHHHHHHHHHHHHGGGCTTCCEEEE--ESSCCSSHHHHHHHHHHHHTTTCEE-EEECGGGGCHHHHHHHHH
+T ss_pred             CEEEEeCCHHHHHHHHHHHHHcCCCcccCceEEE--eCCCCCCHHHHHHHHHHHHhcCCeE-EeeechhcCHHHHHHHHH
+Confidence            35677888888888888999999      58887  3444555666777777776655544 444444557888888888
+
+
+Q gi|556503834|r  623 LNAGD  627 (820)
+Q Consensus       623 lnagd  627 (820)
+                      +..|.
+T Consensus       168 i~~g~  172 (438)
+T 3btv_A          168 ISQGY  172 (438)
+T ss_dssp             HHTTT
+T ss_pred             HHcCC
+Confidence            87653
+
+
+No 172
+>4go7_X Aspartokinase; transferase; 2.00A {Mycobacterium tuberculosis} PDB: 4go5_X
+Probab=46.48  E-value=7.4  Score=33.83  Aligned_cols=59  Identities=31%  Similarity=0.438  Sum_probs=44.5  Template_Neff=8.800
+
+Q gi|556503834|r  387 LEPLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSE-----RSISVVVNNDD  447 (820)
+Q Consensus       387 leplavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgsse-----rsisvvvnndd  447 (820)
+                      ..-++..+.++.+++.+  +....+..++.|..|++++|++..+.++.++     .++++++..++
+T Consensus        26 v~~It~~~~~~li~i~~--~~~~~~~~~~i~~~l~~~~i~v~~i~~~~~~~~~~~~~i~~~l~~~~   89 (200)
+T 4go7_X           26 LTGVAHDRSEAKVTIVG--LPDIPGYAAKVFRAVADADVNIDMVLQNVSKVEDGKTDITFTCSRDV   89 (200)
+T ss_dssp             EEEEEEECSEEEEEEEE--EECSTTHHHHHHHHHHHTTCCCCCEECCCCC--CCEEEEEEEEEGGG
+T ss_pred             eEEEEEcCCEEEEEEec--CCCChhHHHHHHHHHHHcCCCEEEEEeCcccCCCCcceEEEEEeHHH
+Confidence            33455666777777765  5555678889999999999999999998765     67888776443
+
+
+No 173
+>3zgy_A R-imine reductase; oxidoreductase, dehydrogenase; 2.71A {Streptomyces kanamyceticus} PDB: 3zhb_A*
+Probab=43.87  E-value=8.7  Score=33.36  Aligned_cols=24  Identities=33%  Similarity=0.387  Sum_probs=19.1  Template_Neff=10.600
+
+Q gi|556503834|r  463 DQVIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       463 dqvievfvigvggvggalleqlkr  486 (820)
+                      -+...|.|||.|.+|.++...|.+
+T Consensus        17 ~~~~~i~viG~G~~G~~~a~~l~~   40 (309)
+T 3zgy_A           17 AEHTPVTVIGLGLMGQALAGAFLG   40 (309)
+T ss_dssp             --CCCEEEECCSHHHHHHHHHHHH
+T ss_pred             cCCCcEEEEccCHHHHHHHHHHHH
+Confidence            345678899999999999988864
+
+
+No 174
+>4ywj_A HTPA reductase, 4-hydroxy-tetrahydrodipicolinate reductase; ssgcid, 4-hydroxy-tetrahydrodipicoli reductase, NAD, structural genomics; HET: NAD PGE; 1.80A {Pseudomonas aeruginosa}
+Probab=43.06  E-value=9.1  Score=36.52  Aligned_cols=63  Identities=17%  Similarity=0.158  Sum_probs=47.7  Template_Neff=7.200
+
+Q gi|556503834|r  548 NPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPV  615 (820)
+Q Consensus       548 npvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglpv  615 (820)
+                      ..|+||||+..++.+.+...++.|..+|+....-   +-+.+.+|+.++  .....+|-+|..-|.-+
+T Consensus        78 ~DvvIdfs~~~~~~~~~~~~l~~g~~vV~gTTG~---~~~~~~~l~~~a--~~~~~l~~~n~siG~~~  140 (276)
+T 4ywj_A           78 FDVLIDFTHPSVTLKNIEQCRKARRAMVIGTTGF---SADEKLLLAEAA--KDIPIVFAANFSVGVNL  140 (276)
+T ss_dssp             CSEEEECSCHHHHHHHHHHHHHTTCEEEECCCCC---CHHHHHHHHHHT--TTSEEEECSCCCHHHHH
+T ss_pred             CCEEEECCCHHHHHHHHHHHHhcCcEEEEeCCCC---CHHHHHHHHHHc--ccCCEEEECCccHHHHH
+Confidence            4699999999999999999999999999865332   334566777777  45667888887776544
+
+
+No 175
+>2fp4_A Succinyl-COA ligase [GDP-forming] alpha-chain, mitochondrial; active site phosphohistidine residue; HET: NEP GTP; 2.08A {Sus scrofa} SCOP: c.2.1.8 c.23.4.1 PDB: 2fpg_A* 2fpi_A* 2fpp_A* 1euc_A* 1eud_A* 4xx0_A*
+Probab=43.00  E-value=9.1  Score=35.57  Aligned_cols=28  Identities=14%  Similarity=0.052  Sum_probs=23.1  Template_Neff=8.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFH-VVT  576 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfh-vvt  576 (820)
+                      .+++.|++.+.+.+...+.++.|.+ ++.
+T Consensus        73 Dlvvi~~p~~~~~~~v~~~~~~G~~~vii  101 (305)
+T 2fp4_A           73 TASVIYVPPPFAAAAINEAIDAEVPLVVC  101 (305)
+T ss_dssp             CEEEECCCHHHHHHHHHHHHHTTCSEEEE
+T ss_pred             CEEEEeCCHHHHHHHHHHHHHcCCCEEEE
+Confidence            4678899999988888888899988 544
+
+
+No 176
+>1ff9_A Saccharopine reductase; lysine biosynthesis, alpha-aminoadipate pathway, dehydrogenase, oxidoreductase; 2.00A {Magnaporthe grisea} SCOP: c.2.1.3 d.81.1.2 PDB: 1e5l_A* 1e5q_A
+Probab=42.94  E-value=9.1  Score=36.79  Aligned_cols=126  Identities=17%  Similarity=0.150  Sum_probs=59.6  Template_Neff=9.200
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKAL-LTNVHGLNLENWQEELAQAKEPFNLGRLIRLVKEY  544 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskal-ltnvhglnlenwqeelaqakepfnlgrlirlvkey  544 (820)
+                      ..|.|||.|.+|..+.+.|.+.       ...+.+++-...++- +...++ +.+..+-.   ..   +...+..+++. 
+T Consensus         4 ~~I~IiG~G~vG~~~~~~L~~~-------~~~v~v~~r~~~~~~~l~~~~~-~~~~~~~D---~~---~~~~l~~~l~~-   68 (450)
+T 1ff9_A            4 KSVLMLGSGFVTRPTLDVLTDS-------GIKVTVACRTLESAKKLSAGVQ-HSTPISLD---VN---DDAALDAEVAK-   68 (450)
+T ss_dssp             CEEEEECCSTTHHHHHHHHHTT-------TCEEEEEESSHHHHHHTTTTCT-TEEEEECC---TT---CHHHHHHHHTT-
+T ss_pred             CEEEEECChHHHHHHHHHHHhC-------cCEEEEEECCHHHHHHHHHhcC-CCcEEEeC---CC---CHHHHHHHHcC-
+Confidence            4578999999999999998764       123444443222210 000000 00000000   00   11112222222 
+
+
+Q gi|556503834|r  545 HLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSSMDYYHQLRYAAEKSRRKFLYDTNVGAGLP  614 (820)
+Q Consensus       545 hllnpvivdctssqavadqyadflregfhvvtpnkkantssmdyyhqlryaaeksrrkflydtnvgaglp  614 (820)
+                         --+++.|+.......-....++.|-|++.....     .+..+++...+++....++.......|+.
+T Consensus        69 ---~DvVI~~~p~~~~~~v~~~al~~g~~~vdls~~-----~~~~~~l~~~a~~~g~~~v~~~g~~pgl~  130 (450)
+T 1ff9_A           69 ---HDLVISLIPYTFHATVIKSAIRQKKHVVTTSYV-----SPAMMELDQAAKDAGITVMNEIGLDPGID  130 (450)
+T ss_dssp             ---SSEEEECCC--CHHHHHHHHHHHTCEEEESSCC-----CHHHHHTHHHHHHTTCEEECSCBBTTBHH
+T ss_pred             ---CCEEEECCCchhchHHHHHHHHcCCeEEEcCCC-----cHHHHHHHHHHHhcCCEEEeccCcCCchH
+Confidence               246677875543333333456778898884421     12233444455666666666655555543
+
+
+No 177
+>5cef_A Aspartate-semialdehyde dehydrogenase; rossman fold, oxidoreductase; 2.60A {Cryptococcus neoformans var}
+Probab=42.64  E-value=9.3  Score=36.30  Aligned_cols=29  Identities=14%  Similarity=0.141  Sum_probs=22.9  Template_Neff=8.800
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVTP  577 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvtp  577 (820)
+                      .+++.||......+....++..|.+|+..
+T Consensus        85 DvV~~atp~~~~~~~~~~~~~~G~~Vi~~  113 (375)
+T 5cef_A           85 GVVFSGLDADVAGDIENAFRAADLVVYSN  113 (375)
+T ss_dssp             SEEEECCCHHHHHHHHHHHHHTTCEEEEC
+T ss_pred             CEEEECCChHHHHHHHHHHHHCCCeEEec
+Confidence            57889999887766666778889998873
+
+
+No 178
+>1a4i_A Methylenetetrahydrofolate dehydrogenase / methenyltetrahydrofolate cyclohydrolase...; THF, bifunctional, oxidoreductase; HET: NDP; 1.50A {Homo sapiens} SCOP: c.2.1.7 c.58.1.2 PDB: 1dia_A* 1dib_A* 1dig_A*
+Probab=41.69  E-value=9.9  Score=35.39  Aligned_cols=22  Identities=23%  Similarity=0.281  Sum_probs=18.9  Template_Neff=8.500
+
+Q gi|556503834|r  465 VIEVFVIGVGG-VGGALLEQLKR  486 (820)
+Q Consensus       465 vievfvigvgg-vggalleqlkr  486 (820)
+                      --.|.|||.|+ +|.++...|++
+T Consensus       165 ~~~v~ViG~G~~vG~~ia~~L~~  187 (301)
+T 1a4i_A          165 GRHAVVVGRSKIVGAPMHDLLLW  187 (301)
+T ss_dssp             TCEEEEECCCTTTHHHHHHHHHH
+T ss_pred             CCEEEEECCCchHHHHHHHHHHH
+Confidence            35689999999 99999988875
+
+
+No 179
+>3v1y_O PP38, glyceraldehyde-3-phosphate dehydrogenase, cytosol; rossmann fold; HET: NAD; 1.86A {Oryza sativa japonica group} PDB: 3e5r_O* 3e6a_O
+Probab=40.14  E-value=11  Score=34.78  Aligned_cols=30  Identities=23%  Similarity=0.220  Sum_probs=22.3  Template_Neff=9.300
+
+Q gi|556503834|r  547 LNPVIVDCTSSQAVADQYADFLREG-FHVVT  576 (820)
+Q Consensus       547 lnpvivdctssqavadqyadflreg-fhvvt  576 (820)
+                      --.++++||......+....+++.| .+++.
+T Consensus        93 ~~DvV~~~tp~~~~~~~~~~~l~~g~k~vvi  123 (337)
+T 3v1y_O           93 GAEYVVESTGVFTDKEKAAAHLKGGAKKVVI  123 (337)
+T ss_dssp             TCCEEEECSSSCCSHHHHTHHHHTTCCEEEE
+T ss_pred             CCCEEEECCCccccHHHHHHHHHCCCCcEEE
+Confidence            3457899999988777777888888 45543
+
+
+No 180
+>2re1_A Aspartokinase, alpha and beta subunits; structural genomics, protein structure initiative, midwest center for structural genomics; 2.75A {Neisseria meningitidis MC58}
+Probab=39.80  E-value=11  Score=30.68  Aligned_cols=57  Identities=28%  Similarity=0.361  Sum_probs=40.5  Template_Neff=9.800
+
+Q gi|556503834|r  389 PLAVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSS---ERSISVVVNNDD  447 (820)
+Q Consensus       389 plavterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgss---ersisvvvnndd  447 (820)
+                      -+...+.++++++-+  +....+..++.|..+.++++++..+.++.+   ..++++++..++
+T Consensus        18 ~It~~~~~~ll~i~~--~~~~~~~~~~l~~~l~~~~i~v~~i~~~~~~~~~~~i~~~v~~~~   77 (167)
+T 2re1_A           18 GIAFDKNQARINVRG--VPDKPGVAYQILGAVADANIEVDMIIQNVGSEGTTDFSFTVPRGD   77 (167)
+T ss_dssp             EEEEECCCEEEEEEE--EECCTTHHHHHHHHHHTTTCCCCCEEEC----CEEEEEEEECGGG
+T ss_pred             EEEeeCCEEEEEEec--CCCCccHHHHHHHHHHHcCCEEEEEEeCCccCCCccEEEEEeHHH
+Confidence            345556677777754  444557888999999999999999998754   357777776444
+
+
+No 181
+>1b7g_O Protein (glyceraldehyde 3-phosphate dehydrogenase; archaea, hyperthermophIle, GAPDH, hyperthermophilic dehydrog oxidoreductase; 2.05A {Sulfolobus solfataricus} SCOP: c.2.1.3 d.81.1.1
+Probab=39.63  E-value=11  Score=34.96  Aligned_cols=99  Identities=21%  Similarity=0.345  Sum_probs=50.6  Template_Neff=9.100
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKA-LLT---NVHGLNLENWQE---ELAQAKEPFNLGRLI  538 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanska-llt---nvhglnlenwqe---elaqakepfnlgrli  538 (820)
+                      +.|.+||.|.+|..+++.|.++        -++.+.++..... ...   .-.|..+..+.+   .+....-++. ..+-
+T Consensus         2 ~~V~IiG~G~iG~~l~~~l~~~--------~~~~vv~v~~~~~~~~~~~~~~~g~~i~~~~~~~~~~~~~~~~~~-~~~~   72 (340)
+T 1b7g_O            2 VNVAVNGYGTIGKRVADAIIKQ--------PDMKLVGVAKTSPNYEAFIAHRRGIRIYVPQQSIKKFEESGIPVA-GTVE   72 (340)
+T ss_dssp             EEEEEECCSHHHHHHHHHHHTC--------TTEEEEEEECSSCSHHHHHHHHTTCCEECCGGGHHHHHTTTCCCC-CCHH
+T ss_pred             eEEEEECcCHHHHHHHHHHHcC--------CCCEEEEEECCCccHHHHHHHhCCCceeeccchhhhcccCceEee-CCHH
+Confidence            4578999999999999887653        2344555443211 100   001222222111   0110000000 1111
+
+
+Q gi|556503834|r  539 RLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTP  577 (820)
+Q Consensus       539 rlvkeyhllnpvivdctssqavadqyadflregfhvvtp  577 (820)
+                      .+.+    ---++++||......+....++..|.+++.-
+T Consensus        73 ~~~~----~~DiVv~atp~~~~~~~~~~~~~~g~~vI~~  107 (340)
+T 1b7g_O           73 DLIK----TSDIVVDTTPNGVGAQYKPIYLQLQRNAIFQ  107 (340)
+T ss_dssp             HHHH----HCSEEEECCSTTHHHHHHHHHHHTTCEEEEC
+T ss_pred             HHhh----CCCEEEECCCCcccHHHHHHHHhCCCEEEEe
+Confidence            1111    2357899999887666666777888888763
+
+
+No 182
+>3aog_A Glutamate dehydrogenase; NAD(H), oxidoreducta; HET: GLU; 2.10A {Thermus thermophilus HB27} PDB: 3aoe_A
+Probab=38.15  E-value=12  Score=38.26  Aligned_cols=50  Identities=22%  Similarity=0.303  Sum_probs=40.5  Template_Neff=6.700
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE  523 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqe  523 (820)
+                      -..|.|+|.|.||..+.+.|.+..         .+|.+|+.++.-+.|-.|++.+...+
+T Consensus       235 ~~~vaIqGfGnVG~~~a~~L~~~G---------akVvaVsd~~G~i~~~~GlD~~~l~~  284 (440)
+T 3aog_A          235 GARVAIQGFGNVGNAAARAFHDHG---------ARVVAVQDHTGTVYNEAGIDPYDLLR  284 (440)
+T ss_dssp             TCEEEEECCSHHHHHHHHHHHHTT---------CEEEEEECSSCEEECTTCCCHHHHHH
+T ss_pred             cceeEEEEecCcchHHHHHHHHCC---------CeEEEEEcCCcEEEcCCCCCHHHHHH
+Confidence            356789999999999998886432         48999999999999889998765544
+
+
+No 183
+>3doj_A AT3G25530, dehydrogenase-like protein; gamma-hydroxybutyrate dehydrogenase, 4-hydroxybutyrate dehydrogenase; 2.10A {Arabidopsis thaliana}
+Probab=38.08  E-value=12  Score=32.69  Aligned_cols=25  Identities=28%  Similarity=0.446  Sum_probs=20.5  Template_Neff=10.400
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       462 tdqvievfvigvggvggalleqlkr  486 (820)
+                      ..+...+-|||.|.+|..+...|.+
+T Consensus        18 ~~~~~~i~viG~G~~G~~~a~~l~~   42 (310)
+T 3doj_A           18 GSHMMEVGFLGLGIMGKAMSMNLLK   42 (310)
+T ss_dssp             CCCSCEEEEECCSHHHHHHHHHHHH
+T ss_pred             CCCCCeEEEECCCHHHHHHHHHHHH
+Confidence            3556778899999999999988865
+
+
+No 184
+>1bgv_A Glutamate dehydrogenase; oxidoreductase; HET: GLU; 1.90A {Clostridium symbiosum} SCOP: c.2.1.7 c.58.1.1 PDB: 1hrd_A 1k89_A 1aup_A 2yfh_A
+Probab=37.22  E-value=13  Score=37.93  Aligned_cols=57  Identities=12%  Similarity=0.187  Sum_probs=44.6  Template_Neff=7.000
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEELAQAKE  530 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeelaqake  530 (820)
+                      -..|.+.|.|.||..+.+.|.+.         ..+|.+|..++..+.|-.||+.+...+.+.+.|.
+T Consensus       230 ~~~v~i~G~G~VG~~~a~~l~~~---------Gakvvavsd~~G~i~~~~GlD~~~l~~~~~~~~~  286 (449)
+T 1bgv_A          230 GKTVALAGFGNVAWGAAKKLAEL---------GAKAVTLSGPDGYIYDPEGITTEEKINYMLEMRA  286 (449)
+T ss_dssp             TCEEEECCSSHHHHHHHHHHHHH---------TCEEEEEEETTEEEECTTCSCSHHHHHHHHHHHH
+T ss_pred             CceeeeeeccchHHHHHHHHHHc---------CCEEEEEEecCCceeCCCCCCHHHHHHHHHHhcc
+Confidence            35677889999999999888643         4589999999999999899997766655555444
+
+
+No 185
+>3qha_A Putative oxidoreductase; seattle structural genomics center for infectious disease, S mycobacterium avium 104, rossmann fold; 2.25A {Mycobacterium avium}
+Probab=35.98  E-value=14  Score=32.25  Aligned_cols=27  Identities=19%  Similarity=0.443  Sum_probs=18.7  Template_Neff=10.300
+
+Q gi|556503834|r  460 FNTDQVIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       460 fntdqvievfvigvggvggalleqlkr  486 (820)
+                      ........|-+||.|-+|.++...|.+
+T Consensus        10 ~~~~~~~~i~iiG~G~~G~~~a~~l~~   36 (296)
+T 3qha_A           10 AHTTEQLKLGYIGLGNMGAPMATRMTE   36 (296)
+T ss_dssp             -----CCCEEEECCSTTHHHHHHHHTT
+T ss_pred             CcCCCCCEEEEECcCHHHHHHHHHHHH
+Confidence            334456678899999999999887764
+
+
+No 186
+>2x5j_O E4PDH, D-erythrose-4-phosphate dehydrogenase; oxidoreductase, hydride transfer, aldehyde dehydrogenase, PY biosynthesis; 2.30A {Escherichia coli} PDB: 2xf8_A* 2x5k_O*
+Probab=33.50  E-value=16  Score=33.76  Aligned_cols=29  Identities=21%  Similarity=0.379  Sum_probs=22.5  Template_Neff=9.200
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGF-HVVTP  577 (820)
+Q Consensus       549 pvivdctssqavadqyadflregf-hvvtp  577 (820)
+                      -++++||......+....+++.|. +|+.-
+T Consensus        94 DvVv~at~~~~~~~~a~~~l~aG~k~Viis  123 (339)
+T 2x5j_O           94 DVVLDCTGVYGSREHGEAHIAAGAKKVLFS  123 (339)
+T ss_dssp             SEEEECSSSCCSHHHHHHHHHTTCSEEEES
+T ss_pred             CEEEECCCccccHHHHHHHHHCCCcEEEec
+Confidence            578999999888777788888884 65543
+
+
+No 187
+>3aoe_E Glutamate dehydrogenase; rossmann fold, NADH, oxidoreductase; 2.60A {Thermus thermophilus}
+Probab=33.30  E-value=16  Score=36.70  Aligned_cols=51  Identities=29%  Similarity=0.375  Sum_probs=41.3  Template_Neff=7.200
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE  523 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqe  523 (820)
+                      .-..|.+.|.|.||..+.+.|.+.         ..+|++|..+..-+.|-.|++.+...+
+T Consensus       217 ~~~~v~iqG~G~VG~~~a~~L~~~---------Gakvvaisd~~g~i~~~~GiD~~~l~~  267 (419)
+T 3aoe_E          217 RGARVVVQGLGQVGAAVALHAERL---------GMRVVAVATSMGGMYAPEGLDVAEVLS  267 (419)
+T ss_dssp             TTCEEEEECCSHHHHHHHHHHHHT---------TCEEEEEEETTEEEECTTCCCHHHHHH
+T ss_pred             ccceeeeeccccccHHHHHHHHHC---------CCEEEEEEccCCEEECCCCCCHHHHHH
+Confidence            445678999999999999887643         458999999999998888998765544
+
+
+No 188
+>2hjs_A USG-1 protein homolog; aspartate-semialdehyde dehydrogenase, probable hydrolase, PS aeruginosa, structurual genomics; 2.20A {Pseudomonas aeruginosa} SCOP: c.2.1.3 d.81.1.1
+Probab=33.23  E-value=16  Score=33.62  Aligned_cols=31  Identities=6%  Similarity=0.006  Sum_probs=23.9  Template_Neff=9.300
+
+Q gi|556503834|r  548 NPVIVDCTSSQAVADQYADFLREGFHVVTPN  578 (820)
+Q Consensus       548 npvivdctssqavadqyadflregfhvvtpn  578 (820)
+                      -.+++.||......+.....++.|.+|+.-.
+T Consensus        69 ~DiV~~atp~~~~~~~~~~~l~~G~~Vid~s   99 (340)
+T 2hjs_A           69 VGLAFFAAAAEVSRAHAERARAAGCSVIDLS   99 (340)
+T ss_dssp             CSEEEECSCHHHHHHHHHHHHHTTCEEEETT
+T ss_pred             CCEEEEcCChHHHHHHHHHHHHCCCcEEecc
+Confidence            3578889988877776677788899988753
+
+
+No 189
+>3cmc_O GAPDH, glyceraldehyde-3-phosphate dehydrogenase; microspectrophotometry, reaction intermediate, dehydrogenase phosphate binding site; HET: G3H NAD; 1.77A {Bacillus stearothermophilus} SCOP: c.2.1.3 d.81.1.1 PDB: 2gd1_O 1gd1_O* 1npt_O* 1nqa_O* 1nqo_O* 1nq5_O* 2dbv_O* 1dbv_O* 3dbv_O* 4dbv_O*
+Probab=33.10  E-value=17  Score=33.05  Aligned_cols=73  Identities=14%  Similarity=0.128  Sum_probs=40.2  Template_Neff=9.700
+
+Q gi|556503834|r  548 NPVIVDCTSSQAVADQYADFLREG-FHVVTPNKKANTSSMDYYHQLR---YAAEKSRRKFLYDTNVGAGLPVIENLQN  621 (820)
+Q Consensus       548 npvivdctssqavadqyadflreg-fhvvtpnkkantssmdyyhqlr---yaaeksrrkflydtnvgaglpvienlqn  621 (820)
+                      -.++++||......+....+++.| -+|+..++......+-.| .+.   +...+.++-.....++.+..|++.-|..
+T Consensus        89 ~DiVv~at~~~~~~~~~~~~l~~g~k~V~~s~~~~~~~~~~v~-~vn~~~~~~~~~~~i~~~~c~~~~~~~~l~~l~~  165 (334)
+T 3cmc_O           89 VDIVVESTGRFTKREDAAKHLEAGAKKVIISAPAKNEDITIVM-GVNQDKYDPKAHHVISNASCTTNCLAPFAKVLHE  165 (334)
+T ss_dssp             CCEEEECSSSCCBHHHHTHHHHTTCSEEEESSCCBSCSEECCT-TTSGGGCCTTTCCEEECCCHHHHHHHHHHHHHHH
+T ss_pred             CCEEEecCCCcCCHHHHHHHHHCCCeEEEECCCcccCCCeEEE-ecCHHHhCcCCCcEEECCcchhhhhhhhhhhhhh
+Confidence            347889999887777777788888 677766543221111111 111   1111133333455555666777766554
+
+
+No 190
+>4dpl_A Malonyl-COA/succinyl-COA reductase; dinucleotide binding, dimerization domain, NADP, oxidoreductase; HET: NAP; 1.90A {Sulfolobus tokodaii} PDB: 4dpk_A* 4dpm_A*
+Probab=32.67  E-value=17  Score=33.77  Aligned_cols=30  Identities=23%  Similarity=0.342  Sum_probs=23.0  Template_Neff=9.300
+
+Q gi|556503834|r  548 NPVIVDCTSSQAVADQYADFLREGFHVVTP  577 (820)
+Q Consensus       548 npvivdctssqavadqyadflregfhvvtp  577 (820)
+                      -.++++||......+....+++.|.+|++-
+T Consensus        80 ~DvV~~atp~~~~~~~~~~~~~~G~~Vid~  109 (359)
+T 4dpl_A           80 VDIIFSPLPQGAAGPVEEQFAKEGFPVISN  109 (359)
+T ss_dssp             CCEEEECCCTTTHHHHHHHHHHTTCEEEEC
+T ss_pred             CCEEEEecCchHHHHHHHHHHHcCCEEEEC
+Confidence            357889998877777666777889998764
+
+
+No 191
+>4ei7_A Plasmid replication protein REPX; GTP hydrolase, plasmid segregation; HET: GDP; 1.90A {Bacillus cereus} PDB: 4ei8_A 4ei9_A*
+Probab=32.23  E-value=18  Score=34.40  Aligned_cols=52  Identities=15%  Similarity=0.165  Sum_probs=34.9  Template_Neff=9.000
+
+Q gi|556503834|r  459 LFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALL  510 (820)
+Q Consensus       459 lfntdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskall  510 (820)
+                      .-+.+.-.++.+||+|+-|..+.+++.++..-.++.....|..-|..++.-+
+T Consensus         9 ~~~~~~~~~i~~IGiG~~G~~i~~~l~~~~~~~~~~~~~~~~i~idtd~~~l   60 (389)
+T 4ei7_A            9 ESQGNISLKFGFLGLGMGGCAIAAECANKETQIKNNKYPYRAILVNTNSQDF   60 (389)
+T ss_dssp             HHHCCCSSCEEEEEEHHHHHHHHHHHHTCCCCCTTCSCCCEEEEEECCCHHH
+T ss_pred             hhccCCCceEEEEeeCccHHHHHHHHHHhhhhhccccccccEEEEECCHHHH
+Confidence            3445667899999999999999999887753223333345555555544433
+
+
+No 192
+>3hsk_A Aspartate-semialdehyde dehydrogenase; candida albicans NADP amino-acid biosynthesis, oxidoreductase; HET: NAP; 2.20A {Candida albicans}
+Probab=31.86  E-value=18  Score=34.76  Aligned_cols=104  Identities=16%  Similarity=0.222  Sum_probs=52.5  Template_Neff=8.500
+
+Q gi|556503834|r  462 TDQVIEVFVIG-VGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKAL----LTNVHGLNLENWQEELAQAKEPFNLGR  536 (820)
+Q Consensus       462 tdqvievfvig-vggvggalleqlkrqqswlknkhidlrvcgvanskal----ltnvhglnlenwqeelaqakepfnlgr  536 (820)
+                      +...+.|-+|| .|.+|..+++.|.+        |-++.+.++..+..-    +...|+.. ....  ......+.....
+T Consensus        16 ~~~~ikVaIiGatG~iG~~ll~~L~~--------~~~~~I~~v~~~~~~~~~~~~~~~~~~-~~~~--~~~~~~~~~~~~   84 (381)
+T 3hsk_A           16 HMSVKKAGVLGATGSVGQRFILLLSK--------HPEFEIHALGASSRSAGKKYKDAASWK-QTET--LPETEQDIVVQE   84 (381)
+T ss_dssp             --CCEEEEEETTTSHHHHHHHHHHTT--------CSSEEEEEEEECTTTTTSBHHHHCCCC-CSSC--CCHHHHTCBCEE
+T ss_pred             cCCcceEEEECCCcHHHHHHHHHHHc--------CCCCEEEEEEcCCHHHHHHHHHHcCcc-cccc--cccccCceEEec
+Confidence            34567899999 69999999988765        223556665522110    11112110 0000  000000100000
+
+
+Q gi|556503834|r  537 LIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPN  578 (820)
+Q Consensus       537 lirlvkeyhllnpvivdctssqavadqyadflregfhvvtpn  578 (820)
+                      +-...  -..---+++.||......+.....++.|.+|++-+
+T Consensus        85 ~~~~~--~~~~~DvV~~atp~~~~~~~~~~al~aG~~VId~s  124 (381)
+T 3hsk_A           85 CKPEG--NFLECDVVFSGLDADVAGDIEKSFVEAGLAVVSNA  124 (381)
+T ss_dssp             SSSCT--TGGGCSEEEECCCHHHHHHHHHHHHHTTCEEEECC
+T ss_pred             hhHhh--hccCCCEEEEcCCcHHHHHHHHHHHHCCCEEEECC
+Confidence            00000  00123578899988877777777888899988643
+
+
+No 193
+>2g1u_A Hypothetical protein TM1088A; structural genomics, joint center for structural genomics, J protein structure initiative, PSI-2; HET: AMP; 1.50A {Thermotoga maritima} PDB: 3l4b_A*
+Probab=31.71  E-value=18  Score=28.82  Aligned_cols=22  Identities=14%  Similarity=0.336  Sum_probs=18.5  Template_Neff=10.000
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrq  487 (820)
+                      ..|.++|.|.+|.++.+.|.+.
+T Consensus        20 ~~v~iiG~G~~g~~~~~~l~~~   41 (155)
+T 2g1u_A           20 KYIVIFGCGRLGSLIANLASSS   41 (155)
+T ss_dssp             CEEEEECCSHHHHHHHHHHHHT
+T ss_pred             CeEEEECCcHHHHHHHHHHHHC
+Confidence            4568899999999999988763
+
+
+No 194
+>3pdu_A 3-hydroxyisobutyrate dehydrogenase family protein; gamma-hydroxybutyrate dehydrogenase, succinic semialdehyde R glyoxylate metabolism; HET: NAP; 1.89A {Geobacter sulfurreducens}
+Probab=31.15  E-value=19  Score=30.91  Aligned_cols=20  Identities=30%  Similarity=0.524  Sum_probs=16.7  Template_Neff=10.600
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       467 evfvigvggvggalleqlkr  486 (820)
+                      .|-|||.|.+|.++...|.+
+T Consensus         3 ~i~iiG~G~~G~~~a~~l~~   22 (287)
+T 3pdu_A            3 TYGFLGLGIMGGPMAANLVR   22 (287)
+T ss_dssp             CEEEECCSTTHHHHHHHHHH
+T ss_pred             eEEEEcCcHhHHHHHHHHHh
+Confidence            46789999999999887764
+
+
+No 195
+>2izz_A Pyrroline-5-carboxylate reductase 1; amino-acid biosynthesis, NADP, oxidoreductase, proline biosy; HET: NAD; 1.95A {Homo sapiens} PDB: 2ger_A 2gr9_A* 2gra_A*
+Probab=30.26  E-value=20  Score=32.60  Aligned_cols=36  Identities=28%  Similarity=0.309  Sum_probs=18.8  Template_Neff=9.500
+
+Q gi|556503834|r  449 TTGVRVTHQMLFNTDQVIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       449 ttgvrvthqmlfntdqvievfvigvggvggalleqlkr  486 (820)
+                      ..|+|+-+-+.  ..+...|-+||.|.+|.++...|.+
+T Consensus         8 ~~~~~~~~~~~--~~~~~~I~iIG~G~mG~~ia~~L~~   43 (322)
+T 2izz_A            8 SSGVDLGTENL--YFQSMSVGFIGAGQLAFALAKGFTA   43 (322)
+T ss_dssp             ----------------CCCEEEESCSHHHHHHHHHHHH
+T ss_pred             cchhhhhhhcc--ccCCCEEEEECCCHHHHHHHHHHHH
+Confidence            34555544333  2455678899999999999988864
+
+
+No 196
+>2dt5_A AT-rich DNA-binding protein; REX, NADH, NAD, rossmann fold, redox sensing, winged helix, themophilus; HET: NAD; 2.16A {Thermus thermophilus} SCOP: a.4.5.38 c.2.1.12 PDB: 1xcb_A* 3ikt_A* 3ikv_A 3il2_A*
+Probab=29.82  E-value=20  Score=30.65  Aligned_cols=37  Identities=16%  Similarity=0.289  Sum_probs=26.2  Template_Neff=9.400
+
+Q gi|556503834|r  462 TDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANS  506 (820)
+Q Consensus       462 tdqvievfvigvggvggalleqlkrqqswlknkhidlrvcgvans  506 (820)
+                      .+....+.+||.|..|..+++.+...        -+.++.|+.+.
+T Consensus        77 ~~~~~~v~iiG~G~~g~~~~~~l~~~--------~~~~vv~i~d~  113 (211)
+T 2dt5_A           77 LNRKWGLCIVGMGRLGSALADYPGFG--------ESFELRGFFDV  113 (211)
+T ss_dssp             TTSCEEEEEECCSHHHHHHHHCSCCC--------SSEEEEEEEES
+T ss_pred             CCCCceEEEEcCCHHHHHHHHHhhcc--------CCcEEEEEECC
+Confidence            34567889999999999998876542        14566665543
+
+
+No 197
+>1vl6_A Malate oxidoreductase; TM0542, NAD-dependent malic enzyme, structural genomics, JCS protein structure initiative, PSI; 2.61A {Thermotoga maritima} SCOP: c.2.1.7 c.58.1.3 PDB: 2hae_A*
+Probab=28.35  E-value=23  Score=34.75  Aligned_cols=22  Identities=27%  Similarity=0.468  Sum_probs=19.5  Template_Neff=7.900
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrq  487 (820)
+                      ..|.|+|.|.+|.++.+.|++.
+T Consensus       193 ~kV~ViGaG~~G~~iA~~L~~~  214 (388)
+T 1vl6_A          193 VKVVVNGIGAAGYNIVKFLLDL  214 (388)
+T ss_dssp             CEEEEECCSHHHHHHHHHHHHH
+T ss_pred             ceEEEEcCcHHHHHHHHHHHhc
+Confidence            4689999999999999998775
+
+
+No 198
+>4b4u_A Bifunctional protein fold; oxidoreductase; HET: NAP; 1.45A {Acinetobacter baumannii atcc 19606} PDB: 4b4v_A* 4b4w_A*
+Probab=27.90  E-value=23  Score=33.44  Aligned_cols=21  Identities=19%  Similarity=0.321  Sum_probs=18.0  Template_Neff=8.000
+
+Q gi|556503834|r  466 IEVFVIGVGG-VGGALLEQLKR  486 (820)
+Q Consensus       466 ievfvigvgg-vggalleqlkr  486 (820)
+                      -.|.|||.|+ +|.++...|.+
+T Consensus       180 k~v~ViG~G~~vG~~ia~~L~~  201 (303)
+T 4b4u_A          180 KHAVVVGRSAILGKPMAMMLLQ  201 (303)
+T ss_dssp             CEEEEECCCTTTHHHHHHHHHH
+T ss_pred             CEEEEECCCCchHHHHHHHHHH
+Confidence            4689999999 99999888765
+
+
+No 199
+>2cdc_A Glucose dehydrogenase glucose 1-dehydrogenase, DHG-1; reductase, oxidoreductase, MDR family; HET: XYS XYP NAP; 1.50A {Sulfolobus solfataricus} PDB: 2cdb_A* 2cd9_A 2cda_A*
+Probab=27.62  E-value=24  Score=31.42  Aligned_cols=29  Identities=17%  Similarity=0.137  Sum_probs=17.9  Template_Neff=10.600
+
+Q gi|556503834|r  549 PVIVDCTSSQ-AVADQYADFLREGFHVVTP  577 (820)
+Q Consensus       549 pvivdctssq-avadqyadflregfhvvtp  577 (820)
+                      .+++||+... ...++..+.++.+-.++..
+T Consensus       248 d~vid~~g~~~~~~~~~~~~l~~~G~~v~~  277 (366)
+T 2cdc_A          248 DVIIDATGADVNILGNVIPLLGRNGVLGLF  277 (366)
+T ss_dssp             EEEEECCCCCTHHHHHHGGGEEEEEEEEEC
+T ss_pred             cEEEECCCCchHHHHHHHHHhcCCCEEEEE
+Confidence            4778888766 2455666666655555443
+
+
+No 200
+>2pc6_A Probable acetolactate synthase isozyme III (small; regulatory subunit, structural genomi protein structure initiative; HET: MSE; 2.50A {Nitrosomonas europaea atcc 19718} SCOP: d.58.18.6 d.58.18.6
+Probab=27.44  E-value=24  Score=29.41  Aligned_cols=125  Identities=12%  Similarity=0.072  Sum_probs=67.9  Template_Neff=9.100
+
+Q gi|556503834|r  318 FSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSS----EYSISFCVPQSD--CVRAERAMQEEFYLELKEGLLEP-L  390 (820)
+Q Consensus       318 fsvsgpgmkgmvgmaarvfaamsrarisvvlitqsss----eysisfcvpqsd--cvraeramqeefylelkegllep-l  390 (820)
+                      +++.++.-   .|..+++...+++..+.+.-++++..    .+.+.|.+...+  ..+..+++..-. ..+.-..+++ -
+T Consensus         7 i~i~~~d~---pGvL~~I~~~l~~~g~nI~~i~~~~~~~~~~~~i~i~v~~~~~~~~~l~~~L~~l~-~v~~v~~~~~~~   82 (165)
+T 2pc6_A            7 ISLLMENE---AGALSRVAGLFSARGYNIESLSVAPTEDPTLSRMTLVTNGPDEIVEQITKQLNKLI-EVVKLIDLSSEG   82 (165)
+T ss_dssp             EEEEEECS---TTHHHHHHHHHHHHTCCCCEEEEEECSSTTEEEEEEEEEECHHHHHHHHHHHHHST-TEEEEEEGGGSC
+T ss_pred             EEEEEcCC---CCHHHHHHHHHHHCCCchHHeEeEecCCCCEEEEEEEEecCcchHHHHHHHHhhcc-cEeeeecccchh
+Confidence            44444443   35566777777788887777766543    334455555433  334333332211 1111111211 1
+
+
+Q gi|556503834|r  391 AVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVR  453 (820)
+Q Consensus       391 avterlaiisvvgdgmrtlrgisakffaalaraninivaiaqgssersisvvvnnddattgvr  453 (820)
+                      .+...++.+.++|.+-+.     .+++..++..++||+-+...  +-.+++....++...-++
+T Consensus        83 ~~~~~~~~v~v~~~~d~~-----g~i~~~l~~~~~~I~~i~~~--~~~~~~~g~~~~i~~~~~  138 (165)
+T 2pc6_A           83 YVERELMLVKVRAVGKDR-----EEMKRLADIFRGNIIDVTNE--LYTIELTGTRSKLDGFLQ  138 (165)
+T ss_dssp             EEEEEEEEEEEECCTHHH-----HHHHHHHHHTTCEEEEEETT--EEEEEEEECHHHHHHHHH
+T ss_pred             hhhheeeeEEeccCcccH-----HHHHHHHHHcCCEEEEecCC--EEEEEEcCCHHHHHHHHH
+Confidence            344556778888853222     28899999999999988544  344555544544444443
+
+
+No 201
+>4o59_O Glyceraldehyde-3-phosphate dehydrogenase; oxidoreductase, transferase; HET: NAD; 1.52A {Bos taurus} PDB: 4o63_P* 1j0x_O* 1u8f_O* 4wnc_O* 1znq_O* 4wni_O* 3gpd_R* 4k9d_A* 1dss_G* 1crw_G* 1szj_G* 1ihx_A* 1ihy_A* 1gpd_G* 4gpd_1
+Probab=27.27  E-value=24  Score=33.34  Aligned_cols=99  Identities=17%  Similarity=0.210  Sum_probs=52.1  Template_Neff=8.400
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKAL---------LTNVHGLNLENWQEELAQAKEPFNLGR  536 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskal---------ltnvhglnlenwqeelaqakepfnlgr  536 (820)
+                      +.|.++|.|-+|+.++..+...        -++.+.+|.....-         ...+||--..+-.  .....-.+| |.
+T Consensus         1 ~kVgIiG~G~iG~~l~r~l~~~--------~~~elv~i~d~~~~~~~~~~ll~~ds~~g~~~~~~~--~~~~~l~~~-g~   69 (332)
+T 4o59_O            1 VKVGVNGFGRIGRLVTRAAFNS--------GKVDIVAINDPFIDLHYMVYMFQYDSTHGKFNGTVK--AENGKLVIN-GK   69 (332)
+T ss_dssp             CEEEEECCSHHHHHHHHHHHTT--------SSCEEEEEECTTSCHHHHHHHHHCCTTTCSCSSCEE--EETTEEEET-TE
+T ss_pred             CEEEEECcChHHHHHHHHHhhC--------CCeEEEEEecCCCCcceeeeeeccccccCCCCcceE--ecCCeEEEC-CE
+Confidence            3588999999999998877642        34555555443221         1223442110000  000001111 12
+
+
+Q gi|556503834|r  537 LIRLVKE--YH------LLNPVIVDCTSSQAVADQYADFLREGF-HVV  575 (820)
+Q Consensus       537 lirlvke--yh------llnpvivdctssqavadqyadflregf-hvv  575 (820)
+                      .+++..+  ..      .---++++||......+.....++.|. +|+
+T Consensus        70 ~i~~~~~~~~~~~~~~~~~vDvVi~~t~~~~~~~~~~~~l~~g~k~vi  117 (332)
+T 4o59_O           70 AITIFQERDPANIKWGDAGAEYVVESTGVFTTMEKAGAHLKGGAKRVI  117 (332)
+T ss_dssp             EEEEECCSSGGGCCHHHHTCSEEEECSSSCCSHHHHTHHHHTTCSEEE
+T ss_pred             EEEEeecCChHHhccccccCCEEEeCCchhhhHHHHHHHHhCCCCeEE
+Confidence            2223221  11      123478999999888888888888884 444
+
+
+No 202
+>3mw9_A GDH 1, glutamate dehydrogenase 1; allostery, inhibition, oxidoreducta; HET: GLU NAI GTP; 2.40A {Bos taurus} PDB: 3mvo_A* 3mvq_A* 3qmu_A* 3etd_A* 3ete_A* 3etg_A* 1l1f_A 1nr1_A 1nr7_A 1nqt_A 1hwz_A* 1hwy_A*
+Probab=27.00  E-value=25  Score=36.69  Aligned_cols=50  Identities=22%  Similarity=0.283  Sum_probs=40.6  Template_Neff=6.600
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE  523 (820)
+Q Consensus       465 vievfvigvggvggalleqlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqe  523 (820)
+                      -..|.|.|.|.||..+.+.|.+..         .+|.+|+.++..+.+-.|++.+...+
+T Consensus       244 ~~~vaIqGfG~VG~~~a~~L~~~G---------a~VvaVsd~~G~i~~~~Gld~~~l~~  293 (501)
+T 3mw9_A          244 DKTFVVQGFGNVGLHSMRYLHRFG---------AKCITVGESDGSIWNPDGIDPKELED  293 (501)
+T ss_dssp             TCEEEEECCSHHHHHHHHHHHHTT---------CEEEEEECSSCEEECTTCCCHHHHHH
+T ss_pred             cceEEEEeecCchHHHHHHHHHCC---------CEEEEEEecCceEECCCCCCHHHHHH
+Confidence            456778999999999999887532         48999999999888888998776554
+
+
+No 203
+>4egb_A DTDP-glucose 4,6-dehydratase; rhamnose pathway, center for structural genomics of infectio diseases, csgid, niaid; HET: NAD SUC; 3.00A {Bacillus anthracis}
+Probab=25.86  E-value=27  Score=31.53  Aligned_cols=39  Identities=15%  Similarity=0.382  Sum_probs=19.8  Template_Neff=10.000
+
+Q gi|556503834|r  449 TTGVRVTHQMLFNTDQVIEVFVIGVG-GVGGALLEQLKRQ  487 (820)
+Q Consensus       449 ttgvrvthqmlfntdqvievfvigvg-gvggalleqlkrq  487 (820)
+                      ..||.....++.+.-...-|+|+|.. .+|.+|.++|.++
+T Consensus         8 ~~~~~~~~~~~~~~~~~~~vlItGatGfiG~~l~~~L~~~   47 (346)
+T 4egb_A            8 SSGVDLGTENLYFQSNAMNILVTGGAGFIGSNFVHYMLQS   47 (346)
+T ss_dssp             ----------------CEEEEEETTTSHHHHHHHHHHHHH
+T ss_pred             ccccccCccceeeccCCCEEEEECCCchHHHHHHHHHHHh
+Confidence            45677777788888888889999875 6899999999875
+
+
+No 204
+>3wv7_A HMD CO-occurring protein HCGE; E1 enzyme superfamily, UBA/THIF-type NAD/FAD binding fold, adenylyltransferase, ATP binding; HET: ADP; 1.60A {Methanothermobacter marburgensis} PDB: 3wv8_A* 3wv9_A*
+Probab=25.24  E-value=28  Score=30.72  Aligned_cols=20  Identities=30%  Similarity=0.403  Sum_probs=18.0  Template_Neff=8.700
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       467 evfvigvggvggalleqlkr  486 (820)
+                      .|.|+|.||+|..++++|-+
+T Consensus        15 ~V~ivG~GglG~~va~~La~   34 (218)
+T 3wv7_A           15 EVTLVGAGRLGFRTALNLMQ   34 (218)
+T ss_dssp             EEEEECCSHHHHHHHHHHHT
+T ss_pred             EEEEECCCHHHHHHHHHHHH
+Confidence            68899999999999999983
+
+
+No 205
+>2yop_A Protein FAM3B; apoptosis, diabetes, ILEI, EMT; 2.30A {Mus musculus} PDB: 2yoq_A
+Probab=24.75  E-value=29  Score=31.71  Aligned_cols=60  Identities=22%  Similarity=0.233  Sum_probs=31.6  Template_Neff=7.100
+
+Q gi|556503834|r  101 IKHVLHGISLLGQCPDSIN------------AALICRGEKMSIAIMAGVLEARGHNVTVIDPVE-KLLAVGHYL  161 (820)
+Q Consensus       101 ikhvlhgisllgqcpdsin------------aalicrgekmsiaimagvlearghnvtvidpve-kllavghyl  161 (820)
+                      ...+.+-.++.+.||+...            .+.||-..+.-+.- ..-.-.||+||.|+||.. ++....+|-
+T Consensus        11 ~~~~~~~c~~~~~c~~~~~~i~v~S~~~~~~~~~I~ing~~~~~~-~~~~~~rGlnv~v~d~~tg~v~~~~~FD   83 (198)
+T 2yop_A           11 PAPKRQKCDHWSPCPPDTYAYRLLSGGGRDKYAKICFEDEVLIGE-KTGNVARGINIAVVNYETGKVIATKYFD   83 (198)
+T ss_dssp             ----CCGGGCSSCCCTTEEEEEEECCBTTTBCCEEEETTEEEEST-TTTCCCSEEEEEEEETTTCCEEEEEEEC
+T ss_pred             CCccccCCCCCCCCCCcceeEEEEeCCCCCcccEEEECCEEeeec-cccccCCceeEEEEecCCCcEEeeeecc
+Confidence            3445567788889998322            34444443332110 011124999999999875 444444443
+
+
+No 206
+>4d79_A TRNA threonylcarbamoyladenosine dehydratase; ligase, L-cysteine desulfurase, transpersulfuration, sulfur trafficking; HET: ATP; 1.77A {Escherichia coli} PDB: 4d7a_A* 4rdi_A* 4rdh_A*
+Probab=24.69  E-value=29  Score=32.18  Aligned_cols=23  Identities=39%  Similarity=0.673  Sum_probs=19.5  Template_Neff=8.200
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQQ  488 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrqq  488 (820)
+                      -.|.|+|.|++|....+.|.+.-
+T Consensus        31 ~~VlVvG~G~vG~~~a~~L~~~G   53 (276)
+T 4d79_A           31 AHICVVGIGGVGSWAAEALARTG   53 (276)
+T ss_dssp             CEEEEECCSTTHHHHHHHHHHTT
+T ss_pred             CeEEEEcCCHHHHHHHHHHHHcC
+Confidence            36889999999999999887653
+
+
+No 207
+>1zud_1 Adenylyltransferase THIF; thiamin, thiazole, protein-protein complex, THIF, TRAN biosynthetic protein complex; 1.98A {Escherichia coli} PDB: 1zfn_A* 1zkm_A
+Probab=24.67  E-value=29  Score=29.13  Aligned_cols=22  Identities=32%  Similarity=0.522  Sum_probs=19.0  Template_Neff=10.600
+
+Q gi|556503834|r  465 VIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       465 vievfvigvggvggalleqlkr  486 (820)
+                      -..|.|+|.|++|..++++|.+
+T Consensus        28 ~~~v~ivG~g~~g~~~~~~L~~   49 (251)
+T 1zud_1           28 DSQVLIIGLGGLGTPAALYLAG   49 (251)
+T ss_dssp             TCEEEEECCSTTHHHHHHHHHH
+T ss_pred             cCeEEEEccCHHHHHHHHHHHH
+Confidence            3468899999999999999875
+
+
+No 208
+>1jw9_B Molybdopterin biosynthesis MOEB protein; MOEB: modified rossmann fold, (2) Cys-X-X-Cys zinc-binding M MOAD: ubiquitin-like fold; 1.70A {Escherichia coli} SCOP: c.111.1.1 PDB: 1jwa_B* 1jwb_B*
+Probab=23.66  E-value=31  Score=29.01  Aligned_cols=22  Identities=32%  Similarity=0.614  Sum_probs=18.9  Template_Neff=10.500
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       466 ievfvigvggvggalleqlkrq  487 (820)
+                      ..|.|||.|++|..+..+|.+.
+T Consensus        32 ~~v~iiG~g~~g~~~~~~L~~~   53 (249)
+T 1jw9_B           32 SRVLIVGLGGLGCAASQYLASA   53 (249)
+T ss_dssp             CEEEEECCSHHHHHHHHHHHHH
+T ss_pred             CeEEEEcCCHHHHHHHHHHHHc
+Confidence            5688999999999999988753
+
+
+No 209
+>2f1f_A Acetolactate synthase isozyme III small subunit; ferredoxin fold, ACT domain, transferase; HET: P33 1PE; 1.75A {Escherichia coli} SCOP: d.58.18.6 d.58.18.6
+Probab=23.23  E-value=32  Score=28.81  Aligned_cols=99  Identities=11%  Similarity=0.148  Sum_probs=56.4  Template_Neff=8.900
+
+Q gi|556503834|r  329 VGMAARVFAAMSRARISVVLITQSSSE----YSISFCVPQ--SDCVRAERAMQEEFYLELKEGLLEP-LAVTERLAIISV  401 (820)
+Q Consensus       329 vgmaarvfaamsrarisvvlitqssse----ysisfcvpq--sdcvraeramqeefylelkegllep-lavterlaiisv  401 (820)
+                      .|+.+++...+++..+.+.-+.++..+    +.+.|-+..  .++-+....+.+-.. .++-..+++ -.+...++.+.+
+T Consensus        14 ~Gvl~~I~~~l~~~~~nI~~i~~~~~~~~~~~~~~i~v~~~~~~~~~l~~~L~~l~~-v~~v~~~~~~~~~~~~~~~v~v   92 (164)
+T 2f1f_A           14 SGALSRVIGLFSQRGYNIESLTVAPTDDPTLSRMTIQTVGDEKVLEQIEKQLHKLVD-VLRVSELGQGAHVEREIMLVKI   92 (164)
+T ss_dssp             TTHHHHHHHHHHTTTCCCSEEEEEECSCSSEEEEEEEEESCHHHHHHHHHHHHHSTT-EEEEEEGGGSCEEEEEEEEEEE
+T ss_pred             CCHHHHHHHHHHHcCCceeeEEEEecCCCCEEEEEEEEecChHHHHHHHHHHHhcCC-ceEEEEeccccceeeeeeEEEE
+Confidence            456677777888888888777775543    445555543  233333333221110 111111111 134456778888
+
+
+Q gi|556503834|r  402 VGDGMRTLRGISAKFFAALARANINIVAIAQG  433 (820)
+Q Consensus       402 vgdgmrtlrgisakffaalaraninivaiaqg  433 (820)
+                      .|.+-+.     .+++..++..++||+-+...
+T Consensus        93 ~~~~d~~-----~~i~~~l~~~~i~I~~i~~~  119 (164)
+T 2f1f_A           93 QASGYGR-----DEVKRNTEIFRGQIIDVTPS  119 (164)
+T ss_dssp             ECCTHHH-----HHHHHHHHHTTCEEEEECSS
+T ss_pred             ecCccCH-----HHHHHHHHHcCCEEEEecCC
+Confidence            8863222     38889999999999988544
+
+
+No 210
+>3ic5_A Putative saccharopine dehydrogenase; structural genomics, APC63807.2, N-terminal domain, saccharo dehydrogenase, PSI-2; HET: MSE; 2.08A {Ruegeria pomeroyi}
+Probab=23.21  E-value=32  Score=23.60  Aligned_cols=21  Identities=29%  Similarity=0.558  Sum_probs=17.4  Template_Neff=12.100
+
+Q gi|556503834|r  466 IEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       466 ievfvigvggvggalleqlkr  486 (820)
+                      ..+.++|.|.+|..+++.+++
+T Consensus         6 ~~i~iiG~G~~g~~~~~~l~~   26 (118)
+T 3ic5_A            6 WNICVVGAGKIGQMIAALLKT   26 (118)
+T ss_dssp             EEEEEECCSHHHHHHHHHHHH
+T ss_pred             cEEEEECCcHHHHHHHHHHHh
+Confidence            356789999999999988765
+
+
+No 211
+>4r3n_A Aspartate-semialdehyde dehydrogenase; protein-NADP-ligand complex, oxidoreductase, binding; HET: NAP 3GQ; 1.35A {Streptococcus pneumoniae} PDB: 2gyy_A* 2gz2_A* 2gz3_A* 2gz1_A* 3pws_A* 3pyl_A 3pyx_A* 3pzb_A* 3q11_A* 3q1l_A 3pwk_A* 4r3w_A* 4r41_A* 4r4j_A* 4r51_A* 4r54_A* 4r5h_A*
+Probab=23.07  E-value=33  Score=32.70  Aligned_cols=28  Identities=18%  Similarity=0.147  Sum_probs=23.2  Template_Neff=8.600
+
+Q gi|556503834|r  549 PVIVDCTSSQAVADQYADFLREGFHVVT  576 (820)
+Q Consensus       549 pvivdctssqavadqyadflregfhvvt  576 (820)
+                      .+++.|+......+....+++.|.+|+.
+T Consensus        66 DvV~~a~~~~~~~~~~~~~l~aG~~VId   93 (366)
+T 4r3n_A           66 DIALFSAGSSTSAKYAPYAVKAGVVVVD   93 (366)
+T ss_dssp             SEEEECSCHHHHHHHHHHHHHTTCEEEE
+T ss_pred             CEEEEeCCchHHHHHHHHHHhhCCEEEE
+Confidence            5788899998888887888888998873
+
+
+No 212
+>1y81_A Conserved hypothetical protein; hyperthermophIle, structural genomics, PSI, protein structure initiative; HET: COA; 1.70A {Pyrococcus furiosus} SCOP: c.2.1.8
+Probab=22.89  E-value=33  Score=27.10  Aligned_cols=32  Identities=19%  Similarity=0.337  Sum_probs=19.0  Template_Neff=9.700
+
+Q gi|556503834|r  455 THQMLFNTDQVIEVFVIGVG----GVGGALLEQLKR  486 (820)
+Q Consensus       455 thqmlfntdqvievfvigvg----gvggalleqlkr  486 (820)
+                      .|.|..+......|.|||.|    .+|..++..|++
+T Consensus         4 ~~~~~~~~~~~~~i~vIG~g~~~g~~g~~~~~~l~~   39 (138)
+T 1y81_A            4 HHHHGSNSKEFRKIALVGASKNPAKYGNIILKDLLS   39 (138)
+T ss_dssp             ----------CCEEEEETCCSCTTSHHHHHHHHHHH
+T ss_pred             cccccccccCCCeEEEEeecCCCCchHHHHHHHHHH
+Confidence            36677788889999999996    599988888766
+
+
+No 213
+>1npy_A Hypothetical shikimate 5-dehydrogenase-like protein HI0607; structural genomics, PSI, protein structure initiative; 1.75A {Haemophilus influenzae} SCOP: c.2.1.7 c.58.1.5
+Probab=22.43  E-value=34  Score=30.50  Aligned_cols=24  Identities=29%  Similarity=0.509  Sum_probs=20.4  Template_Neff=9.300
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkrq  487 (820)
+                      .--.|.|||.||+|.++...|++.
+T Consensus       118 ~~~~vlViGaG~~g~~ia~~L~~~  141 (271)
+T 1npy_A          118 KNAKVIVHGSGGMAKAVVAAFKNS  141 (271)
+T ss_dssp             TTSCEEEECSSTTHHHHHHHHHHT
+T ss_pred             CCCEEEEECCcHHHHHHHHHHHhC
+Confidence            457899999999999999988653
+
+
+No 214
+>1ofu_A FTSZ, cell division protein FTSZ; bacterial cell division inhibitor, SULA protein; HET: GDP; 2.1A {Pseudomonas aeruginosa} SCOP: c.32.1.1 d.79.2.1
+Probab=22.32  E-value=35  Score=31.00  Aligned_cols=28  Identities=36%  Similarity=0.621  Sum_probs=20.9  Template_Neff=9.500
+
+Q gi|556503834|r  461 NTDQVIEVFVIGVGGVGGALLEQLKRQQ  488 (820)
+Q Consensus       461 ntdqvievfvigvggvggalleqlkrqq  488 (820)
+                      +...-.++.+||+|+.|..+++++.++.
+T Consensus         7 ~~~~~~~i~viGvG~~G~~i~~~~~~~~   34 (320)
+T 1ofu_A            7 NIAQTAVIKVIGVGGGGGNAVNHMAKNN   34 (320)
+T ss_dssp             ----CCCEEEEEEHHHHHHHHHHHHHTT
+T ss_pred             ccccCceEEEEEECccHHHHHHHHHHcC
+Confidence            3455678999999999999999887653
+
+
+No 215
+>4a26_A Putative C-1-tetrahydrofolate synthase, cytoplasm; oxidoreductase, hydrolase, leishmaniasis; 2.70A {Leishmania major}
+Probab=22.24  E-value=35  Score=31.73  Aligned_cols=21  Identities=24%  Similarity=0.401  Sum_probs=18.3  Template_Neff=8.500
+
+Q gi|556503834|r  466 IEVFVIGVGG-VGGALLEQLKR  486 (820)
+Q Consensus       466 ievfvigvgg-vggalleqlkr  486 (820)
+                      -.|.|||.|+ +|.++...|+.
+T Consensus       166 ~~vlIiG~G~~vG~~ia~~L~~  187 (300)
+T 4a26_A          166 KRAVVLGRSNIVGAPVAALLMK  187 (300)
+T ss_dssp             CEEEEECCCTTTHHHHHHHHHH
+T ss_pred             CEEEEECCCchhHHHHHHHHHH
+Confidence            4689999999 99999888765
+
+
+No 216
+>5hm8_A Adenosylhomocysteinase; adenosine, NAD, csgid, structural center for structural genomics of infectious diseases, HYDR; HET: ADN NAD; 2.85A {Cryptosporidium parvum}
+Probab=22.13  E-value=35  Score=34.76  Aligned_cols=20  Identities=30%  Similarity=0.541  Sum_probs=16.4  Template_Neff=7.600
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       467 evfvigvggvggalleqlkr  486 (820)
+                      .|.|+|.|.||..+...++.
+T Consensus       273 ~VlViG~G~VG~~~aq~l~~  292 (498)
+T 5hm8_A          273 KIVVLGYGEVGKGCAQGLSG  292 (498)
+T ss_dssp             EEEEECCSHHHHHHHHHHHH
+T ss_pred             EEEEECCchhHHHHHHHHHH
+Confidence            57889999999998876654
+
+
+No 217
+>2iz1_A 6-phosphogluconate dehydrogenase, decarboxylating; pentose shunt, oxidoreductase, gluconate utilization; HET: ATR RES P33; 2.30A {Lactococcus lactis} PDB: 2iz0_A* 2iyp_A* 2iyo_A*
+Probab=22.00  E-value=35  Score=32.79  Aligned_cols=23  Identities=17%  Similarity=0.226  Sum_probs=19.3  Template_Neff=9.400
+
+Q gi|556503834|r  464 QVIEVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       464 qvievfvigvggvggalleqlkr  486 (820)
+                      +...|-|||.|.+|.++...|.+
+T Consensus         4 ~~~~I~IIG~G~mG~~la~~L~~   26 (474)
+T 2iz1_A            4 AQANFGVVGMAVMGKNLALNVES   26 (474)
+T ss_dssp             TTBSEEEECCSHHHHHHHHHHHH
+T ss_pred             CCCeEEEECchHHHHHHHHHHHh
+Confidence            44578899999999999988865
+
+
+No 218
+>2rir_A Dipicolinate synthase, A chain; structural genomics, APC1343, PSI-2, structure initiative; HET: MSE NAP; 2.79A {Bacillus subtilis}
+Probab=21.75  E-value=36  Score=28.88  Aligned_cols=21  Identities=24%  Similarity=0.447  Sum_probs=16.6  Template_Neff=11.000
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       467 evfvigvggvggalleqlkrq  487 (820)
+                      .+.|+|.|.+|..+...+.++
+T Consensus       159 ~v~i~G~g~~g~~~~~~~~~~  179 (300)
+T 2rir_A          159 QVAVLGLGRTGMTIARTFAAL  179 (300)
+T ss_dssp             EEEEECCSHHHHHHHHHHHHT
+T ss_pred             cEEEEcCCHHHHHHHHHHHhC
+Confidence            577889999998888777643
+
+
+No 219
+>3gvp_A Adenosylhomocysteinase 3; protein CO-factor complex, hydrolase, NAD, one-carbon metabolism, phosphoprotein; HET: NAD; 2.25A {Homo sapiens} PDB: 3mtg_A*
+Probab=21.17  E-value=38  Score=33.03  Aligned_cols=20  Identities=40%  Similarity=0.527  Sum_probs=17.0  Template_Neff=8.600
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKR  486 (820)
+Q Consensus       467 evfvigvggvggalleqlkr  486 (820)
+                      .|.|||.|.+|..+...++.
+T Consensus       222 ~v~IiG~G~iG~~~a~~l~~  241 (435)
+T 3gvp_A          222 QVVVCGYGEVGKGCCAALKA  241 (435)
+T ss_dssp             EEEEECCSHHHHHHHHHHHH
+T ss_pred             EEEEECcHHHHHHHHHHHHH
+Confidence            57889999999999887764
+
+
+No 220
+>3h8v_A Ubiquitin-like modifier-activating enzyme 5; rossmann fold, ATP-binding, UBL conjugation pathway, transfe structural genomics consortium, SGC; HET: ATP; 2.00A {Homo sapiens} PDB: 3guc_A*
+Probab=21.11  E-value=38  Score=30.54  Aligned_cols=21  Identities=48%  Similarity=0.754  Sum_probs=18.6  Template_Neff=9.300
+
+Q gi|556503834|r  467 EVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       467 evfvigvggvggalleqlkrq  487 (820)
+                      .|.|||.|++|..+++.|-+.
+T Consensus        38 ~V~IvG~G~lG~~ia~~L~~~   58 (292)
+T 3h8v_A           38 AVAIVGVGGVGSVTAEMLTRC   58 (292)
+T ss_dssp             EEEEECCSHHHHHHHHHHHHH
+T ss_pred             cEEEECcCHHHHHHHHHHHHh
+Confidence            578999999999999998764
+
+
+No 221
+>2d59_A Hypothetical protein PH1109; COA binding, structural genomics; 1.65A {Pyrococcus horikoshii} SCOP: c.2.1.8 PDB: 2d5a_A* 2e6u_X* 3qa9_A 3q9n_A* 3q9u_A*
+Probab=20.47  E-value=40  Score=27.35  Aligned_cols=22  Identities=9%  Similarity=0.196  Sum_probs=17.3  Template_Neff=9.200
+
+Q gi|556503834|r  465 VIEVFVIGVGG----VGGALLEQLKR  486 (820)
+Q Consensus       465 vievfvigvgg----vggalleqlkr  486 (820)
+                      -..|.|||.|.    +|..++..|++
+T Consensus        22 ~~~I~viG~g~~~~~~g~~~~~~l~~   47 (144)
+T 2d59_A           22 YKKIALVGASPKPERDANIVMKYLLE   47 (144)
+T ss_dssp             CCEEEEETCCSCTTSHHHHHHHHHHH
+T ss_pred             CCEEEEEeecCCCcchHHHHHHHHHH
+Confidence            45678899998    88888877764
+
+
+No 222
+>2r75_1 Cell division protein FTSZ; GTPase, tubulin-like, inhibitor, cell cycle; HET: 01G; 1.40A {Aquifex aeolicus} PDB: 2r6r_1*
+Probab=20.30  E-value=40  Score=31.32  Aligned_cols=27  Identities=26%  Similarity=0.416  Sum_probs=19.6  Template_Neff=9.000
+
+Q gi|556503834|r  461 NTDQVIEVFVIGVGGVGGALLEQLKRQ  487 (820)
+Q Consensus       461 ntdqvievfvigvggvggalleqlkrq  487 (820)
+                      +++.-.++.|||+||.|+.+++.+..+
+T Consensus         3 ~~~~~~~i~viGiG~~G~~iv~~~~~~   29 (338)
+T 2r75_1            3 EFVNPCKIKVIGVGGGGSNAVNRMYED   29 (338)
+T ss_dssp             -----CCEEEEEEHHHHHHHHHHHHHT
+T ss_pred             ccCCCCcEEEEEECchHHHHHHHHHHc
+Confidence            345566889999999999999988765
+
+
+No 223
+>3off_A LDLR chaperone BOCA; MESD, molecular chaperone, protein folding, YWTD propeller; 2.00A {Drosophila melanogaster} PDB: 3ofe_A*
+Probab=20.25  E-value=41  Score=28.51  Aligned_cols=42  Identities=24%  Similarity=0.168  Sum_probs=33.7  Template_Neff=5.500
+
+Q gi|556503834|r  484 LKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEEL  525 (820)
+Q Consensus       484 lkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeel  525 (820)
+                      -++-|+-|.|.||+.+..+|..++++.+--+|-......+=|
+T Consensus        31 ~~~Wq~~L~n~~i~v~~y~vd~~r~if~~~dG~~a~e~k~FL   72 (90)
+T 3off_A           31 TKLWQTSLWNNHIQAERYMVDDNRAIFLFKDGTQAWDAKDFL   72 (90)
+T ss_dssp             HHHHHHHHHHTTCCEEEEEEETTEEEEEESSGGGHHHHHHHH
+T ss_pred             HHHHHHHHhhCCeEEEEEEEcCCEEEEEeCchHhHHHHHHHH
+Confidence            355678899999999999999999999988887665444433
+
+
+No 224
+>4zrm_A UDP-glucose 4-epimerase; hyperthermophiles, epimerization, isome; HET: NAD; 1.90A {Thermotoga maritima} PDB: 4zrn_A*
+Probab=20.23  E-value=41  Score=28.14  Aligned_cols=21  Identities=24%  Similarity=0.534  Sum_probs=17.4  Template_Neff=11.500
+
+Q gi|556503834|r  467 EVFVIGV-GGVGGALLEQLKRQ  487 (820)
+Q Consensus       467 evfvigv-ggvggalleqlkrq  487 (820)
+                      -|+|+|. |.+|.++.++|.++
+T Consensus         5 ~vlItG~tG~iG~~l~~~l~~~   26 (312)
+T 4zrm_A            5 NILVTGGAGFIGSHVVDKLIEN   26 (312)
+T ss_dssp             EEEEETTTSHHHHHHHHHHHHT
+T ss_pred             EEEEECCcchHHHHHHHHHHHC
+Confidence            4678877 88999999999864
+
+
+No 225
+>3ofg_A BOCA/MESD chaperone for YWTD beta-propeller-EGF P; molecular chaperone, protein folding, YWTD propeller, LDLR; HET: MSE; 1.37A {Caenorhabditis elegans}
+Probab=20.11  E-value=41  Score=28.65  Aligned_cols=43  Identities=26%  Similarity=0.240  Sum_probs=34.5  Template_Neff=5.600
+
+Q gi|556503834|r  483 QLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQEEL  525 (820)
+Q Consensus       483 qlkrqqswlknkhidlrvcgvanskalltnvhglnlenwqeel  525 (820)
+                      --++-|+-|.|.||+.++.+|..++++.+--+|-......+=|
+T Consensus        35 ia~~Wq~~L~n~~I~v~~y~vd~~r~if~~~dG~~a~e~k~FL   77 (95)
+T 3ofg_A           35 WTQIWQSQLYNNHVDLQVFVIDDNRAIFMFKNGEQAFEAKKFL   77 (95)
+T ss_dssp             HHHHHHHHHHHTTCCEEEEEEETTEEEEEESSGGGHHHHHHHH
+T ss_pred             HHHHHHHHHHhCCeEEEEEEEcCCEEEEEeCchhhHHHHHHHH
+Confidence            3456788899999999999999999999988887665444433
+
+

--- a/microprot/tests/data/test_pdb_search/T0810-D1.fasta.out
+++ b/microprot/tests/data/test_pdb_search/T0810-D1.fasta.out
@@ -1,0 +1,200 @@
+Query         T0810-D1 | T0810-D1 | 113 aa | generated using PDB2FASTA.py (c) T.KOSCIOLEK
+Match_columns 113
+No_of_seqs    1 out of 1
+Neff          1
+Searched_HMMs 36595
+Date          Wed Dec  7 17:07:29 2016
+Command       /projects/microprot/tools/hhsuite-3.0.0/build/bin/hhsearch -i T0810-D1.fasta -e 0.001 -d /projects/microprot/dbs/pdb70/pdb70 -o T0810-D1.fasta.out 
+
+ No Hit                             Prob E-value P-value  Score    SS Cols Query HMM  Template HMM
+  1 2xqo_A Cellulosome enzyme, doc  31.5      18  0.0005   28.9   0.0   38   71-108    43-80  (243)
+  2 2ld7_A Histone deacetylase com  27.2      24 0.00066   23.4   0.0   16   86-101    48-63  (94)
+  3 3eoq_A Putative zinc protease;  24.1      30 0.00083   24.1   0.0   81   19-99    122-205 (406)
+  4 4h0e_A Arabinose metabolism tr  17.7      50  0.0014   19.2   0.0   27   35-61      8-34  (88)
+  5 3hdi_A Processing protease; CA  16.4      57  0.0016   23.0   0.0   81   20-100   124-206 (421)
+  6 3qbz_A DDK kinase regulatory s  14.6      67  0.0018   23.3   0.0   56   14-74     42-109 (160)
+  7 1v54_H AED, cytochrome C oxida  14.3      70  0.0019   20.3   0.0   25   82-110    60-84  (85)
+  8 4nnz_A Probable zinc protease;  13.7      74   0.002   22.2   0.0   73   28-100   138-213 (439)
+  9 1hr6_B Beta-MPP, mitochondrial  12.5      84  0.0023   22.0   0.0   81   20-100   129-212 (443)
+ 10 4xea_A Peptidase M16 domain pr  12.1      89  0.0024   21.6   0.0   80   21-100   135-217 (423)
+
+No 1
+>2xqo_A Cellulosome enzyme, dockerin type I; hydrolase; HET: MSE CTR; 1.40A {Clostridium thermocellum}
+Probab=31.45  E-value=18  Score=28.87  Aligned_cols=38  Identities=29%  Similarity=0.348  Sum_probs=30.9  Template_Neff=1.400
+
+Q T0810-D1         71 ENEIRDENNRALVSGCKEELLAQVDEHFDEQRESMSVP  108 (113)
+Q Consensus        71 eneirdennralvsgckeellaqvdehfdeqresmsvp  108 (113)
+                      ..|||.-|...-|+..|-.|..|||||+|-.+.....|
+T Consensus        43 ~~Ei~A~~~~m~VqEVK~~l~KeiDEHWdlI~~~~G~~   80 (243)
+T 2xqo_A           43 KHELIARASSLKVSEVKAIIKKQVDEHWDVIRDVCGFK   80 (243)
+T ss_dssp             HHHHHHHHHHCCHHHHHHHHHHHHHHTHHHHHHHHCCS
+T ss_pred             HHHHHHHhccccHHHHHHHHHHHHHHHHHHHHHHhCCC
+Confidence            35788888888999999999999999999766544433
+
+
+No 2
+>2ld7_A Histone deacetylase complex subunit SAP30; transcription; NMR {Mus musculus}
+Probab=27.22  E-value=24  Score=23.40  Aligned_cols=16  Identities=31%  Similarity=0.403  Sum_probs=14.3  Template_Neff=5.400
+
+Q T0810-D1         86 CKEELLAQVDEHFDEQ  101 (113)
+Q Consensus        86 ckeellaqvdehfdeq  101 (113)
+                      -|++|+..|..||..+
+T Consensus        48 sK~~La~aV~kHF~~~   63 (94)
+T 2ld7_A           48 NKAQLVEIVGCHFKSI   63 (94)
+T ss_dssp             CHHHHHHHHHHHHTTC
+T ss_pred             CHHHHHHHHHHHHHcC
+Confidence            3999999999999976
+
+
+No 3
+>3eoq_A Putative zinc protease; two similar domains of beta(2)-alpha(2)-beta(2)-alpha(5)- beta structure, hydrolase; 2.29A {Thermus thermophilus}
+Probab=24.13  E-value=30  Score=24.14  Aligned_cols=81  Identities=14%  Similarity=0.172  Sum_probs=47.0  Template_Neff=10.300
+
+Q T0810-D1         19 TLVEWENSEANPEALFANWRHEFMVDSSKRESMKTELCKELQALPAQDLTLFENEIRDENNR-ALVSGC--KEELLAQVD   95 (113)
+Q Consensus        19 tlvewenseanpealfanwrhefmvdsskresmktelckelqalpaqdltlfeneirdennr-alvsgc--keellaqvd   95 (113)
+                      .+-+++....+|+.++...-++.+...........--.+.++.+...|+.-|-+..-..+|- ..+.|-  .+++++.+.
+T Consensus       122 ~~~e~~~~~~~p~~~~~~~~~~~~~~~~p~~~~~~g~~~~i~~it~~~l~~f~~~~~~~~~~~l~i~Gd~~~~~~~~~i~  201 (406)
+T 3eoq_A          122 ILEEIARYQDRPGFMAYEWARARFFQGHPLGNSVLGTRESITALTREGMAAYHRRRYLPKNMVLAATGRVDFDRLLAEAE  201 (406)
+T ss_dssp             HHHHHHHHHHCHHHHHHHHHHHHHHTTCGGGCCSSCCHHHHHHCCHHHHHHHHHHHCCGGGEEEEEEESCCHHHHHHHHH
+T ss_pred             HHHHHHHhhcCHHHHHHHHHHHHhhCCCCCCCCCCCCHHHHHhcCHHHHHHHHHhccCcccEEEEEEcCCCHHHHHHHHH
+Confidence            34566666778887777766666654322222111124567778888887776666554443 345552  456666666
+
+
+Q T0810-D1         96 EHFD   99 (113)
+Q Consensus        96 ehfd   99 (113)
+                      ..|.
+T Consensus       202 ~~~~  205 (406)
+T 3eoq_A          202 RLTE  205 (406)
+T ss_dssp             HHHT
+T ss_pred             HHhc
+Confidence            6655
+
+
+No 4
+>4h0e_A Arabinose metabolism transcriptional repressor; winged helix turn helix, transcription factor, DNA, transcri complex; 1.97A {Bacillus subtilis} PDB: 4egz_A 4egy_A 5d4r_A* 5d4s_A*
+Probab=17.70  E-value=50  Score=19.18  Aligned_cols=27  Identities=7%  Similarity=-0.090  Sum_probs=10.0  Template_Neff=8.600
+
+Q T0810-D1         35 ANWRHEFMVDSSKRESMKTELCKELQA   61 (113)
+Q Consensus        35 anwrhefmvdsskresmktelckelqa   61 (113)
+                      -+|++.++.+..++.+....+...+..
+T Consensus         8 ~~~~~~~~~~~~~~~~~~~~i~~~l~~   34 (88)
+T 4h0e_A            8 LEVLFQGPLGSEFMLPKYAQVKEEISS   34 (88)
+T ss_dssp             -----------CCCCCHHHHHHHHHHH
+T ss_pred             hheeeeeecccccCCCHHHHHHHHHHH
+Confidence            378888888887777666666655543
+
+
+No 5
+>3hdi_A Processing protease; CAGE structure, M16B peptidase, metallopeptidase, peptidasome, protease, hydrolase; 2.70A {Bacillus halodurans c-125}
+Probab=16.37  E-value=57  Score=22.96  Aligned_cols=81  Identities=12%  Similarity=0.185  Sum_probs=44.5  Template_Neff=10.200
+
+Q T0810-D1         20 LVEWENSEANPEALFANWRHEFMVDSSKRESMKTELCKELQALPAQDLTLFENEIRDENNRA-LVSGC-KEELLAQVDEH   97 (113)
+Q Consensus        20 lvewenseanpealfanwrhefmvdsskresmktelckelqalpaqdltlfeneirdennra-lvsgc-keellaqvdeh   97 (113)
+                      +.++...+.+|+.++..--++.+-..........-..+.|..+...++..|-......+|.. .+.|- .+++.+.+.+.
+T Consensus       124 ~~e~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~g~~~~l~~it~~~l~~~~~~~~~~~~~~l~i~Gd~~~~~~~~~~~~  203 (421)
+T 3hdi_A          124 FEEIKMVDDTPDDIVHDLLSSATYGKHSLGYPILGTVETLNSFNEGMLRHYMDRFYTGDYVVISVAGNVHDELIDKIKET  203 (421)
+T ss_dssp             HHHHHHHHTCHHHHHHHHHHHHHHTTSGGGSCTTCCHHHHHHCCHHHHHHHHHHHSSTTTEEEEEEESCCHHHHHHHHHH
+T ss_pred             HHHHHHhhCCHHHHHHHHHHHHHhcCCCCCCCCcCCHHHHhhCCHHHHHHHHHhhCCcCcEEEEEecCchHHHHHHHHHH
+Confidence            34555555667665544333333322222111111234566777788888888877777665 35553 45666666666
+
+
+Q T0810-D1         98 FDE  100 (113)
+Q Consensus        98 fde  100 (113)
+                      |..
+T Consensus       204 ~~~  206 (421)
+T 3hdi_A          204 FSQ  206 (421)
+T ss_dssp             TTS
+T ss_pred             hcC
+Confidence            643
+
+
+No 6
+>3qbz_A DDK kinase regulatory subunit DBF4; FHA domain,RAD53, replication checkpoint, cell cycle; 2.69A {Saccharomyces cerevisiae}
+Probab=14.62  E-value=67  Score=23.33  Aligned_cols=56  Identities=21%  Similarity=0.376  Sum_probs=34.3  Template_Neff=5.000
+
+Q T0810-D1         14 NQSAQTLVEWENSEANPEALFA-NWRHEFMVDSSKRESM-----------KTELCKELQALPAQDLTLFENEI   74 (113)
+Q Consensus        14 nqsaqtlvewenseanpealfa-nwrhefmvdsskresm-----------ktelckelqalpaqdltlfenei   74 (113)
+                      ..+.+.+.+|...   --..|. +|.--|  |.....+.           +..|.+.++.|+|.--..|.+++
+T Consensus        42 ~~~~~~l~eWq~k---wrk~fp~~~vFYF--D~~~~~~~~~~~~~~~~~~~~~l~~~i~~LGA~Ie~FFs~~V  109 (160)
+T 3qbz_A           42 RVTPKELLEWQTN---WKKIMKRDSRIYF--DITDDVEMNTYNKSKMDKRRDLLKRGFLTLGAQITQFFDTTV  109 (160)
+T ss_dssp             SSCHHHHHHHHHH---HHHHHHHHCEEEE--CCCCSSCCCHHHHHHHHHHHHHHHHHHHTTTCEEESSCCTTC
+T ss_pred             ccCHHHHHHHHHH---HHHhcCCCcEEEE--eCCCchhhhhhhhhhhHHHHHHHHHHHHHcCCEEeeecCCCe
+Confidence            3445566777653   334555 564433  33332222           46778889999999988887765
+
+
+No 7
+>1v54_H AED, cytochrome C oxidase polypeptide VIB; oxidoreductase; HET: FME TPO HEA TGL PGV CHD CDL PEK PSC DMU; 1.80A {Bos taurus} SCOP: a.51.1.1 PDB: 1oco_H* 1occ_H* 1ocz_H* 1ocr_H* 1v55_H* 2dyr_H* 2dys_H* 2eij_H* 2eik_H* 2eil_H* 2eim_H* 2ein_H* 2occ_H* 2ybb_S* 2zxw_H* 3abk_H* 3abl_H* 3abm_H* 3ag1_H* 3ag2_H* 3ag3_H* 3ag4_H* 3asn_H* 3aso_H* 3wg7_H* 3x2q_H* 2y69_H*
+Probab=14.25  E-value=70  Score=20.33  Aligned_cols=25  Identities=24%  Similarity=0.478  Sum_probs=17.5  Template_Neff=6.100
+
+Q T0810-D1         82 LVSGCKEELLAQVDEHFDEQRESMSVPGH  110 (113)
+Q Consensus        82 lvsgckeellaqvdehfdeqresmsvpgh  110 (113)
+                      .-+-|..+.+    +|||++|+....||.
+T Consensus        60 y~~~CP~sWV----~~fde~R~~g~f~~~   84 (85)
+T 1v54_H           60 YKSLCPISWV----STWDDRRAEGTFPGK   84 (85)
+T ss_dssp             HHHHSCHHHH----HHHHHHHHHTCCCSC
+T ss_pred             HHccChHHHH----HHHHHHHHcCCCCCC
+Confidence            3445655443    799999998887774
+
+
+No 8
+>4nnz_A Probable zinc protease; zinc finger, outer membrane, hydrolase; 2.48A {Pseudomonas aeruginosa}
+Probab=13.71  E-value=74  Score=22.23  Aligned_cols=73  Identities=21%  Similarity=0.201  Sum_probs=42.6  Template_Neff=10.500
+
+Q T0810-D1         28 ANPEALFANWRHEFMVDSSKRESMKTELCKELQALPAQDLTLFENEIRD-ENNRALVSGC--KEELLAQVDEHFDE  100 (113)
+Q Consensus        28 anpealfanwrhefmvdsskresmktelckelqalpaqdltlfeneird-ennralvsgc--keellaqvdehfde  100 (113)
+                      .+|..++..--++.+...+..........+.|+.+...|+.-|-+.... .|-...++|-  .+++...+...|..
+T Consensus       138 ~~~~~~~~~~~~~~~~~~~~~~~~~~g~~~~l~~it~~~l~~f~~~~~~~~~~~i~i~Gd~~~~~~~~~i~~~~~~  213 (439)
+T 4nnz_A          138 DNPNALAFERFKAAAYPASGYHTPTIGWMADLQRMTIDDLRHWYESWYAPNNATLVVVGDVTADEVKTLAKRYFGE  213 (439)
+T ss_dssp             SSHHHHHHHHHHHHHCSSSGGGSCTTCCHHHHHHCCHHHHHHHHHHHCCGGGEEEEEEESCCHHHHHHHHHHHHTT
+T ss_pred             CChHHHHHHHHHHhccCCCCCCCCCCCCHHHHhcCCHHHHHHHHHHhcCCCceEEEEEcCCCHHHHHHHHHHHhcc
+Confidence            4665554444444444333332222224457888888888887776544 4445567775  45677777777765
+
+
+No 9
+>1hr6_B Beta-MPP, mitochondrial processing peptidase beta subunit; hxxeh zinc-binding motif, hydrolase; HET: EPE; 2.50A {Saccharomyces cerevisiae} SCOP: d.185.1.1 d.185.1.1 PDB: 1hr7_B 1hr8_B* 1hr9_B*
+Probab=12.55  E-value=84  Score=21.98  Aligned_cols=81  Identities=14%  Similarity=0.155  Sum_probs=43.5  Template_Neff=10.500
+
+Q T0810-D1         20 LVEWENSEANPEALFANWRHEFMVDSSKRESMKTELCKELQALPAQDLTLFENEIRDENNR-ALVSGC--KEELLAQVDE   96 (113)
+Q Consensus        20 lvewenseanpealfanwrhefmvdsskresmktelckelqalpaqdltlfeneirdennr-alvsgc--keellaqvde   96 (113)
+                      +.+++....+|..++..--++.+-...........-.+.+..+...|+.-|-+..-..+|- ..+.|.  .+++.+.|.+
+T Consensus       129 ~~~~~~~~~~~~~~~~~~l~~~~~~~~p~~~~~~g~~~~l~~it~~~l~~f~~~~~~~~~~~l~ivGd~~~~~~~~~i~~  208 (443)
+T 1hr6_B          129 IRESEEVDKMYDEVVFDHLHEITYKDQPLGRTILGPIKNIKSITRTDLKDYITKNYKGDRMVLAGAGAVDHEKLVQYAQK  208 (443)
+T ss_dssp             HHHHHHHTTCHHHHHHHHHHHHHTTTSGGGSCSSCCHHHHHHCCHHHHHHHHHHHCCGGGEEEEEEESCCHHHHHHHHHH
+T ss_pred             HHHHHhhhcChHHHHHHHHHHHHhCCCCCCCCCCCCHHHHhhCCHHHHHHHHHHcCCCCcEEEEEecCCCHHHHHHHHHH
+Confidence            3344455556655533322333332211111111224567778888888777766555554 345564  4678888888
+
+
+Q T0810-D1         97 HFDE  100 (113)
+Q Consensus        97 hfde  100 (113)
+                      .|..
+T Consensus       209 ~~~~  212 (443)
+T 1hr6_B          209 YFGH  212 (443)
+T ss_dssp             HHTT
+T ss_pred             Hhcc
+Confidence            8764
+
+
+No 10
+>4xea_A Peptidase M16 domain protein; metallopeptidase, structural genomics, PSI-biology, midwest for structural genomics, MCSG; 1.95A {Alicyclobacillus acidocaldarius subsp}
+Probab=12.10  E-value=89  Score=21.62  Aligned_cols=80  Identities=13%  Similarity=0.110  Sum_probs=43.1  Template_Neff=10.600
+
+Q T0810-D1         21 VEWENSEANPEALFANWRHEFMVDSSKRESMKTELCKELQALPAQDLTLFENEIRDENNR-ALVSGC--KEELLAQVDEH   97 (113)
+Q Consensus        21 vewenseanpealfanwrhefmvdsskresmktelckelqalpaqdltlfeneirdennr-alvsgc--keellaqvdeh   97 (113)
+                      -|+.....+|+.++..--++.+-..+....-..--.+.+..+...|+.-|-+..-..+|- ..+.|.  .+++...+.++
+T Consensus       135 ~ei~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~G~~~~l~~it~~~l~~~~~~~y~~~~~~lvi~Gd~~~~~~~~l~~~~  214 (423)
+T 4xea_A          135 QEIHMVNDHPDRRAYMELLRAMYHEHPVRIDIAGTVESVRAITKEQLLLCYDTFYHPSNMVLVIAGGFDADEIAHVIEEN  214 (423)
+T ss_dssp             HHHHHHHSCHHHHHHHHHHHHHCSSCGGGSCTTCCHHHHHHCCHHHHHHHHHHHCSGGGEEEEEEESSCHHHHHHHHHHH
+T ss_pred             HHHHHhcCChHHHHHHHHHHHhcccCCCCCCCCCCHHHHhhCCHHHHHHHHHHhCCccceEEEEECCCCHHHHHHHHHHh
+Confidence            345455556665543322333332221111111234567888888888887776655444 456666  45677777776
+
+
+Q T0810-D1         98 FDE  100 (113)
+Q Consensus        98 fde  100 (113)
+                      |..
+T Consensus       215 ~~~  217 (423)
+T 4xea_A          215 QAK  217 (423)
+T ss_dssp             HHT
+T ss_pred             hcc
+Confidence            653
+
+

--- a/microprot/tests/test_pdb_search.py
+++ b/microprot/tests/test_pdb_search.py
@@ -285,6 +285,9 @@ class ParsersTests(TestCase):
         del r9['SS']
         self.assertEqual(self.true_block_b, r9)
 
+        with self.assertRaises(IOError):
+            parse_pdb_match('/does/not/exist')
+
     def test_select_hits(self):
         hits = parse_pdb_match(self.file_b)
         self.assertEqual(len(select_hits(hits, e_value_threshold=100)), 2)

--- a/microprot/tests/test_pdb_search.py
+++ b/microprot/tests/test_pdb_search.py
@@ -252,10 +252,21 @@ class ParsersTests(TestCase):
         self.assertFalse(is_overlapping((20, 100), (150, 200)))
         self.assertFalse(is_overlapping((20, 100), (1, 8)))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as ve:
             is_overlapping((100, 20), (1, 8))
-        with self.assertRaises(ValueError):
+        self.assertEqual(
+            ('Left component of intA cannot be larger than its right component'
+             ', i.e. the interval must be forward oriented.'),
+            str(ve.exception)
+        )
+        with self.assertRaises(ValueError) as ve:
             is_overlapping((10, 20), (-9, -20))
+        print(str(ve.exception))
+        self.assertEqual(
+            ('Left component of intB cannot be larger than its right component'
+             ', i.e. the interval must be forward oriented.'),
+            str(ve.exception)
+        )
 
     def test__parse_hit_summary_line(self):
         self.assertEqual(self.true_a, _parse_hit_summary_line(self.line_a))

--- a/microprot/tests/test_pdb_search.py
+++ b/microprot/tests/test_pdb_search.py
@@ -1,0 +1,310 @@
+from unittest import TestCase, main
+
+from skbio.util import get_data_path
+
+from microprot.scripts.pdb_search import is_overlapping, \
+                                         _parse_hit_summary_line, \
+                                         _parse_hit_block, parse_pdb_match, \
+                                         select_hits, report_hits, \
+                                         report_uncovered_subsequences
+
+
+class ParsersTests(TestCase):
+    def setUp(self):
+        self.line_a = ('  3 2cdq_A Aspartokinase; aspartat 100.0 4.1E-58 '
+                       '1.1E-62  453.8   0.0  458    1-473    28-496 (510)\n')
+        self.true_a = {'No': 3,
+                       'Hit': '2cdq_A Aspartokinase; aspartat',
+                       'Prob': 100.0,
+                       'E-value': 4.1e-58,
+                       'P-value': 1.1e-62,
+                       'Score': 453.8,
+                       'SS': 0.0,
+                       'Cols': 458,
+                       'Query HMM': '1-473',
+                       'Template HMM': '28-496',
+                       '#match states': 510,
+                       }
+        self.line_b = ('    36 1gtm_A Glutamate dehydrogenase  98.8 2.9E-12 '
+                       '7.9E-17  126.1   0.0  201  451-679   193-407 (419)\n')
+        self.true_b = {'No': 36,
+                       'Hit': '1gtm_A Glutamate dehydrogenase',
+                       'Prob': 98.8,
+                       'E-value': 2.9E-12,
+                       'P-value': 7.9E-17,
+                       'Score': 126.1,
+                       'SS': 0.0,
+                       'Cols': 201,
+                       'Query HMM': '451-679',
+                       'Template HMM': '193-407',
+                       '#match states': 419,
+                       }
+        self.line_c = ('  5 3hdi_A Processing protease; CA  16.4      57  '
+                       '0.0016   23.0   0.0   81   20-100   124-206 (421)')
+        self.true_c = {'No': 5,
+                       'Hit': '3hdi_A Processing protease; CA',
+                       'Prob': 16.4,
+                       'E-value': 57,
+                       'P-value': 0.0016,
+                       'Score': 23.0,
+                       'SS': 0.0,
+                       'Cols': 81,
+                       'Query HMM': '20-100',
+                       'Template HMM': '124-206',
+                       '#match states': 421,
+                       }
+        self.line_d = ('  9 1hr6_B Beta-MPP, mitochondrial  12.5      84  '
+                       '0.0023   22.0   0.0   81   20-100   129-212 (443)\n')
+        self.true_d = {'No': 9,
+                       'Hit': '1hr6_B Beta-MPP, mitochondrial',
+                       'Prob': 12.5,
+                       'E-value': 84,
+                       'P-value': 0.0023,
+                       'Score': 22.0,
+                       'SS': 0.0,
+                       'Cols': 81,
+                       'Query HMM': '20-100',
+                       'Template HMM': '129-212',
+                       '#match states': 443,
+                       }
+        self.block_a = ("No 1\n"
+                        ">2xqo_A Cellulosome enzyme, dockerin type I; hydrolas"
+                        "e; HET: MSE CTR; 1.40A {Clostridium thermocellum}\n"
+                        "Probab=31.45  E-value=18  Score=28.87  Aligned_cols=3"
+                        "8  Identities=29%  Similarity=0.348  Sum_probs=30.9  "
+                        "Template_Neff=1.400\n"
+                        "\n"
+                        "Q T0810-D1         71 ENEIRDENNRALVSGCKEELLAQVDEHFDEQ"
+                        "RESMSVP  108 (113)\n"
+                        "Q Consensus        71 eneirdennralvsgckeellaqvdehfdeq"
+                        "resmsvp  108 (113)\n"
+                        "                      ..|||.-|...-|+..|-.|..|||||+|-."
+                        "+.....|\n"
+                        "T Consensus        43 ~~Ei~A~~~~m~VqEVK~~l~KeiDEHWdlI"
+                        "~~~~G~~   80 (243)\n"
+                        "T 2xqo_A           43 KHELIARASSLKVSEVKAIIKKQVDEHWDVI"
+                        "RDVCGFK   80 (243)\n"
+                        "T ss_dssp             HHHHHHHHHHCCHHHHHHHHHHHHHHTHHHH"
+                        "HHHHCCS\n"
+                        "T ss_pred             HHHHHHHhccccHHHHHHHHHHHHHHHHHHH"
+                        "HHHhCCC\n"
+                        "Confidence            3578888888899999999999999999976"
+                        "6544433\n")
+        self.true_block_a = {
+            'No': 1,
+            'Hit': ('2xqo_A Cellulosome enzyme, dockerin type I; hydrolase; H'
+                    'ET: MSE CTR; 1.40A {Clostridium thermocellum}'),
+            'Probab': 31.45,
+            'E-value': 18.0,
+            'Score': 28.87,
+            'Aligned_cols': 38,
+            'Identities': 0.29,
+            'Similarity': 0.348,
+            'Sum_probs': 30.9,
+            'Template_Neff': 1.4,
+            'alignment': {
+                'Q T0810-D1': {'start': 71, 'end': 108, 'totallen': 113,
+                               'sequence': ('ENEIRDENNRALVSGCKEELLAQVDEHFDEQR'
+                                            'ESMSVP')},
+                'Q Consensus': {'start': 71, 'end': 108, 'totallen': 113,
+                                'sequence': ('eneirdennralvsgckeellaqvdehfdeq'
+                                             'resmsvp')},
+                'column score': {'sequence': ('..|||.-|...-|+..|-.|..|||||+|-'
+                                              '.+.....|')},
+                'T Consensus': {'start': 43, 'end': 80, 'totallen': 243,
+                                'sequence': ('~~Ei~A~~~~m~VqEVK~~l~KeiDEHWdlI'
+                                             '~~~~G~~')},
+                'T 2xqo_A': {'start': 43, 'end': 80, 'totallen': 243,
+                             'sequence': ('KHELIARASSLKVSEVKAIIKKQVDEHWDVIRDV'
+                                          'CGFK')},
+                'T ss_dssp': {'sequence': ('HHHHHHHHHHCCHHHHHHHHHHHHHHTHHHHHH'
+                                           'HHCCS')},
+                'T ss_pred': {'sequence': ('HHHHHHHhccccHHHHHHHHHHHHHHHHHHHHH'
+                                           'HhCCC')},
+                'Confidence': {'sequence': ('35788888888999999999999999999766'
+                                            '544433')}
+            }}
+        self.block_b = (
+            "No 10\n"
+            ">4xea_A Peptidase M16 domain protein; metallopeptidase, structur"
+            "al genomics, PSI-biology, midwest for structural genomics, MCSG;"
+            " 1.95A {Alicyclobacillus acidocaldarius subsp}\n"
+            "Probab=12.10  E-value=89  Score=21.62  Aligned_cols=80  Identiti"
+            "es=13%  Similarity=0.110  Sum_probs=43.1  Template_Neff=10.600\n"
+            "\n"
+            "Q T0810-D1         21 VEWENSEANPEALFANWRHEFMVDSSKRESMKTELCKELQAL"
+            "PAQDLTLFENEIRDENNR-ALVSGC--KEELLAQVDEH   97 (113)\n"
+            "Q Consensus        21 vewenseanpealfanwrhefmvdsskresmktelckelqal"
+            "paqdltlfeneirdennr-alvsgc--keellaqvdeh   97 (113)\n"
+            "                      -|+.....+|+.++..--++.+-..+....-..--.+.+..+"
+            "...|+.-|-+..-..+|- ..+.|.  .+++...+.++\n"
+            "T Consensus       135 ~ei~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~G~~~~l~~i"
+            "t~~~l~~~~~~~y~~~~~~lvi~Gd~~~~~~~~l~~~~  214 (423)\n"
+            "T 4xea_A          135 QEIHMVNDHPDRRAYMELLRAMYHEHPVRIDIAGTVESVRAI"
+            "TKEQLLLCYDTFYHPSNMVLVIAGGFDADEIAHVIEEN  214 (423)\n"
+            "T ss_dssp             HHHHHHHSCHHHHHHHHHHHHHCSSCGGGSCTTCCHHHHHHC"
+            "CHHHHHHHHHHHCSGGGEEEEEEESSCHHHHHHHHHHH\n"
+            "T ss_pred             HHHHHhcCChHHHHHHHHHHHhcccCCCCCCCCCCHHHHhhC"
+            "CHHHHHHHHHHhCCccceEEEEECCCCHHHHHHHHHHh\n"
+            "Confidence            345455556665543322333332221111111234567888"
+            "888888887776655444 456666  45677777776\n"
+            "\n"
+            "\n"
+            "Q T0810-D1         98 FDE  100 (113)\n"
+            "Q Consensus        98 fde  100 (113)\n"
+            "                      |..\n"
+            "T Consensus       215 ~~~  217 (423)\n"
+            "T 4xea_A          215 QAK  217 (423)\n"
+            "T ss_dssp             HHT\n"
+            "T ss_pred             hcc\n"
+            "Confidence            653\n"
+        )
+        self.true_block_b = {
+            'Score': 21.62,
+            'E-value': 89.0,
+            'Template_Neff': 10.6,
+            'Probab': 12.1,
+            'Sum_probs': 43.1,
+            'Similarity': 0.11,
+            'No': 10,
+            'alignment': {
+                'column score': {'sequence': ('-|+.....+|+.++..--++.+-..+....-'
+                                              '..--.+.+..+...|+.-|-+..-..+|- .'
+                                              '.+.|.  .+++...+.++|..')},
+                'T Consensus': {'start': 135, 'end': 217, 'totallen': 423,
+                                'sequence': ('~ei~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+                                             '~G~~~~l~~it~~~l~~~~~~~y~~~~~~lvi'
+                                             '~Gd~~~~~~~~l~~~~~~~')},
+                'Q T0810-D1': {'start': 21, 'end': 100, 'totallen': 113,
+                               'sequence': ('VEWENSEANPEALFANWRHEFMVDSSKRESMKT'
+                                            'ELCKELQALPAQDLTLFENEIRDENNR-ALVSG'
+                                            'C--KEELLAQVDEHFDE')},
+                'T ss_dssp': {'sequence': ('HHHHHHHSCHHHHHHHHHHHHHCSSCGGGSCTTC'
+                                           'CHHHHHHCCHHHHHHHHHHHCSGGGEEEEEEESS'
+                                           'CHHHHHHHHHHHHHT')},
+                'Confidence': {'sequence': ('345455556665543322333332221111111'
+                                            '234567888888888887776655444 45666'
+                                            '6  45677777776653')},
+                'T 4xea_A': {'start': 135, 'end': 217, 'totallen': 423,
+                             'sequence': ('QEIHMVNDHPDRRAYMELLRAMYHEHPVRIDIAGT'
+                                          'VESVRAITKEQLLLCYDTFYHPSNMVLVIAGGFDA'
+                                          'DEIAHVIEENQAK')},
+                'T ss_pred': {'sequence': ('HHHHHhcCChHHHHHHHHHHHhcccCCCCCCCCC'
+                                           'CHHHHhhCCHHHHHHHHHHhCCccceEEEEECCC'
+                                           'CHHHHHHHHHHhhcc')},
+                'Q Consensus': {'start': 21, 'end': 100, 'totallen': 113,
+                                'sequence': ('vewenseanpealfanwrhefmvdsskresmk'
+                                             'telckelqalpaqdltlfeneirdennr-alv'
+                                             'sgc--keellaqvdehfde')}},
+            'Aligned_cols': 80,
+            'Hit': ('4xea_A Peptidase M16 domain protein; metallopeptidase, st'
+                    'ructural genomics, PSI-biology, midwest for structural ge'
+                    'nomics, MCSG; 1.95A {Alicyclobacillus acidocaldarius subs'
+                    'p}'),
+            'Identities': 0.13}
+        self.file_a = get_data_path('test_pdb_search/NC_000913.3_2.out')
+        self.file_b = get_data_path('test_pdb_search/T0810-D1.fasta.out')
+        self.true_a_hits_report = [{
+            'end': 461,
+            'pdb_id': '2j0w_A',
+            'start': 1,
+            'covered_sequence':
+                ('MRVLKFGGTSVANAERFLRVADILESNARQGQVATVLSAPAKITNHLVAMIEKTISGQDA'
+                 'LPNISDAERIFAELLTGLAAAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINA'
+                 'ALICRGEKMSIAIMAGVLEARGHNVTVIDPVEKLLAVGHYLESTVDIAESTRRIAASRIP'
+                 'ADHMVLMAGFTAGNEKGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQV'
+                 'PDARLLKSMSYQEAMELSYFGAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRD'
+                 'EDELPVKGISNLNNMAMFSVSGPGMKGMVGMAARVFAAMSRARISVVLITQSSSEYSISF'
+                 'CVPQSDCVRAERAMQEEFYLELKEGLLEPLAVTERLAIISVVGDGMRTLRGISAKFFAAL'
+                 'ARANINIVAIAQGSSERSISVVVNNDDATTGVRVTHQMLFN')}, {
+            'end': 815,
+            'pdb_id': '1ebf_A',
+            'start': 464,
+            'covered_sequence':
+                ('QVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLENWQE'
+                 'ELAQAKEPFNLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANT'
+                 'SSMDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAGDELMKFSGILSGSLSYI'
+                 'FGKLDEGMSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARETGRELELADIEIEP'
+                 'VLPAEFNAEGDVAAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDGVCRVKIAEVD'
+                 'GNDPLFKVKNGENALAFYSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTLS')}]
+        self.query = (
+            'MRVLKFGGTSVANAERFLRVADILESNARQGQVATVLSAPAKITNHLVAMIEKTISGQDALPNIS'
+            'DAERIFAELLTGLAAAQPGFPLAQLKTFVDQEFAQIKHVLHGISLLGQCPDSINAALICRGEKMS'
+            'IAIMAGVLEARGHNVTVIDPVEKLLAVGHYLESTVDIAESTRRIAASRIPADHMVLMAGFTAGNE'
+            'KGELVVLGRNGSDYSAAVLAACLRADCCEIWTDVDGVYTCDPRQVPDARLLKSMSYQEAMELSYF'
+            'GAKVLHPRTITPIAQFQIPCLIKNTGNPQAPGTLIGASRDEDELPVKGISNLNNMAMFSVSGPGM'
+            'KGMVGMAARVFAAMSRARISVVLITQSSSEYSISFCVPQSDCVRAERAMQEEFYLELKEGLLEPL'
+            'AVTERLAIISVVGDGMRTLRGISAKFFAALARANINIVAIAQGSSERSISVVVNNDDATTGVRVT'
+            'HQMLFNTDQVIEVFVIGVGGVGGALLEQLKRQQSWLKNKHIDLRVCGVANSKALLTNVHGLNLEN'
+            'WQEELAQAKEPFNLGRLIRLVKEYHLLNPVIVDCTSSQAVADQYADFLREGFHVVTPNKKANTSS'
+            'MDYYHQLRYAAEKSRRKFLYDTNVGAGLPVIENLQNLLNAGDELMKFSGILSGSLSYIFGKLDEG'
+            'MSFSEATTLAREMGYTEPDPRDDLSGMDVARKLLILARETGRELELADIEIEPVLPAEFNAEGDV'
+            'AAFMANLSQLDDLFAARVAKARDEGKVLRYVGNIDEDGVCRVKIAEVDGNDPLFKVKNGENALAF'
+            'YSHYYQPLPLVLRGYGAGNDVTAAGVFADLLRTLSWKLGV')
+        self.true_subseqs = [{'sequence': 'TD', 'start': 462, 'end': 463},
+                             {'sequence': 'WKLGV', 'start': 816, 'end': 820}]
+
+    def test_is_overlapping(self):
+        self.assertTrue(is_overlapping((20, 100), (30, 150)))
+        self.assertTrue(is_overlapping((20, 100), (2, 70)))
+        self.assertTrue(is_overlapping((20, 100), (30, 70)))
+        self.assertTrue(is_overlapping((20, 100), (5, 150)))
+        self.assertFalse(is_overlapping((20, 100), (150, 200)))
+        self.assertFalse(is_overlapping((20, 100), (1, 8)))
+
+        with self.assertRaises(ValueError):
+            is_overlapping((100, 20), (1, 8))
+        with self.assertRaises(ValueError):
+            is_overlapping((10, 20), (-9, -20))
+
+    def test__parse_hit_summary_line(self):
+        self.assertEqual(self.true_a, _parse_hit_summary_line(self.line_a))
+        self.assertEqual(self.true_b, _parse_hit_summary_line(self.line_b))
+        self.assertEqual(self.true_c, _parse_hit_summary_line(self.line_c))
+        self.assertEqual(self.true_d, _parse_hit_summary_line(self.line_d))
+        with self.assertRaises(ValueError):
+            _parse_hit_summary_line('no valid line')
+
+    def test__parse_hit_block(self):
+        self.assertEqual(self.true_block_a, _parse_hit_block(self.block_a))
+        self.assertEqual(self.true_block_b, _parse_hit_block(self.block_b))
+
+    def test_parse_pdb_match(self):
+        res = parse_pdb_match(self.file_b)
+        self.assertEqual(len(res), 10)
+
+        r0 = res[0]
+        del r0['Cols']
+        del r0['P-value']
+        del r0['SS']
+        self.assertEqual(self.true_block_a, r0)
+
+        r9 = res[9]
+        del r9['Cols']
+        del r9['P-value']
+        del r9['SS']
+        self.assertEqual(self.true_block_b, r9)
+
+    def test_select_hits(self):
+        hits = parse_pdb_match(self.file_b)
+        self.assertEqual(len(select_hits(hits, e_value_threshold=100)), 2)
+        self.assertEqual(len(select_hits(hits)), 0)
+
+        hits = parse_pdb_match(self.file_a)
+        goodhits = select_hits(hits)
+        self.assertEqual(len(goodhits), 2)
+        self.assertEqual(goodhits[0]['No'], 1)
+        self.assertEqual(goodhits[1]['No'], 5)
+
+    def test_report_hits(self):
+        hits = select_hits(parse_pdb_match(self.file_a))
+        rep = report_hits(hits)
+        self.assertEqual(self.true_a_hits_report, rep)
+
+    def test_report_uncovered_subsequences(self):
+        hits = select_hits(parse_pdb_match(self.file_a))
+        subseqs = report_uncovered_subsequences(hits, self.true_query, 0)
+        self.assertEqual(subseqs, self.true_subseqs)
+
+if __name__ == '__main__':
+    main()

--- a/microprot/tests/test_pdb_search.py
+++ b/microprot/tests/test_pdb_search.py
@@ -303,7 +303,7 @@ class ParsersTests(TestCase):
 
     def test_report_uncovered_subsequences(self):
         hits = select_hits(parse_pdb_match(self.file_a))
-        subseqs = report_uncovered_subsequences(hits, self.true_query, 0)
+        subseqs = report_uncovered_subsequences(hits, self.query, 0)
         self.assertEqual(subseqs, self.true_subseqs)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addressing issue #3 : 
I decided to split the process into four methods:
1) the complete parsing of the HHsearch output file: parse_pdb_match
2) the selection of those hits that we want (= e-Value < t & no overlap): select_hits
Since the HHsearch file does not contain the whole query sequence, I split the desired result in two functions:
3) list of PDB ids and their corresponding query coverage: report_hits
4) all sequences (n >= 40 residues) not covered by the PDB: report_uncovered_subsequences

Assume f_q is the fasta file holding the query and f_o the HHsearch output for this file, we obtain the information by the following code:
```
all_hits = parse_pdb_match(f_o)
good_hits = select_hits(all_hits)
res_hits = report_hits(good_hits)
res_uncovered = report_uncovered_subsequences(good_hits, sequence string of f_q)
```